### PR TITLE
ci: add marketplace publish workflow with channel safety and CHANGELOG-driven releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,71 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v1.3.0)'
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Compile
+        run: npm run compile
+
+      - name: Derive channel
+        run: |
+          TAG=${{ inputs.tag || github.ref_name }}
+          VERSION=${TAG#v}
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          if [ $((MINOR % 2)) -eq 0 ]; then
+            CHANNEL=stable
+          else
+            CHANNEL=prerelease
+          fi
+          echo "CHANNEL=$CHANNEL" >> "$GITHUB_ENV"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "TAG_NAME=$TAG" >> "$GITHUB_ENV"
+
+      - name: Publish
+        run: npm run publish:${{ env.CHANNEL }}
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Extract release notes
+        if: success()
+        run: node scripts/extract-changelog.js "$VERSION" > release_notes.md
+
+      - name: Create GitHub Release
+        if: success()
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG_NAME }}
+          name: ${{ env.TAG_NAME }}
+          body_path: release_notes.md
+          prerelease: ${{ env.CHANNEL == 'prerelease' }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Orchestrate multiple [Claude Code](https://docs.anthropic.com/claude-code) sessions across different projects as editor tabs in a single VS Code window.
 
-[![CI](https://github.com/cbeaulieu-gt/vscode-claude-conductor/actions/workflows/ci.yml/badge.svg)](https://github.com/cbeaulieu-gt/vscode-claude-conductor/actions/workflows/ci.yml)
+[![CI](https://github.com/cbeaulieu-gt/vscode-claude-conductor/actions/workflows/ci.yml/badge.svg)](https://github.com/cbeaulieu-gt/vscode-claude-conductor/actions/workflows/ci.yml) [![Publish](https://github.com/cbeaulieu-gt/vscode-claude-conductor/actions/workflows/publish.yml/badge.svg)](https://github.com/cbeaulieu-gt/vscode-claude-conductor/actions/workflows/publish.yml)
 [![VS Marketplace](https://badgen.net/vs-marketplace/v/cbeaulieu-gt.claude-conductor)](https://marketplace.visualstudio.com/items?itemName=cbeaulieu-gt.claude-conductor)
 [![Installs](https://badgen.net/vs-marketplace/i/cbeaulieu-gt.claude-conductor)](https://marketplace.visualstudio.com/items?itemName=cbeaulieu-gt.claude-conductor)
 [![Preview](https://img.shields.io/badge/status-preview-orange)](https://marketplace.visualstudio.com/items?itemName=cbeaulieu-gt.claude-conductor)

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -89,3 +89,103 @@ Unit tests live in `test/guard-channel.test.ts` and run with `npm test`.
 ## See also
 
 [VS Code docs — Pre-release extensions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions)
+
+---
+
+## GitHub Actions secret setup
+
+The publish workflow authenticates to the VS Code Marketplace using a Personal
+Access Token stored as a repository secret. Follow these steps before pushing
+the first release tag.
+
+### Create an Azure DevOps PAT
+
+1. Sign in to [dev.azure.com](https://dev.azure.com) with the publisher account
+   (the account that owns the `cbeaulieu-gt` Marketplace publisher).
+2. Open **User settings → Personal access tokens → New Token**.
+3. Give the token a descriptive name, e.g. `vscode-marketplace-publish`.
+4. Set **Organization** to **"All accessible organizations"** — `vsce` requires
+   this; a single-organization PAT will be rejected at publish time.
+5. Set an expiry (one year is a reasonable default).
+6. Under **Scopes**, select **Marketplace → Publish** (and only that scope).
+7. Click **Create** and copy the token immediately — you cannot retrieve it again.
+
+### Add the secret to the repository
+
+1. In the GitHub repo, go to **Settings → Secrets and variables → Actions**.
+2. Click **New repository secret**.
+3. Name: `VSCE_PAT`
+4. Value: the Azure DevOps PAT you copied above.
+5. Click **Add secret**.
+
+### PAT rotation
+
+Rotate the PAT at least once a year (or immediately if it may have been
+exposed). Recommended practice:
+
+- Note the expiry date in a pinned issue or a calendar reminder set one week
+  before expiry.
+- When rotating: create the new PAT first, update the `VSCE_PAT` secret, then
+  revoke the old PAT.
+
+If the secret is missing, expired, or invalid the **Publish** step of the
+workflow will fail loudly — this is intentional so a bad credential is surfaced
+immediately rather than silently skipping the publish.
+
+---
+
+## Cutting a release
+
+Follow these steps every time you publish a new version to the Marketplace.
+
+1. **Merge all PRs** targeting the release into `main`.
+2. **Pull latest `main`:**
+   ```bash
+   git pull --ff-only origin main
+   ```
+3. **Bump `version` in `package.json`:**
+   - Even minor (e.g. `1.4.0`) → publishes to the **stable** channel.
+   - Odd minor (e.g. `1.5.0`) → publishes to the **pre-release** channel.
+   - If you are staying in the same minor lane, increment the patch instead
+     (e.g. `1.3.0` → `1.3.1`).
+4. **Update `CHANGELOG.md`:** move the `[Unreleased]` entries into a new
+   versioned section with today's date:
+   ```markdown
+   ## [X.Y.Z] — YYYY-MM-DD
+   ```
+5. **Commit:**
+   ```bash
+   git commit -am "chore: bump to X.Y.Z"
+   ```
+6. **Push the commit:**
+   ```bash
+   git push origin main
+   ```
+7. **Create the tag:**
+   ```bash
+   git tag vX.Y.Z
+   ```
+8. **Push the tag:**
+   ```bash
+   git push origin vX.Y.Z
+   ```
+9. **Watch the workflow:** go to the **Actions** tab in the GitHub repo and
+   open the **Publish** workflow run that triggered on the tag push. On success
+   the workflow will:
+   - Publish the extension to the VS Code Marketplace (stable or pre-release
+     channel, determined automatically from the minor parity).
+   - Create a GitHub Release for the tag using the matching CHANGELOG entry as
+     the release notes.
+
+### Manual-dispatch retry path
+
+If the tag-triggered run fails due to a transient Marketplace error (e.g.
+a momentary 5xx from the VS Code Marketplace API) you can re-trigger the
+publish without pushing a new tag:
+
+1. Go to **Actions → Publish workflow → Run workflow**.
+2. Enter the existing tag in the **Tag to publish** input (e.g. `v1.3.0`).
+3. Click **Run workflow**.
+
+The workflow checks out that tag, runs the full lint/test/compile pipeline, and
+publishes exactly as the automatic run would have.

--- a/scripts/extract-changelog.d.ts
+++ b/scripts/extract-changelog.d.ts
@@ -1,0 +1,16 @@
+/**
+ * Extract the body of a versioned section from a CHANGELOG markdown string.
+ *
+ * Finds the section that begins with `## [<version>]` (exact version match,
+ * dots treated as literals). Captures everything after that heading line up
+ * to — but not including — the next `## [` heading, or the end of the string.
+ *
+ * @param markdown  - Full CHANGELOG content as a string.
+ * @param version   - The version to look up, e.g. "1.3.0".
+ * @returns The section body (leading/trailing whitespace trimmed), or null if
+ *          the section is not found or the inputs are invalid.
+ */
+export function extractChangelogSection(
+  markdown: string,
+  version: string
+): string | null;

--- a/scripts/extract-changelog.js
+++ b/scripts/extract-changelog.js
@@ -1,0 +1,118 @@
+// extract-changelog.js
+//
+// Extracts the body of a versioned section from CHANGELOG.md.
+//
+// Usage (CLI):
+//   node scripts/extract-changelog.js <version>  — e.g. "1.3.0"
+//   Emits the section body (without the heading line) to stdout.
+//   Exit codes:
+//     0 — success
+//     1 — section not found in CHANGELOG
+//     2 — CHANGELOG.md missing or unreadable
+//     3 — missing or invalid version argument
+//
+// Usage (programmatic):
+//   const { extractChangelogSection } = require('./scripts/extract-changelog');
+//   const body = extractChangelogSection(markdownString, '1.3.0');
+//   // Returns the body string, or null if the section is not found.
+
+"use strict";
+
+/**
+ * Extract the body of a versioned section from a CHANGELOG markdown string.
+ *
+ * Finds the section that begins with `## [<version>]` (exact version match,
+ * dots are treated as literals, not regex wildcards). Captures everything
+ * after that heading line up to — but not including — the next `## [` heading,
+ * or the end of the string.
+ *
+ * @param {string} markdown  - Full CHANGELOG content as a string.
+ * @param {string} version   - The version to look up, e.g. "1.3.0".
+ * @returns {string|null}    - The section body (leading/trailing whitespace
+ *                             trimmed), or null if not found / input invalid.
+ */
+function extractChangelogSection(markdown, version) {
+  if (!markdown || typeof markdown !== "string" || !markdown.trim()) {
+    return null;
+  }
+
+  if (!version || typeof version !== "string") {
+    return null;
+  }
+
+  // Escape regex-special characters in the version string so "1.3.0" matches
+  // literally and not as "1X3Y0".
+  const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+  // Match the heading line for this version, then capture everything up to
+  // the next ## [ heading or end of string.
+  const pattern = new RegExp(
+    `^## \\[${escapedVersion}\\][^\\n]*\\n([\\s\\S]*?)(?=^## \\[|\\Z)`,
+    "m"
+  );
+
+  // The \Z anchor isn't supported in JS regex; use alternation with $ and the
+  // end-of-string position by replacing \Z with end-of-input via a two-pass
+  // approach: try the bounded match first, then the unbounded (last section).
+  const boundedPattern = new RegExp(
+    `^## \\[${escapedVersion}\\][^\\n]*\\n([\\s\\S]*?)(?=^## \\[)`,
+    "m"
+  );
+  const unboundedPattern = new RegExp(
+    `^## \\[${escapedVersion}\\][^\\n]*\\n([\\s\\S]*)$`,
+    "m"
+  );
+
+  const bounded = boundedPattern.exec(markdown);
+  if (bounded) {
+    return bounded[1].trim();
+  }
+
+  const unbounded = unboundedPattern.exec(markdown);
+  if (unbounded) {
+    return unbounded[1].trim();
+  }
+
+  return null;
+}
+
+module.exports = { extractChangelogSection };
+
+// CLI entrypoint
+if (require.main === module) {
+  const version = process.argv[2];
+
+  if (!version || typeof version !== "string" || !version.trim()) {
+    process.stderr.write(
+      "Usage: node scripts/extract-changelog.js <version>\n" +
+        "  e.g.: node scripts/extract-changelog.js 1.3.0\n"
+    );
+    process.exit(3);
+  }
+
+  const path = require("path");
+  const fs = require("fs");
+  const changelogPath = path.join(__dirname, "..", "CHANGELOG.md");
+
+  let markdown;
+  try {
+    markdown = fs.readFileSync(changelogPath, "utf8");
+  } catch (err) {
+    process.stderr.write(
+      `Failed to read CHANGELOG.md at ${changelogPath}: ${err.message}\n`
+    );
+    process.exit(2);
+  }
+
+  const body = extractChangelogSection(markdown, version);
+
+  if (body === null) {
+    process.stderr.write(
+      `Section for version [${version}] not found in CHANGELOG.md\n`
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write(body + "\n");
+  process.exit(0);
+}

--- a/test/extract-changelog.test.ts
+++ b/test/extract-changelog.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { extractChangelogSection } from "../scripts/extract-changelog.js";
+
+// Sample CHANGELOG content used across test cases
+const SAMPLE_CHANGELOG = `# Changelog
+
+## [Unreleased]
+
+_No unreleased changes._
+
+## [2.0.0] — 2026-05-01
+
+### Added
+- Big new feature
+
+## [1.3.0] — 2026-04-23
+
+### Added
+- Vitest test infrastructure
+
+### Fixed
+- Shell init race condition
+
+## [1.1.5] — 2026-04-19
+
+### Fixed
+- README marketplace badges now render
+`;
+
+describe("extractChangelogSection", () => {
+  // --- happy paths ---
+
+  it("returns body for section at the top (2.0.0 is first versioned section)", () => {
+    const result = extractChangelogSection(SAMPLE_CHANGELOG, "2.0.0");
+    expect(result).toContain("Big new feature");
+    // Should NOT include the next heading
+    expect(result).not.toContain("## [1.3.0]");
+    // Should NOT include the heading line itself
+    expect(result).not.toContain("## [2.0.0]");
+  });
+
+  it("returns body for section in middle (1.3.0)", () => {
+    const result = extractChangelogSection(SAMPLE_CHANGELOG, "1.3.0");
+    expect(result).toContain("Vitest test infrastructure");
+    expect(result).toContain("Shell init race condition");
+    // Bounded above by 2.0.0 heading and below by 1.1.5 heading
+    expect(result).not.toContain("## [2.0.0]");
+    expect(result).not.toContain("## [1.1.5]");
+  });
+
+  it("returns body for section at end of file (1.1.5)", () => {
+    const result = extractChangelogSection(SAMPLE_CHANGELOG, "1.1.5");
+    expect(result).toContain("README marketplace badges now render");
+    expect(result).not.toContain("## [1.3.0]");
+  });
+
+  // --- not found / empty / malformed ---
+
+  it("returns null when the version section is not present", () => {
+    const result = extractChangelogSection(SAMPLE_CHANGELOG, "9.9.9");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for an empty CHANGELOG string", () => {
+    const result = extractChangelogSection("", "1.3.0");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when CHANGELOG contains no '## [' headings at all", () => {
+    const result = extractChangelogSection("# Just a title\nSome prose.", "1.3.0");
+    expect(result).toBeNull();
+  });
+
+  // --- regex safety ---
+
+  it("matches version containing dots literally, not as regex wildcards (1.3.0 must not match 1X3Y0)", () => {
+    // "1X3Y0" would match /1.3.0/ if dots were treated as regex wildcards
+    const deceptive = `# Changelog\n\n## [1X3Y0] — 2026-01-01\n\n- fake\n`;
+    const result = extractChangelogSection(deceptive, "1.3.0");
+    expect(result).toBeNull();
+  });
+
+  it("finds the real 1.3.0 section even when a deceptive near-match precedes it", () => {
+    const content = `# Changelog\n\n## [1X3Y0] — 2026-01-01\n\n- fake\n\n## [1.3.0] — 2026-04-23\n\n- real\n`;
+    const result = extractChangelogSection(content, "1.3.0");
+    expect(result).not.toBeNull();
+    expect(result).toContain("real");
+    expect(result).not.toContain("fake");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` triggered on `push.tags: v*.*.*` and `workflow_dispatch` only — no branch push, no PR triggers.
- The workflow derives the publish channel from the tag's minor parity (odd minor → prerelease, even minor → stable), runs lint/test/compile, then invokes the existing `npm run publish:stable|prerelease` scripts (which call `guard-channel.js` as a second safety check).
- After a successful publish, `scripts/extract-changelog.js` extracts the matching CHANGELOG section and `softprops/action-gh-release@v2` creates a GitHub Release with those notes.

## New files

| File | Purpose |
|---|---|
| `.github/workflows/publish.yml` | Publish workflow |
| `scripts/extract-changelog.js` | Extracts a versioned CHANGELOG section; exported function + CLI entrypoint |
| `scripts/extract-changelog.d.ts` | TypeScript declarations for the above |
| `test/extract-changelog.test.ts` | 8 vitest tests (TDD — watched fail before implementing) |

## Updated files

| File | Change |
|---|---|
| `docs/release-strategy.md` | New sections: "GitHub Actions secret setup" and "Cutting a release" |
| `README.md` | Publish workflow badge added next to CI badge |

## Secret required

The repo owner must set `VSCE_PAT` in **Settings → Secrets and variables → Actions** before pushing the first release tag. Setup instructions are in `docs/release-strategy.md`.

## Test results

All 18 tests pass (3 test files: `guard-channel`, `extract-changelog`, `sessionManager.focusSession`).

Closes #57

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*