### PR TITLE
fix: rename extension name to claude-conductor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Manage multiple [Claude Code](https://docs.anthropic.com/claude-code) sessions across different projects as editor tabs in a single VS Code window.
 
-![Version](https://img.shields.io/visual-studio-marketplace/v/cbeaulieu-gt.vscode-claude-sessions)
-![Installs](https://img.shields.io/visual-studio-marketplace/i/cbeaulieu-gt.vscode-claude-sessions)
+![Version](https://img.shields.io/visual-studio-marketplace/v/cbeaulieu-gt.claude-conductor)
+![Installs](https://img.shields.io/visual-studio-marketplace/i/cbeaulieu-gt.claude-conductor)
 
 ## Why
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "vscode-claude-sessions",
-  "version": "1.0.0",
+  "name": "claude-conductor",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vscode-claude-sessions",
-      "version": "1.0.0",
+      "name": "claude-conductor",
+      "version": "1.1.1",
+      "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.85.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vscode-claude-sessions",
+  "name": "claude-conductor",
   "displayName": "Claude Session Manager",
   "description": "Manage multiple Claude Code sessions across projects as editor tabs",
   "version": "1.1.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ let sessionManager: SessionManager;
 
 /**
  * URI handler for cross-window session launch.
- * Handles: vscode://cbeaulieu-gt.vscode-claude-sessions/launch?folder=<encoded-path>
+ * Handles: vscode://cbeaulieu-gt.claude-conductor/launch?folder=<encoded-path>
  *
  * When a URI is received, we open the folder as the workspace (if not already open)
  * and auto-launch a Claude session in an editor tab.
@@ -130,7 +130,7 @@ export function activate(context: vscode.ExtensionContext): void {
       }
       const encodedPath = encodeURIComponent(folderPath);
       const uri = vscode.Uri.parse(
-        `vscode://cbeaulieu-gt.vscode-claude-sessions/launch?folder=${encodedPath}`
+        `vscode://cbeaulieu-gt.claude-conductor/launch?folder=${encodedPath}`
       );
       vscode.env.openExternal(uri);
     }),


### PR DESCRIPTION
## Summary

Resolves marketplace name collision. \`ShahadIshraq.vscode-claude-sessions\` already owns the "vscode-claude-sessions" name in the global marketplace namespace. Renamed to \`claude-conductor\` to unblock the first publish.

- Display name unchanged: still "Claude Session Manager"
- GitHub repository name unchanged: still \`vscode-claude-sessions\`
- URI handler authority updated to match new extension ID

Closes #16

## Test plan

- [x] \`npm run compile\` clean
- [x] \`npm install\` updates package-lock.json without errors
- [ ] After merge and publish, the extension appears on the marketplace at \`cbeaulieu-gt.claude-conductor\`

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*