### PR TITLE
ci: grant contents:write to publish job for GitHub Release creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: write` at the `jobs.publish` level in `.github/workflows/publish.yml`
- The `softprops/action-gh-release@v2` step was failing with HTTP 403 on the v1.3.0 release because GitHub's default `GITHUB_TOKEN` no longer includes write access to release content (tightened defaults since 2023)
- Scoped to the job level (not the workflow root) to avoid over-granting — no other job or step receives elevated permissions

## Context

This is the second hotfix following the v1.3.0 release dance. The marketplace publish itself was unaffected — only the final "Create GitHub Release" step failed. This change unblocks that step for all future releases.

## Verification

| Check | Result |
|---|---|
| `npx js-yaml publish.yml > /dev/null` | YAML parses cleanly |
| `npm run lint` | Pass |
| `npm test` | 18/18 passed |
| `npm run compile` | Pass |

Closes #62

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*