### PR TITLE
fix: suppress installed marketplace copy in Extension Dev Host on F5

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,9 @@
       "type": "extensionHost",
       "request": "launch",
       "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--disable-extension",
+        "cbeaulieu-gt.claude-conductor"
       ],
       "outFiles": [
         "${workspaceFolder}/out/**/*.js"
@@ -18,7 +20,9 @@
       "type": "extensionHost",
       "request": "launch",
       "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--disable-extension",
+        "cbeaulieu-gt.claude-conductor"
       ],
       "outFiles": [
         "${workspaceFolder}/out/**/*.js"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to the Claude Conductor extension are documented here.
 ### Fixed
 - Inline **Focus**, **Close**, and **Open in New Window** buttons in the Active Sessions tree view no longer throw `Cannot read properties of undefined`. Row-click and inline-button invocations pass different argument shapes (the `ActiveSession` data vs. the `TreeItem` wrapper); the command handlers now resolve both to the same session object before acting.
 
+### Fixed
+- F5 launch no longer fails with "extension already exists" when the marketplace copy of `cbeaulieu-gt.claude-conductor` is installed. `.vscode/launch.json` now passes `--disable-extension cbeaulieu-gt.claude-conductor` to the Extension Development Host so the installed copy is suppressed inside the dev host only.
+
 ### Added
 - `.vscode/launch.json` and `tasks.json` so contributors can press **F5** to run the extension in a development host (no VSIX build required for iteration)
 


### PR DESCRIPTION
## Root cause

When VS Code launches the Extension Development Host (F5 / `extensionHost` launch type), it reuses the user's default profile. If the marketplace copy of `cbeaulieu-gt.claude-conductor` is installed in that profile, VS Code loads both the installed copy **and** the workspace development copy simultaneously. Because both register the same extension ID (`cbeaulieu-gt.claude-conductor`), VS Code detects the duplicate and aborts with:

> Extension 'cbeaulieu-gt.claude-conductor' already exists

## Fix

Added `--disable-extension cbeaulieu-gt.claude-conductor` to the `args` array of **both** launch configurations in `.vscode/launch.json` (`Run Extension` and `Run Extension (watch)`). The VS Code CLI `--disable-extension <id>` flag suppresses the named extension inside that process only, so the installed marketplace copy is silenced in the dev host while remaining active everywhere else.

## Why `--disable-extension` over `--profile-temp`

`--profile-temp` gives the dev host a completely clean, ephemeral profile (no installed extensions, no user settings). It would also fix the conflict, but it is overkill: it strips the developer's theme, keybindings, and other extensions from the dev host, making iterative testing less realistic. `--disable-extension` is the surgical option — it targets only the conflicting extension and leaves the rest of the developer's environment intact. This matches VS Code's own documentation recommendation for this exact scenario.

## Verification

JSON validity confirmed:
```
node -e "JSON.parse(require('fs').readFileSync('.vscode/launch.json','utf8')); console.log('JSON valid')"
# → JSON valid
```

The `--disable-extension <id>` flag syntax (flag and value as separate `args` array entries) matches VS Code's CLI specification for this argument.

closes #28

---
🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*