### PR TITLE
fix: focus session button now moves keyboard focus to terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Claude Conductor extension are documented here.
 ## [Unreleased]
 
 ### Fixed
+- **Focus Session** button now moves keyboard focus into the terminal, not just reveals the tab. `Terminal.show(true)` in `focusSession()` was passing `preserveFocus=true`, which intentionally keeps focus elsewhere; changed to `false` so the terminal becomes active after the user clicks Focus. Fixes #32.
 - Inline **Focus**, **Close**, and **Open in New Window** buttons in the Active Sessions tree view no longer throw `Cannot read properties of undefined`. Row-click and inline-button invocations pass different argument shapes (the `ActiveSession` data vs. the `TreeItem` wrapper); the command handlers now resolve both to the same session object before acting.
 
 ### Fixed

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -95,7 +95,7 @@ export class SessionManager implements vscode.Disposable {
 
   /** Focus an existing session's editor tab. */
   focusSession(session: ActiveSession): void {
-    session.terminal.show(true);
+    session.terminal.show(false);
   }
 
   /** Close a session's terminal. */


### PR DESCRIPTION
## Summary

- Clicking the **Focus Session** inline button in the Active Sessions sidebar now moves keyboard focus into the terminal, so the user can type immediately without a second click.

## Root cause

`focusSession()` called `session.terminal.show(true)`. The `preserveFocus=true` argument is VS Code's explicit signal to _reveal_ a terminal without _stealing_ keyboard focus — exactly the wrong behaviour for a user-initiated "focus" action. Changing the argument to `false` transfers focus as expected.

The separate `terminal.show(true)` call in `launchSession()` (~line 87) is intentional and untouched — it runs before `workbench.action.terminal.moveToEditor` and must not steal focus mid-sequence.

## Before / After

| | Before | After |
|---|---|---|
| Click Focus Session | Terminal tab becomes visible; cursor stays in previous editor | Terminal tab becomes visible; keyboard focus moves into terminal |

## Test coverage

No automated test infrastructure exists in this repo (no `test` script, no test framework, no test files). Adding mocha/vitest + a tsconfig for tests would be a larger change than the fix itself and risks churn on a green repo. A regression test is documented here instead.

**Manual regression test:**

1. Open VS Code with this extension active.
2. Launch at least one Claude session via the sidebar.
3. Click elsewhere in the editor (e.g. open a source file) so focus is outside the terminal.
4. In the Active Sessions sidebar, click the **Focus** (arrow) inline button next to the session.
5. **Expected (after fix):** The session's terminal tab is revealed _and_ keyboard focus moves into it — you can type immediately.
6. **Expected (before fix):** Terminal tab was revealed but focus remained in the editor; you had to click the terminal again to type.

**Unchanged behaviour to verify:**

- Launching a new session (`Ctrl+Shift+Alt+C`) still opens the terminal in the editor tab area without stealing focus mid-launch.

closes #32

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*