### PR TITLE
ci: add GitHub Actions workflow for lint, typecheck, test, and compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,29 +7,58 @@ on:
       - main
 
 jobs:
-  ci:
-    name: CI
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
-
       - name: Install dependencies
         run: npm ci
-
       - name: Lint
         run: npm run lint
 
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
       - name: Typecheck
         run: npx tsc --noEmit -p tsconfig.test.json
 
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
       - name: Test
         run: npm test
 
+  compile:
+    name: Compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
       - name: Compile
         run: npm run compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit -p tsconfig.test.json
+
+      - name: Test
+        run: npm test
+
+      - name: Compile
+        run: npm run compile

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Orchestrate multiple [Claude Code](https://docs.anthropic.com/claude-code) sessions across different projects as editor tabs in a single VS Code window.
 
+[![CI](https://github.com/cbeaulieu-gt/vscode-claude-conductor/actions/workflows/ci.yml/badge.svg)](https://github.com/cbeaulieu-gt/vscode-claude-conductor/actions/workflows/ci.yml)
 [![VS Marketplace](https://badgen.net/vs-marketplace/v/cbeaulieu-gt.claude-conductor)](https://marketplace.visualstudio.com/items?itemName=cbeaulieu-gt.claude-conductor)
 [![Installs](https://badgen.net/vs-marketplace/i/cbeaulieu-gt.claude-conductor)](https://marketplace.visualstudio.com/items?itemName=cbeaulieu-gt.claude-conductor)
 [![Preview](https://img.shields.io/badge/status-preview-orange)](https://marketplace.visualstudio.com/items?itemName=cbeaulieu-gt.claude-conductor)
@@ -116,6 +117,8 @@ npm install         # install dependencies
 npm test            # run tests once (CI mode)
 npm run test:watch  # run tests in watch mode during development
 ```
+
+CI runs lint, typecheck, tests, and compile automatically on every pull request and push to `main` via GitHub Actions.
 
 Current scope is unit tests only. Integration tests via `@vscode/test-electron` are deferred to a future milestone.
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with a single `CI` job on `ubuntu-latest`
- Triggers on `pull_request` (any branch) and `push` to `main`
- Steps: `npm ci` → lint → typecheck (`tsc --noEmit -p tsconfig.test.json`) → test → compile — fail-fast, no `continue-on-error`
- Adds a CI status badge to the top of `README.md`
- Notes in the README Testing subsection that CI runs the same commands on every PR

## Test plan

- [ ] All local checks verified green before push: lint, typecheck, test, compile
- [ ] YAML parses cleanly via `js-yaml` (exit 0)
- [ ] CI workflow triggers on this PR (check Actions tab)

Closes #52

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*