### PR TITLE
feat!: rename Claude Sessions surface to Claude Conductor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,47 @@
 
 All notable changes to the Claude Conductor extension are documented here.
 
+## [1.2.0] — 2026-04-23
+
+### Changed (BREAKING)
+
+All user-facing identifiers have been renamed from the `claudeSessions.*` namespace to `claudeConductor.*`. There are no backward-compatibility aliases — users must update any custom keybindings or settings that reference the old names.
+
+**Command ID rename mapping:**
+
+| Old | New |
+|---|---|
+| `claudeSessions.openSession` | `claudeConductor.openSession` |
+| `claudeSessions.addFolder` | `claudeConductor.addFolder` |
+| `claudeSessions.nextSession` | `claudeConductor.nextSession` |
+| `claudeSessions.prevSession` | `claudeConductor.prevSession` |
+| `claudeSessions.focusSession` | `claudeConductor.focusSession` |
+| `claudeSessions.closeSession` | `claudeConductor.closeSession` |
+| `claudeSessions.openInNewWindow` | `claudeConductor.openInNewWindow` |
+| `claudeSessions.setupHooks` | `claudeConductor.setupHooks` |
+| `claudeSessions.removeHooks` | `claudeConductor.removeHooks` |
+| `claudeSessions.refreshTreeView` | `claudeConductor.refreshTreeView` |
+
+**Config key rename mapping:**
+
+| Old | New |
+|---|---|
+| `claudeSessions.claudeCommand` | `claudeConductor.claudeCommand` |
+| `claudeSessions.reuseExistingTerminal` | `claudeConductor.reuseExistingTerminal` |
+| `claudeSessions.enableNotifications` | `claudeConductor.enableNotifications` |
+| `claudeSessions.extraFolders` | `claudeConductor.extraFolders` |
+| `claudeSessions.launchDelayMs` | `claudeConductor.launchDelayMs` |
+
+**Other renamed identifiers:**
+- Activity Bar container ID: `claudeSessions` → `claudeConductor`
+- View IDs: `claudeSessions.activeSessions` → `claudeConductor.activeSessions`, `claudeSessions.recentProjects` → `claudeConductor.recentProjects`
+- Configuration section title: `Claude Sessions` → `Claude Conductor`
+- Command palette prefixes: `Claude Sessions:` → `Claude Conductor:`
+
 ## [Unreleased]
 
 ### Fixed
-- **Shell init race condition** — `claude` is no longer sent to the terminal mid-profile-init. When VS Code shell integration is available (VS Code ≥ 1.93), the command is dispatched via `shellIntegration.executeCommand()` which waits for the shell prompt. On older VS Code or when shell integration is disabled, a configurable delay (`claudeSessions.launchDelayMs`, default 500 ms) is used instead. Fixes #40.
+- **Shell init race condition** — `claude` is no longer sent to the terminal mid-profile-init. When VS Code shell integration is available (VS Code ≥ 1.93), the command is dispatched via `shellIntegration.executeCommand()` which waits for the shell prompt. On older VS Code or when shell integration is disabled, a configurable delay (`claudeConductor.launchDelayMs`, default 500 ms) is used instead. Fixes #40.
 - **Idle notifications restored** — the sidebar bell icon and VS Code notification now correctly appear when a Claude session finishes and waits for input. The `Stop` hook deletes the state file; the extension was ignoring that deletion (`_onStateFileDeleted` was a no-op), so sessions stayed stuck in idle state indefinitely. The handler now looks up the session via a cached filename-to-path map and calls `setSessionIdle(folderPath, false)`, clearing both the tree-view icon and the idle set. A new **"Claude Conductor"** output channel logs state-file reads, dispatch decisions, and path-match results for easier diagnostics. Fixes #37.
 - **Idle notification no longer spams on dismissal** — dismissing the idle notification (clicking × or elsewhere without choosing Focus) no longer causes it to re-appear every second. A new per-session "already notified" guard ensures the notification only re-fires when a session that has not yet been shown goes idle, so each idle episode produces exactly one notification. Fixes #39.
 - **Idle notification no longer double-fires after dismissal** — after dismissing the idle dialog, a second identical dialog could occasionally appear a few seconds later when the deferred retry `setTimeout` fired even though the originally-idle session was already marked notified. The retry now re-verifies that at least one currently-idle session is still unnotified before re-firing, and `_showConsolidatedNotification` short-circuits when every idle path has already been notified this episode. Fixes #42.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Running Claude Code against several projects at once is painful in a plain termi
 
 ### Activity Bar Sidebar
 
