### PR TITLE
fix: rename displayName to Claude Conductor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Claude Session Manager for VS Code
+# Claude Conductor
 
-Manage multiple [Claude Code](https://docs.anthropic.com/claude-code) sessions across different projects as editor tabs in a single VS Code window.
+Orchestrate multiple [Claude Code](https://docs.anthropic.com/claude-code) sessions across different projects as editor tabs in a single VS Code window.
 
 ![Version](https://img.shields.io/visual-studio-marketplace/v/cbeaulieu-gt.claude-conductor)
 ![Installs](https://img.shields.io/visual-studio-marketplace/i/cbeaulieu-gt.claude-conductor)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-conductor",
-  "displayName": "Claude Session Manager",
-  "description": "Manage multiple Claude Code sessions across projects as editor tabs",
+  "displayName": "Claude Conductor",
+  "description": "Orchestrate multiple Claude Code sessions across projects as editor tabs",
   "version": "1.1.1",
   "publisher": "cbeaulieu-gt",
   "engines": {


### PR DESCRIPTION
Resolves second marketplace collision. "Claude Session Manager" is also a taken displayName (\`ratorin.claude-session-manager\`). Switching to "Claude Conductor" for a unified brand.

Closes #18

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*