### PR TITLE
chore: codify release strategy with docs, publish scripts, and version-parity guard

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,4 @@ vsc-extension-quickstart.md
 test/**
 vitest.config.ts
 tsconfig.test.json
+scripts/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+## Prerequisites
+
+- **Node.js** 20+ and **npm**
+- **TypeScript** (installed as a dev dependency — no global install needed)
+- **@vscode/vsce** (installed as a dev dependency — no global install needed)
+
+## Running tests
+
+See the [Testing section in the README](README.md#contributingdevelopment) for the
+full setup. The short version:
+
+```bash
+npm install
+npm test          # run all tests once (Vitest)
+npm run test:watch  # watch mode during development
+npm run lint        # typecheck (tsc --noEmit)
+```
+
+## Releasing
+
+Releases follow the VS Code Marketplace odd/even minor convention for stable vs
+pre-release channels. Read [`docs/release-strategy.md`](docs/release-strategy.md)
+before cutting a release — in particular:
+
+- Use `npm run publish:stable` or `npm run publish:prerelease` (never raw `vsce publish`).
+- The channel guard (`scripts/guard-channel.js`) will abort the publish if the version
+  minor parity does not match the target channel.
+
+## Filing issues
+
+Use [GitHub Issues](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues).
+Please include your VS Code version, OS, and steps to reproduce.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ CI runs lint, typecheck, tests, and compile automatically on every pull request 
 
 Current scope is unit tests only. Integration tests via `@vscode/test-electron` are deferred to a future milestone.
 
+**Releases** — this extension follows the VS Code marketplace odd/even minor convention for stable vs pre-release channels. See [docs/release-strategy.md](docs/release-strategy.md).
+
 ## Source
 
 [github.com/cbeaulieu-gt/vscode-claude-conductor](https://github.com/cbeaulieu-gt/vscode-claude-conductor)

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -1,0 +1,91 @@
+# Release Strategy
+
+## Why this convention exists
+
+The VS Code Marketplace does not support semver pre-release suffixes (`1.2.0-beta.1`).
+Versions must be plain `MAJOR.MINOR.PATCH`. The channel (stable vs pre-release) is
+signalled at publish time via a flag — not encoded in the version string itself.
+
+To make the channel unambiguous from the version number alone, we adopt Microsoft's
+own odd/even minor convention.
+
+## The odd/even minor rule
+
+| Minor is… | Example  | Channel     | Publish command             |
+|-----------|----------|-------------|-----------------------------|
+| Even      | `1.2.x`  | Stable      | `npm run publish:stable`    |
+| Odd       | `1.3.x`  | Pre-release | `npm run publish:prerelease` |
+
+Examples of the parallel lanes:
+
+```
+1.0.x  stable      1.1.x  pre-release
+1.2.x  stable      1.3.x  pre-release
+1.4.x  stable      1.5.x  pre-release
+2.0.x  stable      2.1.x  pre-release
+```
+
+## User opt-in mechanics
+
+Stable-channel users **never** receive pre-release versions automatically.
+Pre-release users must explicitly opt in via the Marketplace UI or the
+`--pre-release` flag when installing. This means a pre-release publish cannot
+accidentally break stable users.
+
+## Monotonic version rule
+
+Published versions must be monotonically increasing across **both** channels
+combined. The marketplace enforces this globally — you cannot publish `1.3.0`
+if `1.4.0` has already been published, regardless of channel. Plan your lane
+jumps accordingly: always move forward.
+
+## Versioning within a channel (same as semver)
+
+| Change type      | What to bump          | Example               |
+|------------------|-----------------------|-----------------------|
+| Breaking change  | Major (reset minor/patch) | `1.4.2` → `2.0.0` |
+| New feature      | Minor (stay in lane)  | `1.4.0` → `1.4.1` *(or bump to next even minor for a new stable cycle: `1.6.0`)* |
+| Bug / patch fix  | Patch                 | `1.4.0` → `1.4.1`    |
+
+When promoting a pre-release cycle to stable, increment to the next even minor:
+`1.3.x` (pre-release) → `1.4.0` (stable).
+
+## Publish commands
+
+Never run `vsce publish` directly — always use the npm scripts, which run the
+channel guard first:
+
+```bash
+npm run publish:stable      # even minor required
+npm run publish:prerelease  # odd minor required
+```
+
+Both commands are defined in `package.json`:
+
+```json
+"publish:stable":    "node scripts/guard-channel.js stable && vsce publish",
+"publish:prerelease":"node scripts/guard-channel.js prerelease && vsce publish --pre-release"
+```
+
+## The channel guard
+
+`scripts/guard-channel.js` enforces parity before every publish.
+
+It reads `version` from `package.json`, checks the minor parity, and:
+
+- Exits **0** silently on match.
+- Exits **1** with a descriptive error on mismatch, e.g.:
+
+  ```
+  Version 1.2.0 has EVEN minor (2) — cannot publish as pre-release.
+  Bump to 1.3.0 first, or use `npm run publish:stable`.
+  ```
+
+- Exits **2** for an unknown channel argument.
+- Exits **3** if `package.json` is missing or has no `version` field.
+
+Unit tests live in `test/guard-channel.test.ts` and run with `npm test`.
+
+## See also
+
+[VS Code docs — Pre-release extensions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions)

--- a/package.json
+++ b/package.json
@@ -203,7 +203,9 @@
     "package": "npm run compile && vsce package --no-dependencies",
     "lint": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "publish:stable": "node scripts/guard-channel.js stable && vsce publish",
+    "publish:prerelease": "node scripts/guard-channel.js prerelease && vsce publish --pre-release"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/scripts/guard-channel.d.ts
+++ b/scripts/guard-channel.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Validate that a semver version string is compatible with the target publish
+ * channel, using the odd/even minor convention.
+ *
+ * Throws an Error with a descriptive message on any problem.
+ * Returns void on success.
+ *
+ * @param version  - The version string from package.json (e.g. "1.2.0").
+ * @param channel  - The intended publish channel: "stable" or "prerelease".
+ * @throws {Error} If version is malformed, channel is unknown, or minor parity
+ *                 does not match the channel.
+ */
+export function validateChannel(
+  version: string,
+  channel: "stable" | "prerelease"
+): void;