-A dedicated "Claude Sessions" panel with two sections:
+A dedicated "Claude Conductor" panel with two sections:
 
 - **Active Sessions** — currently running Claude terminals. Click to focus. A green terminal icon means the session is working; an orange bell means it's waiting for your input.
 - **Recent Projects** — your VS Code recently opened folders plus any configured extras. Click to launch a new session.
@@ -65,20 +65,20 @@ Cycles through Claude tabs only, not every terminal or editor tab.
 
 | Setting | Default | Description |
 |---|---|---|
-| `claudeSessions.claudeCommand` | `"claude"` | CLI command to run in the terminal |
-| `claudeSessions.reuseExistingTerminal` | `true` | Focus an existing session tab instead of opening a duplicate |
-| `claudeSessions.enableNotifications` | `true` | Show notifications when a session is waiting for input |
-| `claudeSessions.extraFolders` | `[]` | Additional folder paths to show in the launcher |
+| `claudeConductor.claudeCommand` | `"claude"` | CLI command to run in the terminal |
+| `claudeConductor.reuseExistingTerminal` | `true` | Focus an existing session tab instead of opening a duplicate |
+| `claudeConductor.enableNotifications` | `true` | Show notifications when a session is waiting for input |
+| `claudeConductor.extraFolders` | `[]` | Additional folder paths to show in the launcher |
 
 ## Commands
 
 Available from the command palette (`Ctrl+Shift+P`):
 
-- `Claude Sessions: Launch Session`
-- `Claude Sessions: Add Folder`
-- `Claude Sessions: Next Session` / `Previous Session`
-- `Claude Sessions: Setup Notification Hooks`
-- `Claude Sessions: Remove Notification Hooks`
+- `Claude Conductor: Launch Session`
+- `Claude Conductor: Add Folder`
+- `Claude Conductor: Next Session` / `Previous Session`
+- `Claude Conductor: Setup Notification Hooks`
+- `Claude Conductor: Remove Notification Hooks`
 
 ## How Idle Detection Works
 
