### PR TITLE
fix: clear ghost session row when editor tab is closed (#47)

### DIFF
--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -163,7 +163,16 @@ export class SessionManager implements vscode.Disposable {
 
   /** Close a session's terminal. */
   closeSession(session: ActiveSession): void {
-    session.terminal.dispose();
+    // The terminal reference on the passed session may be the pre-moveToEditor
+    // panel terminal whose internal VS Code handle is no longer valid — calling
+    // dispose() on it throws "Cannot read properties of undefined (reading
+    // 'dispose')" inside the terminal proxy. Always resolve the live entry from
+    // _sessions by folderPath so we dispose the current, valid terminal
+    // reference. Falls back to session.terminal when the entry has already been
+    // evicted (e.g. a rapid double-close), in which case ?. makes it a no-op.
+    const live = this._findSessionByFolder(session.folderPath);
+    const terminal = live?.terminal ?? session.terminal;
+    terminal?.dispose();
     // onDidCloseTerminal listener handles cleanup and event firing
   }
 

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -1,10 +1,21 @@
 import * as vscode from "vscode";
 import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
 import { getClaudeCommand, getReuseTerminal, getLaunchDelayMs } from "./config";
 import { log } from "./output";
 
 /** Prefix used for all Claude session terminal names */
 export const SESSION_NAME_PREFIX = "claude · ";
+
+const STATE_DIR = path.join(os.homedir(), ".claude", "session-state");
+
+interface SessionState {
+  state: "idle" | "active";
+  cwd: string;
+  sessionId: string;
+  timestamp: number;
+}
 
 export interface ActiveSession {
   terminal: vscode.Terminal;
@@ -17,6 +28,15 @@ export interface ActiveSession {
 export class SessionManager implements vscode.Disposable {
   private readonly _sessions = new Map<vscode.Terminal, ActiveSession>();
   private readonly _disposables: vscode.Disposable[] = [];
+
+  /**
+   * Secondary index: processId → terminal map entry key.
+   * When moveToEditor causes VS Code to swap terminal references, the new
+   * onDidCloseTerminal fires with a reference that isn't in _sessions by
+   * identity. Storing the PID lets us fall back to a pid-based lookup when
+   * both the identity check and the name-match fail.
+   */
+  private readonly _pidToTerminal = new Map<number, vscode.Terminal>();
 
   private readonly _onDidChangeSessions = new vscode.EventEmitter<void>();
   /** Fires whenever the active session list changes (open or close). */
@@ -33,19 +53,7 @@ export class SessionManager implements vscode.Disposable {
         this._trackIfClaudeSession(terminal);
       }),
       vscode.window.onDidCloseTerminal((terminal) => {
-        // Try identity-based delete first
-        if (this._sessions.delete(terminal)) {
-          this._onDidChangeSessions.fire();
-          return;
-        }
-        // Fallback: match by name (terminal reference can change after moveToEditor)
-        for (const [key, session] of this._sessions) {
-          if (session.terminal.name === terminal.name) {
-            this._sessions.delete(key);
-            this._onDidChangeSessions.fire();
-            return;
-          }
-        }
+        this._handleTerminalClose(terminal);
       }),
       this._onDidChangeSessions
     );
@@ -173,6 +181,32 @@ export class SessionManager implements vscode.Disposable {
     return this._findSessionByFolder(path.normalize(folderPath));
   }
 
+  /**
+   * Reconcile _sessions against vscode.window.terminals.
+   *
+   * Called each poll tick by StateWatcher. Any session whose terminal is no
+   * longer present in the live terminal list is treated as closed (the
+   * onDidCloseTerminal event was missed, e.g. editor-tab X on Windows).
+   * The corresponding state file in ~/.claude/session-state/ is also deleted
+   * so the Stop hook gap doesn't leave orphaned idle files on disk.
+   */
+  reconcile(): void {
+    const liveTerminals = new Set(vscode.window.terminals);
+    let changed = false;
+
+    for (const [terminal, session] of this._sessions) {
+      if (!liveTerminals.has(terminal)) {
+        this._sessions.delete(terminal);
+        this._cleanupStateFile(session.folderPath);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      this._onDidChangeSessions.fire();
+    }
+  }
+
   /** Check if a terminal is a Claude session by name pattern. */
   private _isClaudeSession(terminal: vscode.Terminal): boolean {
     return terminal.name.startsWith(SESSION_NAME_PREFIX);
@@ -204,7 +238,112 @@ export class SessionManager implements vscode.Disposable {
       startedAt: new Date(),
       isIdle: false,
     });
+
+    // Register PID as a secondary lookup key once it resolves.
+    // processId is a Thenable<number | undefined> — we don't await here to
+    // avoid blocking the synchronous tracking path.
+    // Use two-argument .then() because PromiseLike lacks .catch().
+    terminal.processId.then(
+      (pid) => { if (pid !== undefined) { this._pidToTerminal.set(pid, terminal); } },
+      () => { /* PID unavailable for this terminal */ }
+    );
+
     this._onDidChangeSessions.fire();
+  }
+
+  /**
+   * Handle a terminal-close event with three-tier fallback:
+   * 1. Identity match (the common case for panel terminals).
+   * 2. Name match (handles some reference swaps after moveToEditor).
+   * 3. PID match (handles the editor-tab X case where name becomes "").
+   */
+  private _handleTerminalClose(terminal: vscode.Terminal): void {
+    // Tier 1 — identity
+    if (this._removeByKey(terminal)) {
+      return;
+    }
+
+    // Tier 2 — name match (only when name is non-empty)
+    if (terminal.name) {
+      for (const [key, session] of this._sessions) {
+        if (session.terminal.name === terminal.name) {
+          this._removeByKey(key);
+          return;
+        }
+      }
+    }
+
+    // Tier 3 — PID match. processId is a Thenable; we must handle it async.
+    // Use two-argument .then() because PromiseLike lacks .catch().
+    // Falls back to reconcile() on the next poll tick if this also misses.
+    terminal.processId.then(
+      (pid) => {
+        if (pid === undefined) { return; }
+        const trackedTerminal = this._pidToTerminal.get(pid);
+        if (trackedTerminal && this._sessions.has(trackedTerminal)) {
+          this._removeByKey(trackedTerminal);
+        }
+      },
+      () => { /* PID unavailable — reconcile() will catch it */ }
+    );
+  }
+
+  /**
+   * Remove a session keyed by terminal, clean up the PID index and state
+   * file, and fire the change event. Returns true if a session was removed.
+   */
+  private _removeByKey(terminal: vscode.Terminal): boolean {
+    const session = this._sessions.get(terminal);
+    if (!session) {
+      return false;
+    }
+    this._sessions.delete(terminal);
+
+    // Remove from PID index (two-argument .then() because PromiseLike lacks .catch())
+    terminal.processId.then(
+      (pid) => { if (pid !== undefined) { this._pidToTerminal.delete(pid); } },
+      () => { /* ignore */ }
+    );
+
+    this._cleanupStateFile(session.folderPath);
+    this._onDidChangeSessions.fire();
+    return true;
+  }
+
+  /**
+   * Delete the ~/.claude/session-state/*.json file whose `cwd` matches
+   * folderPath. This is a best-effort extension-side fallback for the case
+   * where the Claude Code Stop hook didn't run (e.g. terminal killed via
+   * editor-tab X). Without this, StateWatcher keeps re-marking the session
+   * idle on every poll tick even after the terminal is gone.
+   */
+  private _cleanupStateFile(folderPath: string): void {
+    try {
+      if (!fs.existsSync(STATE_DIR)) {
+        return;
+      }
+      const files = fs.readdirSync(STATE_DIR);
+      for (const file of files) {
+        if (!file.endsWith(".json")) {
+          continue;
+        }
+        const filePath = path.join(STATE_DIR, file);
+        try {
+          const raw = fs.readFileSync(filePath, "utf8");
+          const parsed = JSON.parse(raw) as Partial<SessionState>;
+          if (
+            parsed.cwd &&
+            path.normalize(parsed.cwd).toLowerCase() === folderPath.toLowerCase()
+          ) {
+            fs.unlinkSync(filePath);
+          }
+        } catch {
+          // File may be partially written, already deleted, or unreadable
+        }
+      }
+    } catch {
+      // STATE_DIR may not exist yet or may be unreadable
+    }
   }
 
   /** Find session by normalized folder path. */
@@ -223,5 +362,6 @@ export class SessionManager implements vscode.Disposable {
       d.dispose();
     }
     this._sessions.clear();
+    this._pidToTerminal.clear();
   }
 }

--- a/src/stateWatcher.ts
+++ b/src/stateWatcher.ts
@@ -214,9 +214,18 @@ export class StateWatcher implements vscode.Disposable {
   /**
    * Poll the state directory every few seconds as a fallback for
    * FileSystemWatcher which is unreliable on Windows for non-workspace dirs.
+   *
+   * Each tick also calls sessionManager.reconcile() to evict any _sessions
+   * entry whose terminal is no longer in vscode.window.terminals. This is the
+   * self-healing path for the editor-tab X case where onDidCloseTerminal
+   * either doesn't fire or fires with a mismatched reference.
    */
   private _startPolling(): void {
     this._pollTimer = setInterval(() => {
+      // Reconcile sessions first so stale entries don't produce idle-state
+      // callbacks below for terminals that are already gone.
+      this.sessionManager.reconcile();
+
       try {
         if (!fs.existsSync(STATE_DIR)) {
           return;


### PR DESCRIPTION
## Summary
Fixes #47 — closing a Claude session via the editor tab `X` was leaving a ghost row in the `Active Sessions` panel that persisted as idle until window reload.

The bug had two compounding root causes; both are addressed.

## Root Cause

**Layer 1 — Extension side.** When `launchSession()` calls `workbench.action.terminal.moveToEditor`, VS Code wraps the terminal in the editor tab area. The original `vscode.Terminal` reference still works for sending text, but on tab-`X` close, `onDidCloseTerminal` fires with a *different* terminal reference whose `.name` is empty or changed. Both the existing identity-match and name-match tiers in `SessionManager._sessions` cleanup miss, leaving the entry orphaned.

**Layer 2 — Claude Code `Stop` hook side.** The hook doesn't reliably fire on this code path (the pty is killed before the hook can run), so `~/.claude/session-state/<sessionId>.json` lingers. `StateWatcher` then keeps re-marking the orphaned session as idle every 2s, producing the persistent bell indicator.

## Changes

**`src/sessionManager.ts`**
- New `_pidToTerminal` index — the terminal's `processId` is the only stable identifier across the `moveToEditor` reference swap.
- Three-tier `_handleTerminalClose()`: identity → name → PID. The PID tier catches the editor-tab-X case the previous two missed.
- New public `reconcile()` method: walks `_sessions` against `vscode.window.terminals` and evicts entries whose terminal is gone. Self-healing fallback for any future event-firing edge case.
- New `_cleanupStateFile()`: on any session removal, scans `~/.claude/session-state/*.json`, matches by `cwd === folderPath`, and deletes the orphaned file. Eliminates the Layer 2 self-resurrection without requiring a hook fix.

**`src/stateWatcher.ts`**
- Existing 2s poll now calls `sessionManager.reconcile()` at the top of each tick. No new timer.

## Test Plan
*(Repo has no test infra yet — tracked under #36. Manual verification only.)*

- [ ] F5 Extension Dev Host: launch a session, click editor-tab `X`, confirm the row clears within ~2s and no bell indicator persists.
- [ ] Repeat with multiple sessions across different folders, closing in various orders.
- [ ] Confirm normal close paths (inline X button, `closeSession()` command) still clear immediately, not delayed by the poll.
- [ ] Confirm `~/.claude/session-state/*.json` for the closed session is deleted within 2s.
- [ ] Sanity: `npm run lint` and `npm run compile` both pass cleanly (verified locally).

## Out of Scope
- Restoring sessions across window reload (#43).
- Process-wrapper architectural shift (#44).
- Test infrastructure to lock in this regression — follow-up under #36.

---

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*