--- a/scripts/guard-channel.js
+++ b/scripts/guard-channel.js
@@ -1,0 +1,115 @@
+// guard-channel.js
+//
+// VS Code Marketplace version-parity guard.
+//
+// Rule: the minor version number encodes the publish channel.
+//   Even minor (0, 2, 4, …) → stable channel   (vsce publish)
+//   Odd  minor (1, 3, 5, …) → pre-release channel (vsce publish --pre-release)
+//
+// This mirrors Microsoft's own convention for first-party VS Code extensions.
+// See: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions
+//
+// Usage (CLI):
+//   node scripts/guard-channel.js <stable|prerelease>
+//
+// Usage (programmatic):
+//   const { validateChannel } = require('./scripts/guard-channel');
+//   validateChannel('1.2.0', 'stable');  // throws on mismatch
+
+"use strict";
+
+/**
+ * Validate that a semver version string is compatible with the target publish
+ * channel, using the odd/even minor convention.
+ *
+ * Contract:
+ *   - Throws an Error with a descriptive message on any problem.
+ *   - Returns undefined (void) on success.
+ *
+ * @param {string} version  - The version string from package.json (e.g. "1.2.0").
+ * @param {"stable"|"prerelease"} channel - The intended publish channel.
+ * @throws {Error} If the version is malformed, the channel is unknown, or the
+ *                 minor parity does not match the channel.
+ */
+function validateChannel(version, channel) {
+  // --- validate channel arg ---
+  if (channel !== "stable" && channel !== "prerelease") {
+    throw new Error(
+      `Unknown channel "${channel}". Expected "stable" or "prerelease".`
+    );
+  }
+
+  // --- validate & parse version ---
+  if (!version || typeof version !== "string") {
+    throw new Error(`Malformed version: expected a non-empty string, got ${JSON.stringify(version)}.`);
+  }
+
+  const parts = version.split(".");
+  if (parts.length !== 3) {
+    throw new Error(`Malformed version "${version}": expected MAJOR.MINOR.PATCH format.`);
+  }
+
+  const minor = parseInt(parts[1], 10);
+  if (isNaN(minor)) {
+    throw new Error(`Invalid version "${version}": minor segment "${parts[1]}" is not a number.`);
+  }
+
+  const isEven = minor % 2 === 0;
+
+  // --- parity check ---
+  if (channel === "stable" && !isEven) {
+    throw new Error(
+      `Version ${version} has ODD minor (${minor}) — cannot publish as stable. ` +
+      `Bump to ${parts[0]}.${minor + 1}.0 first, or use \`npm run publish:prerelease\`.`
+    );
+  }
+
+  if (channel === "prerelease" && isEven) {
+    throw new Error(
+      `Version ${version} has EVEN minor (${minor}) — cannot publish as pre-release. ` +
+      `Bump to ${parts[0]}.${minor + 1}.0 first, or use \`npm run publish:stable\`.`
+    );
+  }
+}
+
+module.exports = { validateChannel };
+
+// CLI entrypoint
+if (require.main === module) {
+  const channel = process.argv[2];
+
+  if (!channel || (channel !== "stable" && channel !== "prerelease")) {
+    process.stderr.write(
+      "Usage: node scripts/guard-channel.js <stable|prerelease>\n"
+    );
+    process.exit(2);
+  }
+
+  // Read package.json relative to this script file
+  const path = require("path");
+  const fs = require("fs");
+  const pkgPath = path.resolve(__dirname, "..", "package.json");
+
+  let pkg;
+  try {
+    pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+  } catch (err) {
+    process.stderr.write(`Failed to read package.json: ${err.message}\n`);
+    process.exit(3);
+  }
+
+  const version = pkg.version;
+  if (!version) {
+    process.stderr.write(`package.json does not contain a "version" field.\n`);
+    process.exit(3);
+  }
+
+  try {
+    validateChannel(version, channel);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  }
+
+  process.exit(0);
+}

