### PR TITLE
fix: bump engines.vscode to 1.93 to match @types/vscode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ All user-facing identifiers have been renamed from the `claudeSessions.*` namesp
 - Configuration section title: `Claude Sessions` → `Claude Conductor`
 - Command palette prefixes: `Claude Sessions:` → `Claude Conductor:`
 
+### Changed
+- **Minimum VS Code version raised to 1.93.** This aligns `engines.vscode` with `@types/vscode` (required by `vsce publish`). Users on VS Code < 1.93 will no longer receive updates via the marketplace.
+
 ### Fixed
 - **Shell init race condition** — `claude` is no longer sent to the terminal mid-profile-init. When VS Code shell integration is available (VS Code ≥ 1.93), the command is dispatched via `shellIntegration.executeCommand()` which waits for the shell prompt. On older VS Code or when shell integration is disabled, a configurable delay (`claudeConductor.launchDelayMs`, default 500 ms) is used instead. Fixes #40.
 - **Idle notifications restored** — the sidebar bell icon and VS Code notification now correctly appear when a Claude session finishes and waits for input. The `Stop` hook deletes the state file; the extension was ignoring that deletion (`_onStateFileDeleted` was a no-op), so sessions stayed stuck in idle state indefinitely. The handler now looks up the session via a cached filename-to-path map and calls `setSessionIdle(folderPath, false)`, clearing both the tree-view icon and the idle set. A new **"Claude Conductor"** output channel logs state-file reads, dispatch decisions, and path-match results for easier diagnostics. Fixes #37.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher": "cbeaulieu-gt",
   "preview": true,
   "engines": {
-    "vscode": "^1.85.0"
+    "vscode": "^1.93.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
## Summary

- Raises `engines.vscode` from `^1.85.0` to `^1.93.0` in `package.json`
- Adds a `### Changed` entry to the `[1.3.0]` section of `CHANGELOG.md`

## Context

This is the hotfix for the failed v1.3.0 `vsce publish`. The publish step rejected the package because `@types/vscode` was declared at `^1.93.0` while `engines.vscode` was still `^1.85.0` — `vsce` enforces that the declared engine minimum must be >= the types version. Raising the engine floor to `1.93` unblocks the publish. The router will re-tag `v1.3.0` after this merges.

Users on VS Code < 1.93 will no longer receive marketplace updates; this is acceptable given the extension is primarily internal use.

## Verification

All CI checks mirror the pre-publish gate and pass locally:

| Check | Result |
|---|---|
| `npm run lint` | ✓ |
| `npx tsc --noEmit -p tsconfig.test.json` | ✓ |
| `npm test` (18 tests) | ✓ |
| `npm run compile` | ✓ |
| `npx vsce package --no-dependencies` | ✓ exit 0, no engine/types error |

Closes #60

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*