### PR TITLE
chore: add preview flag, bump to 1.1.3, update renamed repo URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-All notable changes to the Claude Session Manager extension are documented here.
+All notable changes to the Claude Conductor extension are documented here.
+
+## [1.1.3] — 2026-04-19
+
+### Changed
+- Rebranded from "Claude Session Manager" to **Claude Conductor** (marketplace name collision with two existing extensions)
+- Extension now shows a "Preview" badge on the marketplace reflecting its pre-release status
+- Repository renamed: `vscode-claude-sessions` → `vscode-claude-conductor`
 
 ## [1.1.1] — 2026-04-14
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To remove the hooks at any time: run `Claude Sessions: Remove Notification Hooks
 
 ## Source
 
-[github.com/cbeaulieu-gt/vscode-claude-sessions](https://github.com/cbeaulieu-gt/vscode-claude-sessions)
+[github.com/cbeaulieu-gt/vscode-claude-conductor](https://github.com/cbeaulieu-gt/vscode-claude-conductor)
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "claude-conductor",
   "displayName": "Claude Conductor",
   "description": "Orchestrate multiple Claude Code sessions across projects as editor tabs",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "publisher": "cbeaulieu-gt",
+  "preview": true,
   "engines": {
     "vscode": "^1.85.0"
   },
@@ -19,12 +20,12 @@
   "icon": "media/icon.png",
   "repository": {
     "type": "git",
-    "url": "https://github.com/cbeaulieu-gt/vscode-claude-sessions.git"
+    "url": "https://github.com/cbeaulieu-gt/vscode-claude-conductor.git"
   },
   "bugs": {
-    "url": "https://github.com/cbeaulieu-gt/vscode-claude-sessions/issues"
+    "url": "https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues"
   },
-  "homepage": "https://github.com/cbeaulieu-gt/vscode-claude-sessions#readme",
+  "homepage": "https://github.com/cbeaulieu-gt/vscode-claude-conductor#readme",
   "license": "MIT",
   "author": "Christopher Beaulieu",
   "activationEvents": ["onStartupFinished", "onUri"],


### PR DESCRIPTION
Closes #20

Adds the `preview` flag for a visible Preview badge on the marketplace listing. Bumps to 1.1.3 for pre-release publish. Updates repository URLs to the new `vscode-claude-conductor` repo name.

\ud83e\udd16 *Generated by Claude Code on behalf of @cbeaulieu-gt*