### PR TITLE
fix: resolve tree-view inline button arg mismatch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "npm: compile"
+    },
+    {
+      "name": "Run Extension (watch)",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "npm: watch"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "compile",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "panel": "dedicated",
+        "reveal": "silent"
+      },
+      "problemMatcher": "$tsc"
+    },
+    {
+      "type": "npm",
+      "script": "watch",
+      "isBackground": true,
+      "group": "build",
+      "presentation": {
+        "panel": "dedicated",
+        "reveal": "never"
+      },
+      "problemMatcher": "$tsc-watch"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 All notable changes to the Claude Conductor extension are documented here.
 
-## [1.1.7] — 2026-04-19
+## [Unreleased]
 
 ### Fixed
 - Inline **Focus**, **Close**, and **Open in New Window** buttons in the Active Sessions tree view no longer throw `Cannot read properties of undefined`. Row-click and inline-button invocations pass different argument shapes (the `ActiveSession` data vs. the `TreeItem` wrapper); the command handlers now resolve both to the same session object before acting.
+
+### Added
+- `.vscode/launch.json` and `tasks.json` so contributors can press **F5** to run the extension in a development host (no VSIX build required for iteration)
 
 ## [1.1.5] — 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Claude Conductor extension are documented here.
 
+## [1.1.7] — 2026-04-19
+
+### Fixed
+- Inline **Focus**, **Close**, and **Open in New Window** buttons in the Active Sessions tree view no longer throw `Cannot read properties of undefined`. Row-click and inline-button invocations pass different argument shapes (the `ActiveSession` data vs. the `TreeItem` wrapper); the command handlers now resolve both to the same session object before acting.
+
 ## [1.1.5] — 2026-04-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-conductor",
   "displayName": "Claude Conductor",
   "description": "Orchestrate multiple Claude Code sessions across projects as editor tabs",
-  "version": "1.1.7",
+  "version": "1.1.5",
   "publisher": "cbeaulieu-gt",
   "preview": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-conductor",
   "displayName": "Claude Conductor",
   "description": "Orchestrate multiple Claude Code sessions across projects as editor tabs",
-  "version": "1.1.5",
+  "version": "1.1.7",
   "publisher": "cbeaulieu-gt",
   "preview": true,
   "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,32 @@ import { ensureHooksInstalled, setupHooksCommand, uninstallHooks } from "./hookI
 let sessionManager: SessionManager;
 
 /**
+ * Normalizes the argument passed to a tree-view-triggered command.
+ *
+ * Row-click commands receive an `ActiveSession` (via `TreeItem.command.arguments`),
+ * but inline action buttons and context-menu entries receive the `TreeItem` itself
+ * (VS Code ignores `command.arguments` for those). The `ActiveSessionItem` tree item
+ * exposes its `ActiveSession` at `.session`, so we unwrap if needed.
+ *
+ * Also tolerates direct `ActiveSession` arguments from programmatic callers.
+ */
+function resolveSession(arg: unknown): ActiveSession | undefined {
+  if (!arg || typeof arg !== "object") {
+    return undefined;
+  }
+  const obj = arg as Record<string, unknown>;
+  // TreeItem case: has a nested .session property
+  if ("session" in obj && obj.session && typeof obj.session === "object") {
+    return obj.session as ActiveSession;
+  }
+  // ActiveSession case: has a .terminal property
+  if ("terminal" in obj && "folderPath" in obj) {
+    return obj as unknown as ActiveSession;
+  }
+  return undefined;
+}
+
+/**
  * URI handler for cross-window session launch.
  * Handles: vscode://cbeaulieu-gt.claude-conductor/launch?folder=<encoded-path>
  *
@@ -111,19 +137,22 @@ export function activate(context: vscode.ExtensionContext): void {
       addFolderPrompt()
     ),
 
-    vscode.commands.registerCommand("claudeSessions.focusSession", (session?: ActiveSession) => {
+    vscode.commands.registerCommand("claudeSessions.focusSession", (arg?: unknown) => {
+      const session = resolveSession(arg);
       if (session) {
         sessionManager.focusSession(session);
       }
     }),
 
-    vscode.commands.registerCommand("claudeSessions.closeSession", (session?: ActiveSession) => {
+    vscode.commands.registerCommand("claudeSessions.closeSession", (arg?: unknown) => {
+      const session = resolveSession(arg);
       if (session) {
         sessionManager.closeSession(session);
       }
     }),
 
-    vscode.commands.registerCommand("claudeSessions.openInNewWindow", (session?: ActiveSession) => {
+    vscode.commands.registerCommand("claudeSessions.openInNewWindow", (arg?: unknown) => {
+      const session = resolveSession(arg);
       const folderPath = session?.folderPath;
       if (!folderPath) {
         return;


### PR DESCRIPTION
## Summary

Fixes inline **Focus** / **Close** / **Open in New Window** buttons in the Active Sessions tree view, which previously threw \`Cannot read properties of undefined\`.

## Root cause

VS Code passes different arguments depending on how a tree view command is invoked:

- **Row click:** \`TreeItem.command.arguments\` is honored → handler receives \`ActiveSession\`
- **Inline button / context menu:** \`command.arguments\` is ignored → handler receives the \`TreeItem\` itself

Our handlers assumed the first shape and crashed dereferencing \`session.terminal\` when they actually got an \`ActiveSessionItem\` (where \`terminal\` lives at \`item.session.terminal\`).

## Fix

Added a \`resolveSession()\` helper that normalizes both shapes and wired it into \`focusSession\`, \`closeSession\`, and \`openInNewWindow\` command handlers.

Closes #26

## Test plan

- [ ] Install v1.1.7 VSIX
- [ ] Launch a session, hover the row in Active Sessions
- [ ] Click the inline **Focus** icon \u2192 tab is focused, no error
- [ ] Click the inline **Close** icon \u2192 session terminates, removed from tree, no error
- [ ] Click the inline **Open in New Window** icon \u2192 new VS Code window spawns with that folder
- [ ] Regression: clicking the row (not icons) still focuses the session
- [ ] Regression: quick-pick launch, keyboard cycling, status bar click all still work

\ud83e\udd16 *Generated by Claude Code on behalf of @cbeaulieu-gt*