@@ -92,7 +92,7 @@ When you allow notification hooks, the extension adds three entries to your `~/.
 
 The hooks write state files to `~/.claude/session-state/` which the extension watches. **Only your VS Code extension reads these files** — no data leaves your machine.
 
-To remove the hooks at any time: run `Claude Sessions: Remove Notification Hooks` from the command palette.
+To remove the hooks at any time: run `Claude Conductor: Remove Notification Hooks` from the command palette.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-conductor",
   "displayName": "Claude Conductor",
   "description": "Orchestrate multiple Claude Code sessions across projects as editor tabs",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "publisher": "cbeaulieu-gt",
   "preview": true,
   "engines": {
@@ -38,47 +38,47 @@
   "contributes": {
     "commands": [
       {
-        "command": "claudeSessions.openSession",
-        "title": "Claude Sessions: Launch Session",
+        "command": "claudeConductor.openSession",
+        "title": "Claude Conductor: Launch Session",
         "icon": "$(play)"
       },
       {
-        "command": "claudeSessions.addFolder",
-        "title": "Claude Sessions: Add Folder",
+        "command": "claudeConductor.addFolder",
+        "title": "Claude Conductor: Add Folder",
         "icon": "$(add)"
       },
       {
-        "command": "claudeSessions.nextSession",
-        "title": "Claude Sessions: Next Session"
+        "command": "claudeConductor.nextSession",
+        "title": "Claude Conductor: Next Session"
       },
       {
-        "command": "claudeSessions.prevSession",
-        "title": "Claude Sessions: Previous Session"
+        "command": "claudeConductor.prevSession",
+        "title": "Claude Conductor: Previous Session"
       },
       {
-        "command": "claudeSessions.focusSession",
+        "command": "claudeConductor.focusSession",
         "title": "Focus Session"
       },
       {
-        "command": "claudeSessions.closeSession",
+        "command": "claudeConductor.closeSession",
         "title": "Close Session",
         "icon": "$(close)"
       },
       {
-        "command": "claudeSessions.openInNewWindow",
+        "command": "claudeConductor.openInNewWindow",
         "title": "Open in New Window",
         "icon": "$(link-external)"
       },
       {
-        "command": "claudeSessions.setupHooks",
-        "title": "Claude Sessions: Setup Notification Hooks"
+        "command": "claudeConductor.setupHooks",
+        "title": "Claude Conductor: Setup Notification Hooks"
       },
       {
-        "command": "claudeSessions.removeHooks",
-        "title": "Claude Sessions: Remove Notification Hooks"
+        "command": "claudeConductor.removeHooks",
+        "title": "Claude Conductor: Remove Notification Hooks"
       },
       {
-        "command": "claudeSessions.refreshTreeView",
+        "command": "claudeConductor.refreshTreeView",
         "title": "Refresh",
         "icon": "$(refresh)"
       }
@@ -86,20 +86,20 @@
     "viewsContainers": {
       "activitybar": [
         {
-          "id": "claudeSessions",
-          "title": "Claude Sessions",
+          "id": "claudeConductor",
+          "title": "Claude Conductor",
           "icon": "$(sparkle)"
         }
       ]
     },
     "views": {
-      "claudeSessions": [
+      "claudeConductor": [
         {
-          "id": "claudeSessions.activeSessions",
+          "id": "claudeConductor.activeSessions",
           "name": "Active Sessions"
         },
         {
-          "id": "claudeSessions.recentProjects",
+          "id": "claudeConductor.recentProjects",
           "name": "Recent Projects"
         }
       ]
@@ -107,63 +107,63 @@
     "menus": {
       "view/title": [
         {
-          "command": "claudeSessions.openSession",
-          "when": "view == claudeSessions.recentProjects",
+          "command": "claudeConductor.openSession",
+          "when": "view == claudeConductor.recentProjects",
           "group": "navigation"
         },
         {
-          "command": "claudeSessions.addFolder",
-          "when": "view == claudeSessions.recentProjects",
+          "command": "claudeConductor.addFolder",
+          "when": "view == claudeConductor.recentProjects",
           "group": "navigation"
         },
         {
-          "command": "claudeSessions.refreshTreeView",
-          "when": "view == claudeSessions.activeSessions || view == claudeSessions.recentProjects",
+          "command": "claudeConductor.refreshTreeView",
+          "when": "view == claudeConductor.activeSessions || view == claudeConductor.recentProjects",
           "group": "navigation"
         }
       ],
       "view/item/context": [
         {
-          "command": "claudeSessions.focusSession",
+          "command": "claudeConductor.focusSession",
           "when": "viewItem == activeSession",
           "group": "inline"
         },
         {
-          "command": "claudeSessions.openInNewWindow",
+          "command": "claudeConductor.openInNewWindow",
           "when": "viewItem == activeSession",
           "group": "inline"
         },
         {
-          "command": "claudeSessions.closeSession",
+          "command": "claudeConductor.closeSession",
           "when": "viewItem == activeSession",
           "group": "inline"
         },
         {
-          "command": "claudeSessions.openSession",
+          "command": "claudeConductor.openSession",
           "when": "viewItem == recentProject",
           "group": "inline"
         }
       ]
     },
     "configuration": {
-      "title": "Claude Sessions",
+      "title": "Claude Conductor",
       "properties": {
-        "claudeSessions.claudeCommand": {
+        "claudeConductor.claudeCommand": {
           "type": "string",
           "default": "claude",
           "description": "The Claude Code CLI command to run"
         },
-        "claudeSessions.reuseExistingTerminal": {
+        "claudeConductor.reuseExistingTerminal": {
           "type": "boolean",
           "default": true,
           "description": "Focus existing session tab instead of opening a duplicate"
         },
-        "claudeSessions.enableNotifications": {
+        "claudeConductor.enableNotifications": {
           "type": "boolean",
           "default": true,
           "description": "Show notifications when a Claude session is waiting for input"
         },
-        "claudeSessions.extraFolders": {
+        "claudeConductor.extraFolders": {
           "type": "array",
           "items": {
             "type": "string"
@@ -171,7 +171,7 @@
           "default": [],
           "description": "Additional folder paths to show in the session launcher"
         },
-        "claudeSessions.launchDelayMs": {
+        "claudeConductor.launchDelayMs": {
           "type": "number",
           "default": 500,
           "minimum": 0,
@@ -181,17 +181,17 @@
     },
     "keybindings": [
       {
-        "command": "claudeSessions.openSession",
+        "command": "claudeConductor.openSession",
         "key": "ctrl+shift+alt+c",
         "mac": "cmd+shift+alt+c"
       },
       {
-        "command": "claudeSessions.nextSession",
+        "command": "claudeConductor.nextSession",
         "key": "ctrl+alt+]",
         "mac": "cmd+alt+]"
       },
       {
-        "command": "claudeSessions.prevSession",
+        "command": "claudeConductor.prevSession",
         "key": "ctrl+alt+[",
         "mac": "cmd+alt+["
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as os from "os";
 
-const SECTION = "claudeSessions";
+const SECTION = "claudeConductor";
 
 function getConfig(): vscode.WorkspaceConfiguration {
   return vscode.workspace.getConfiguration(SECTION);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,7 @@ function resolveSession(arg: unknown): ActiveSession | undefined {
  * When a URI is received, we open the folder as the workspace (if not already open)
  * and auto-launch a Claude session in an editor tab.
  */
-const AUTO_LAUNCH_KEY = "claudeSessions.autoLaunchFolder";
+const AUTO_LAUNCH_KEY = "claudeConductor.autoLaunchFolder";
 
 class SessionUriHandler implements vscode.UriHandler {
   constructor(
@@ -111,8 +111,8 @@ export function activate(context: vscode.ExtensionContext): void {
   const recentProvider = new RecentProjectsProvider(sessionManager);
 
   context.subscriptions.push(
-    vscode.window.registerTreeDataProvider("claudeSessions.activeSessions", activeProvider),
-    vscode.window.registerTreeDataProvider("claudeSessions.recentProjects", recentProvider)
+    vscode.window.registerTreeDataProvider("claudeConductor.activeSessions", activeProvider),
+    vscode.window.registerTreeDataProvider("claudeConductor.recentProjects", recentProvider)
   );
 
   // Status bar
@@ -125,7 +125,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
   // Commands
   context.subscriptions.push(
-    vscode.commands.registerCommand("claudeSessions.openSession", async (folderPath?: string) => {
+    vscode.commands.registerCommand("claudeConductor.openSession", async (folderPath?: string) => {
       if (typeof folderPath === "string") {
         await sessionManager.launchSession(folderPath);
       } else {
@@ -133,25 +133,25 @@ export function activate(context: vscode.ExtensionContext): void {
       }
     }),
 
-    vscode.commands.registerCommand("claudeSessions.addFolder", () =>
+    vscode.commands.registerCommand("claudeConductor.addFolder", () =>
       addFolderPrompt()
     ),
 
-    vscode.commands.registerCommand("claudeSessions.focusSession", (arg?: unknown) => {
+    vscode.commands.registerCommand("claudeConductor.focusSession", (arg?: unknown) => {
       const session = resolveSession(arg);
       if (session) {
         sessionManager.focusSession(session);
       }
     }),
 
-    vscode.commands.registerCommand("claudeSessions.closeSession", (arg?: unknown) => {
+    vscode.commands.registerCommand("claudeConductor.closeSession", (arg?: unknown) => {
       const session = resolveSession(arg);
       if (session) {
         sessionManager.closeSession(session);
       }
     }),
 
-    vscode.commands.registerCommand("claudeSessions.openInNewWindow", (arg?: unknown) => {
+    vscode.commands.registerCommand("claudeConductor.openInNewWindow", (arg?: unknown) => {
       const session = resolveSession(arg);
       const folderPath = session?.folderPath;
       if (!folderPath) {
@@ -164,25 +164,25 @@ export function activate(context: vscode.ExtensionContext): void {
       vscode.env.openExternal(uri);
     }),
 
-    vscode.commands.registerCommand("claudeSessions.setupHooks", () =>
+    vscode.commands.registerCommand("claudeConductor.setupHooks", () =>
       setupHooksCommand(context)
     ),
 
-    vscode.commands.registerCommand("claudeSessions.removeHooks", () => {
+    vscode.commands.registerCommand("claudeConductor.removeHooks", () => {
       uninstallHooks();
       vscode.window.showInformationMessage("Claude session hooks removed.");
     }),
 
-    vscode.commands.registerCommand("claudeSessions.refreshTreeView", () => {
+    vscode.commands.registerCommand("claudeConductor.refreshTreeView", () => {
       activeProvider.refresh();
       recentProvider.refresh();
     }),
 
-    vscode.commands.registerCommand("claudeSessions.nextSession", () => {
+    vscode.commands.registerCommand("claudeConductor.nextSession", () => {
       cycleSession(sessionManager, 1);
     }),
 
-    vscode.commands.registerCommand("claudeSessions.prevSession", () => {
+    vscode.commands.registerCommand("claudeConductor.prevSession", () => {
       cycleSession(sessionManager, -1);
     }),
   );
@@ -218,5 +218,5 @@ function cycleSession(sm: SessionManager, direction: 1 | -1): void {
 export function deactivate(): void {
   // Hooks are intentionally left in ~/.claude/settings.json on deactivate.
   // VS Code calls deactivate() on every window close, not just uninstall.
-  // Use "Claude Sessions: Remove Notification Hooks" command to clean up manually.
+  // Use "Claude Conductor: Remove Notification Hooks" command to clean up manually.
 }

--- a/src/hookInstaller.ts
+++ b/src/hookInstaller.ts
@@ -6,7 +6,7 @@ import * as os from "os";
 const SETTINGS_PATH = path.join(os.homedir(), ".claude", "settings.json");
 const STATE_DIR = path.join(os.homedir(), ".claude", "session-state");
 const HOOK_MARKER = "session-state.js";
-const SETUP_DECLINED_KEY = "claudeSessions.hookSetupDeclined";
+const SETUP_DECLINED_KEY = "claudeConductor.hookSetupDeclined";
 
 /**
  * Get the path to our hook script, using Unix-style paths for git bash compatibility.

--- a/src/quickPick.ts
+++ b/src/quickPick.ts
@@ -51,11 +51,11 @@ export async function showQuickPick(sessionManager: SessionManager): Promise<voi
       "Open Settings"
     );
     if (choice === "Add Folder") {
-      vscode.commands.executeCommand("claudeSessions.addFolder");
+      vscode.commands.executeCommand("claudeConductor.addFolder");
     } else if (choice === "Open Settings") {
       vscode.commands.executeCommand(
         "workbench.action.openSettings",
-        "claudeSessions"
+        "claudeConductor"
       );
     }
     return;
@@ -106,7 +106,7 @@ export async function addFolderPrompt(): Promise<void> {
     return;
   }
 
-  const config = vscode.workspace.getConfiguration("claudeSessions");
+  const config = vscode.workspace.getConfiguration("claudeConductor");
   const current = config.get<string[]>("extraFolders", []);
   const expanded = input.replace(/^~/, os.homedir());
 

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -107,7 +107,7 @@ export class SessionManager implements vscode.Disposable {
    *
    * 1. Fast path — shell integration already active at call time.
    * 2. Slow path — wait up to 2 s for shell integration to activate.
-   * 3. Delay fallback — sleep `claudeSessions.launchDelayMs` ms then sendText.
+   * 3. Delay fallback — sleep `claudeConductor.launchDelayMs` ms then sendText.
    *    Covers VS Code < 1.93 and setups where shell integration never activates.
    */
   private async _dispatchClaudeCommand(terminal: vscode.Terminal): Promise<void> {

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -10,8 +10,8 @@ export class StatusBar implements vscode.Disposable {
       vscode.StatusBarAlignment.Left,
       100
     );
-    this._item.command = "claudeSessions.openSession";
-    this._item.tooltip = "Claude Sessions — click to launch or switch";
+    this._item.command = "claudeConductor.openSession";
+    this._item.tooltip = "Claude Conductor — click to launch or switch";
 
     this._update(sessionManager.count);
 

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -16,7 +16,7 @@ class ActiveSessionItem extends vscode.TreeItem {
       : new vscode.ThemeIcon("terminal", new vscode.ThemeColor("testing.iconPassed"));
     this.contextValue = "activeSession";
     this.command = {
-      command: "claudeSessions.focusSession",
+      command: "claudeConductor.focusSession",
       title: "Focus Session",
       arguments: [session],
     };
@@ -34,7 +34,7 @@ class RecentProjectItem extends vscode.TreeItem {
     this.iconPath = new vscode.ThemeIcon("folder");
     this.contextValue = "recentProject";
     this.command = {
-      command: "claudeSessions.openSession",
+      command: "claudeConductor.openSession",
       title: "Launch Session",
       arguments: [entry.folderPath],
     };


### PR DESCRIPTION
## Summary

- Renames all `claudeSessions.*` command IDs to `claudeConductor.*` (10 commands)
- Renames all `claudeSessions.*` config keys to `claudeConductor.*` (5 keys)
- Renames Activity Bar container ID, view IDs, and configuration section title
- Updates command palette prefixes from `Claude Sessions:` to `Claude Conductor:`
- Bumps version to **1.2.0**
- Updates README and CHANGELOG with new names and breaking-change mapping

## Breaking Change

No backward-compatibility aliases. Users with custom keybindings or `settings.json` entries referencing `claudeSessions.*` must update to `claudeConductor.*`.

**Command ID renames:**

| Old | New |
|---|---|
| `claudeSessions.openSession` | `claudeConductor.openSession` |
| `claudeSessions.addFolder` | `claudeConductor.addFolder` |
| `claudeSessions.nextSession` | `claudeConductor.nextSession` |
| `claudeSessions.prevSession` | `claudeConductor.prevSession` |
| `claudeSessions.focusSession` | `claudeConductor.focusSession` |
| `claudeSessions.closeSession` | `claudeConductor.closeSession` |
| `claudeSessions.openInNewWindow` | `claudeConductor.openInNewWindow` |
| `claudeSessions.setupHooks` | `claudeConductor.setupHooks` |
| `claudeSessions.removeHooks` | `claudeConductor.removeHooks` |
| `claudeSessions.refreshTreeView` | `claudeConductor.refreshTreeView` |

**Config key renames:**

| Old | New |
|---|---|
| `claudeSessions.claudeCommand` | `claudeConductor.claudeCommand` |
| `claudeSessions.reuseExistingTerminal` | `claudeConductor.reuseExistingTerminal` |
| `claudeSessions.enableNotifications` | `claudeConductor.enableNotifications` |
| `claudeSessions.extraFolders` | `claudeConductor.extraFolders` |
| `claudeSessions.launchDelayMs` | `claudeConductor.launchDelayMs` |

**Other renames:** Activity Bar container `claudeSessions` → `claudeConductor`; view IDs `claudeSessions.activeSessions` / `claudeSessions.recentProjects` → `claudeConductor.*`; configuration section title `Claude Sessions` → `Claude Conductor`.

## Verification

- `npm run lint` — clean
- `npx tsc --noEmit -p tsconfig.test.json` — clean
- `npm test` — 1 test file, 1 test passed
- `npm run compile` — clean
- `grep -r claudeSessions src/ package.json` — zero matches

Closes #34

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*