--- a/test/guard-channel.test.ts
+++ b/test/guard-channel.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { validateChannel } from "../scripts/guard-channel.js";
+
+describe("validateChannel", () => {
+  // --- happy paths ---
+
+  it("accepts stable channel for even minor (1.2.0)", () => {
+    expect(() => validateChannel("1.2.0", "stable")).not.toThrow();
+  });
+
+  it("accepts prerelease channel for odd minor (1.3.0)", () => {
+    expect(() => validateChannel("1.3.0", "prerelease")).not.toThrow();
+  });
+
+  it("accepts stable channel for even minor (2.0.5)", () => {
+    expect(() => validateChannel("2.0.5", "stable")).not.toThrow();
+  });
+
+  it("accepts prerelease channel for odd minor (1.1.0)", () => {
+    expect(() => validateChannel("1.1.0", "prerelease")).not.toThrow();
+  });
+
+  // --- mismatch errors ---
+
+  it("rejects even minor (1.2.0) for prerelease channel", () => {
+    expect(() => validateChannel("1.2.0", "prerelease")).toThrow(
+      /EVEN minor.*stable/i
+    );
+  });
+
+  it("rejects odd minor (1.3.0) for stable channel", () => {
+    expect(() => validateChannel("1.3.0", "stable")).toThrow(
+      /ODD minor.*prerelease/i
+    );
+  });
+
+  // --- malformed / missing inputs ---
+
+  it("throws on malformed version string ('abc')", () => {
+    expect(() => validateChannel("abc", "stable")).toThrow(/malformed|invalid/i);
+  });
+
+  it("throws on missing version (empty string)", () => {
+    expect(() => validateChannel("", "stable")).toThrow(/malformed|invalid/i);
+  });
+
+  it("throws on unknown channel", () => {
+    expect(() => validateChannel("1.2.0", "weird" as never)).toThrow(
+      /unknown channel/i
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `docs/release-strategy.md` documenting the VS Code Marketplace odd/even minor convention for stable vs pre-release channels
- Adds `scripts/guard-channel.js` — a zero-dependency Node CJS module that aborts a publish when the `package.json` version minor parity does not match the target channel; exports `validateChannel(version, channel)` for unit testing
- Adds `scripts/guard-channel.d.ts` so the test file type-checks cleanly
- Adds `test/guard-channel.test.ts` with 9 Vitest unit tests covering all happy paths, mismatches, and error cases
- Adds `publish:stable` and `publish:prerelease` npm scripts that run the guard before invoking `vsce publish`
- Adds `CONTRIBUTING.md` with prerequisites, test instructions, and a link to the release strategy
- Updates `README.md` with a one-sentence release strategy pointer after the CI section
- Updates `.vscodeignore` to exclude `scripts/**` from the VSIX bundle

## Test plan

- [x] `npm run lint` — clean (tsc --noEmit)
- [x] `npx tsc --noEmit -p tsconfig.test.json` — clean
- [x] `npm test` — 10/10 pass (9 new guard tests + 1 existing)
- [x] `npm run compile` — clean
- [x] Smoke: `node scripts/guard-channel.js stable` → exit 0
- [x] Smoke: `node scripts/guard-channel.js prerelease` → exit 1 with descriptive error
- [x] Smoke: `node scripts/guard-channel.js bogus` → exit 2 with usage message

Closes #56

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*