### PR TITLE
chore: bump to 1.1.5 for README badge fix republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Claude Conductor extension are documented here.
 
+## [1.1.5] — 2026-04-19
+
+### Fixed
+- README marketplace badges now render (shields.io had retired the `visual-studio-marketplace/*` endpoints; switched to badgen.net for live badges and shields.io static badges for Preview/License)
+
 ## [1.1.3] — 2026-04-19
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-conductor",
   "displayName": "Claude Conductor",
   "description": "Orchestrate multiple Claude Code sessions across projects as editor tabs",
-  "version": "1.1.3",
+  "version": "1.1.5",
   "publisher": "cbeaulieu-gt",
   "preview": true,
   "engines": {


### PR DESCRIPTION
Closes #24. Version bump so the already-merged README badge fix reaches the marketplace listing.

\ud83e\udd16 *Generated by Claude Code on behalf of @cbeaulieu-gt*