### PR TITLE
chore: ignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 out/
 *.vsix
 .worktrees/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Adds `.claude/settings.local.json` to `.gitignore`.

This file is generated by Claude Code to store per-developer local settings (allowed commands, personal preferences, etc.). It is developer-specific and should never be committed to version control — committing it would impose one developer's local config on all contributors.

closes #30

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*