### PR TITLE
fix: reconcile stale hook paths after extension update

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ When you allow notification hooks, the extension adds three entries to your `~/.
 
 The hooks write state files to `~/.claude/session-state/` which the extension watches. **Only your VS Code extension reads these files** — no data leaves your machine.
 
+**After an extension update**, VS Code installs the new version to a different directory, which would normally leave the hook commands pointing at the old path. Claude Conductor detects this automatically on activation and silently updates the paths in `~/.claude/settings.json` — no user action required.
+
 To remove the hooks at any time: run `Claude Conductor: Remove Notification Hooks` from the command palette.
 
 ## Requirements

--- a/src/hookInstaller.ts
+++ b/src/hookInstaller.ts
@@ -11,8 +11,11 @@ const SETUP_DECLINED_KEY = "claudeConductor.hookSetupDeclined";
 /**
  * Get the path to our hook script, using Unix-style paths for git bash compatibility.
  * Claude Code on Windows uses git bash paths like /c/Users/...
+ *
+ * Exported so tests can build platform-correct fixtures without hardcoding
+ * OS-specific command strings.
  */
-function getHookScriptPath(context: vscode.ExtensionContext): string {
+export function getHookScriptPath(context: vscode.ExtensionContext): string {
   const hookPath = path.join(context.extensionPath, "hooks", "session-state.js");
 
   if (process.platform === "win32") {

--- a/src/hookInstaller.ts
+++ b/src/hookInstaller.ts
@@ -58,6 +58,79 @@ function hooksInstalled(settings: Record<string, unknown>): boolean {
 }
 
 /**
+ * Return true only when every hook entry containing the session-state.js marker
+ * has a command string that starts with expectedScriptBase.
+ *
+ * If no hooks containing the marker exist, there is nothing stale — returns true.
+ */
+export function hooksUpToDate(
+  settings: Record<string, unknown>,
+  expectedScriptBase: string
+): boolean {
+  const hooks = settings.hooks as Record<string, unknown[]> | undefined;
+  if (!hooks) {
+    return true;
+  }
+
+  for (const entries of Object.values(hooks)) {
+    for (const entry of entries as Array<Record<string, unknown>>) {
+      const innerHooks = entry.hooks as Array<Record<string, unknown>> | undefined;
+      if (!innerHooks) {
+        continue;
+      }
+      for (const h of innerHooks) {
+        const cmd = h.command as string | undefined;
+        if (cmd && cmd.includes(HOOK_MARKER)) {
+          if (!cmd.startsWith(expectedScriptBase)) {
+            return false;
+          }
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Rewrite every hook command that contains the session-state.js marker so
+ * its leading path portion is replaced with expectedScriptBase, preserving
+ * the trailing action argument (idle / active / stop).
+ *
+ * Both Windows git-bash form (`/c/PROGRA~1/nodejs/node.exe /c/Users/...`) and
+ * POSIX form (`node /path/to/...`) round-trip correctly because we split on
+ * the last space before the action arg to isolate the action, then reconstruct.
+ */
+export function reconcileHookPaths(
+  settings: Record<string, unknown>,
+  expectedScriptBase: string
+): void {
+  const hooks = settings.hooks as Record<string, unknown[]> | undefined;
+  if (!hooks) {
+    return;
+  }
+
+  for (const entries of Object.values(hooks)) {
+    for (const entry of entries as Array<Record<string, unknown>>) {
+      const innerHooks = entry.hooks as Array<Record<string, unknown>> | undefined;
+      if (!innerHooks) {
+        continue;
+      }
+      for (const h of innerHooks) {
+        const cmd = h.command as string | undefined;
+        if (cmd && cmd.includes(HOOK_MARKER)) {
+          // The command is "<scriptBase> <action>" — extract the action from
+          // the last whitespace-delimited token.
+          const lastSpace = cmd.lastIndexOf(" ");
+          const action = lastSpace !== -1 ? cmd.slice(lastSpace + 1) : "";
+          h.command = `${expectedScriptBase} ${action}`;
+        }
+      }
+    }
+  }
+}
+
+/**
  * Install our hooks into the existing settings, preserving all existing hooks.
  */
 function installHooks(settings: Record<string, unknown>, scriptBase: string): void {
@@ -147,6 +220,16 @@ export async function ensureHooksInstalled(
   const settings = readSettings();
 
   if (hooksInstalled(settings)) {
+    const scriptBase = getHookScriptPath(context);
+    if (!hooksUpToDate(settings, scriptBase)) {
+      // Paths are stale (extension updated to a new directory). Silently
+      // reconcile — consent was already granted at initial install.
+      reconcileHookPaths(settings, scriptBase);
+      writeSettings(settings);
+      vscode.window.showInformationMessage(
+        "Claude session hook paths updated for new extension version."
+      );
+    }
     return true;
   }
 

--- a/test/hookInstaller.test.ts
+++ b/test/hookInstaller.test.ts
@@ -17,6 +17,8 @@ import * as fs from "fs";
 // We mock fs so we don't touch the real ~/.claude/settings.json
 vi.mock("fs");
 
+// Unix-style paths used in unit tests for hooksUpToDate / reconcileHookPaths
+// (those functions are purely string-based and platform-agnostic).
 const OLD_PATH = "/c/Users/chris/.vscode/extensions/conductor-0.1.0";
 const NEW_PATH = "/c/Users/chris/.vscode/extensions/conductor-0.2.0";
 
@@ -25,6 +27,19 @@ const NEW_SCRIPT_BASE_WIN = `/c/PROGRA~1/nodejs/node.exe ${NEW_PATH}/hooks/sessi
 
 const OLD_SCRIPT_BASE_POSIX = `node ${OLD_PATH}/hooks/session-state.js`;
 const NEW_SCRIPT_BASE_POSIX = `node ${NEW_PATH}/hooks/session-state.js`;
+
+// Integration tests need platform-native extension paths so that path.join()
+// inside getHookScriptPath() resolves correctly on the current OS.
+// On Windows use backslash-separated "C:\Users\..." style; on POSIX use the
+// forward-slash paths directly.
+const OLD_EXT_PATH =
+  process.platform === "win32"
+    ? "C:\\Users\\chris\\.vscode\\extensions\\conductor-0.1.0"
+    : "/c/Users/chris/.vscode/extensions/conductor-0.1.0";
+const NEW_EXT_PATH =
+  process.platform === "win32"
+    ? "C:\\Users\\chris\\.vscode\\extensions\\conductor-0.2.0"
+    : "/c/Users/chris/.vscode/extensions/conductor-0.2.0";
 
 function makeSettingsWithHooks(scriptBase: string): Record<string, unknown> {
   return {
@@ -52,7 +67,7 @@ function makeSettingsWithHooks(scriptBase: string): Record<string, unknown> {
 // ---------------------------------------------------------------------------
 // Import helpers under test AFTER setting up the vi.mock above
 // ---------------------------------------------------------------------------
-import { hooksUpToDate, reconcileHookPaths } from "../src/hookInstaller.js";
+import { hooksUpToDate, reconcileHookPaths, getHookScriptPath } from "../src/hookInstaller.js";
 
 describe("hooksUpToDate", () => {
   it("returns true when all hook commands match the expected script base", () => {
@@ -186,28 +201,28 @@ describe("ensureHooksInstalled — path reconciliation", () => {
   });
 
   it("silently rewrites stale paths and returns true without prompting the user", async () => {
+    // Build platform-correct script bases from the actual helper so the fixture
+    // always matches the platform under test (Windows or Linux CI).
+    const oldContext = makeContext(OLD_EXT_PATH);
+    const newContext = makeContext(NEW_EXT_PATH);
+    const oldScriptBase = getHookScriptPath(oldContext);
+    const newScriptBase = getHookScriptPath(newContext);
+
     // Arrange: settings on disk have hooks pointing at OLD_PATH
-    const oldSettings = makeSettingsWithHooks(OLD_SCRIPT_BASE_WIN);
+    const oldSettings = makeSettingsWithHooks(oldScriptBase);
     (fs.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
       JSON.stringify(oldSettings)
     );
     const writeMock = fs.writeFileSync as ReturnType<typeof vi.fn>;
     writeMock.mockImplementation(() => {});
 
-    // VS Code would install the new version at NEW_PATH
-    // On Windows getHookScriptPath builds: /c/PROGRA~1/nodejs/node.exe /<drive><rest>
-    // We need the context to resolve to a path that produces NEW_SCRIPT_BASE_WIN.
-    // The function hard-codes the node prefix, so we set extensionPath to a value
-    // that will produce NEW_PATH after drive-letter conversion.
-    // NEW_PATH = "/c/Users/chris/.vscode/extensions/conductor-0.2.0"
-    // → Windows equivalent: C:\Users\chris\.vscode\extensions\conductor-0.2.0
-    const winExtPath = "C:\\Users\\chris\\.vscode\\extensions\\conductor-0.2.0";
-    const context = makeContext(winExtPath);
+    // Sanity: old and new script bases must differ — otherwise the test is vacuous
+    expect(oldScriptBase).not.toBe(newScriptBase);
 
     const { window } = await import("../test/mocks/vscode.js");
     const showInfoSpy = vi.spyOn(window, "showInformationMessage");
 
-    const result = await ensureHooksInstalled(context);
+    const result = await ensureHooksInstalled(newContext);
 
     expect(result).toBe(true);
     // writeFileSync should have been called (settings were rewritten)
@@ -225,16 +240,18 @@ describe("ensureHooksInstalled — path reconciliation", () => {
   });
 
   it("does not write settings when paths are already up to date", async () => {
-    // The NEW context path is the same as what's already in the settings
-    const winExtPath = "C:\\Users\\chris\\.vscode\\extensions\\conductor-0.2.0";
-    const currentSettings = makeSettingsWithHooks(NEW_SCRIPT_BASE_WIN);
+    // Build the fixture from the same helper the implementation uses so the
+    // expected script base matches on any platform (Windows or Linux CI).
+    const context = makeContext(NEW_EXT_PATH);
+    const currentScriptBase = getHookScriptPath(context);
+    const currentSettings = makeSettingsWithHooks(currentScriptBase);
+
     (fs.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
       JSON.stringify(currentSettings)
     );
     const writeMock = fs.writeFileSync as ReturnType<typeof vi.fn>;
     writeMock.mockImplementation(() => {});
 
-    const context = makeContext(winExtPath);
     const result = await ensureHooksInstalled(context);
 
     expect(result).toBe(true);

--- a/test/hookInstaller.test.ts
+++ b/test/hookInstaller.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for hook path reconciliation (issue #64).
+ *
+ * When the extension updates, VS Code installs it to a new directory. The
+ * hook entries in ~/.claude/settings.json embed an absolute path to
+ * hooks/session-state.js inside the OLD extension directory. These tests
+ * verify that:
+ *  - hooksUpToDate() correctly detects stale vs current paths
+ *  - reconcileHookPaths() rewrites every stale command preserving the action arg
+ *  - ensureHooksInstalled() silently reconciles without prompting if paths are stale
+ *  - No spurious write happens when paths are already current
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fs from "fs";
+
+// We mock fs so we don't touch the real ~/.claude/settings.json
+vi.mock("fs");
+
+const OLD_PATH = "/c/Users/chris/.vscode/extensions/conductor-0.1.0";
+const NEW_PATH = "/c/Users/chris/.vscode/extensions/conductor-0.2.0";
+
+const OLD_SCRIPT_BASE_WIN = `/c/PROGRA~1/nodejs/node.exe ${OLD_PATH}/hooks/session-state.js`;
+const NEW_SCRIPT_BASE_WIN = `/c/PROGRA~1/nodejs/node.exe ${NEW_PATH}/hooks/session-state.js`;
+
+const OLD_SCRIPT_BASE_POSIX = `node ${OLD_PATH}/hooks/session-state.js`;
+const NEW_SCRIPT_BASE_POSIX = `node ${NEW_PATH}/hooks/session-state.js`;
+
+function makeSettingsWithHooks(scriptBase: string): Record<string, unknown> {
+  return {
+    hooks: {
+      Notification: [
+        {
+          matcher: "idle_prompt",
+          hooks: [{ type: "command", command: `${scriptBase} idle` }],
+        },
+      ],
+      UserPromptSubmit: [
+        {
+          hooks: [{ type: "command", command: `${scriptBase} active` }],
+        },
+      ],
+      Stop: [
+        {
+          hooks: [{ type: "command", command: `${scriptBase} stop` }],
+        },
+      ],
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Import helpers under test AFTER setting up the vi.mock above
+// ---------------------------------------------------------------------------
+import { hooksUpToDate, reconcileHookPaths } from "../src/hookInstaller.js";
+
+describe("hooksUpToDate", () => {
+  it("returns true when all hook commands match the expected script base", () => {
+    const settings = makeSettingsWithHooks(NEW_SCRIPT_BASE_WIN);
+    expect(hooksUpToDate(settings, NEW_SCRIPT_BASE_WIN)).toBe(true);
+  });
+
+  it("returns false when hook commands contain the marker but point at a different path", () => {
+    const settings = makeSettingsWithHooks(OLD_SCRIPT_BASE_WIN);
+    expect(hooksUpToDate(settings, NEW_SCRIPT_BASE_WIN)).toBe(false);
+  });
+
+  it("returns true for POSIX paths when they match", () => {
+    const settings = makeSettingsWithHooks(NEW_SCRIPT_BASE_POSIX);
+    expect(hooksUpToDate(settings, NEW_SCRIPT_BASE_POSIX)).toBe(true);
+  });
+
+  it("returns false for POSIX paths when stale", () => {
+    const settings = makeSettingsWithHooks(OLD_SCRIPT_BASE_POSIX);
+    expect(hooksUpToDate(settings, NEW_SCRIPT_BASE_POSIX)).toBe(false);
+  });
+
+  it("returns true when no hooks are installed at all (nothing to be stale)", () => {
+    expect(hooksUpToDate({}, NEW_SCRIPT_BASE_WIN)).toBe(true);
+  });
+});
+
+describe("reconcileHookPaths", () => {
+  it("rewrites stale Windows-style paths to the new script base", () => {
+    const settings = makeSettingsWithHooks(OLD_SCRIPT_BASE_WIN);
+    reconcileHookPaths(settings, NEW_SCRIPT_BASE_WIN);
+
+    const hooks = settings.hooks as Record<string, unknown[]>;
+    const notifCmd = (
+      (hooks.Notification[0] as Record<string, unknown[]>).hooks[0] as Record<
+        string,
+        string
+      >
+    ).command;
+    expect(notifCmd).toBe(`${NEW_SCRIPT_BASE_WIN} idle`);
+
+    const submitCmd = (
+      (hooks.UserPromptSubmit[0] as Record<string, unknown[]>).hooks[0] as Record<
+        string,
+        string
+      >
+    ).command;
+    expect(submitCmd).toBe(`${NEW_SCRIPT_BASE_WIN} active`);
+
+    const stopCmd = (
+      (hooks.Stop[0] as Record<string, unknown[]>).hooks[0] as Record<
+        string,
+        string
+      >
+    ).command;
+    expect(stopCmd).toBe(`${NEW_SCRIPT_BASE_WIN} stop`);
+  });
+
+  it("rewrites stale POSIX-style paths to the new script base", () => {
+    const settings = makeSettingsWithHooks(OLD_SCRIPT_BASE_POSIX);
+    reconcileHookPaths(settings, NEW_SCRIPT_BASE_POSIX);
+
+    const hooks = settings.hooks as Record<string, unknown[]>;
+    const notifCmd = (
+      (hooks.Notification[0] as Record<string, unknown[]>).hooks[0] as Record<
+        string,
+        string
+      >
+    ).command;
+    expect(notifCmd).toBe(`${NEW_SCRIPT_BASE_POSIX} idle`);
+  });
+
+  it("preserves the trailing action arg after rewriting", () => {
+    const settings = makeSettingsWithHooks(OLD_SCRIPT_BASE_WIN);
+    reconcileHookPaths(settings, NEW_SCRIPT_BASE_WIN);
+
+    const hooks = settings.hooks as Record<string, unknown[]>;
+    const stopCmd = (
+      (hooks.Stop[0] as Record<string, unknown[]>).hooks[0] as Record<
+        string,
+        string
+      >
+    ).command;
+    // Must end with " stop", not " idle" or " active"
+    expect(stopCmd.endsWith(" stop")).toBe(true);
+  });
+
+  it("does not modify hooks that do not contain session-state.js", () => {
+    const settings: Record<string, unknown> = {
+      hooks: {
+        Notification: [
+          {
+            hooks: [{ type: "command", command: "some-other-tool notify" }],
+          },
+        ],
+      },
+    };
+    reconcileHookPaths(settings, NEW_SCRIPT_BASE_WIN);
+    const hooks = settings.hooks as Record<string, unknown[]>;
+    const cmd = (
+      (hooks.Notification[0] as Record<string, unknown[]>).hooks[0] as Record<
+        string,
+        string
+      >
+    ).command;
+    expect(cmd).toBe("some-other-tool notify");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: ensureHooksInstalled reconciles stale paths silently
+// ---------------------------------------------------------------------------
+
+import { ensureHooksInstalled } from "../src/hookInstaller.js";
+
+// Minimal ExtensionContext stub
+function makeContext(extensionPath: string) {
+  return {
+    extensionPath,
+    globalState: {
+      get: vi.fn().mockReturnValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined),
+    },
+    subscriptions: [],
+  } as unknown as import("vscode").ExtensionContext;
+}
+
+describe("ensureHooksInstalled — path reconciliation", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("silently rewrites stale paths and returns true without prompting the user", async () => {
+    // Arrange: settings on disk have hooks pointing at OLD_PATH
+    const oldSettings = makeSettingsWithHooks(OLD_SCRIPT_BASE_WIN);
+    (fs.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+      JSON.stringify(oldSettings)
+    );
+    const writeMock = fs.writeFileSync as ReturnType<typeof vi.fn>;
+    writeMock.mockImplementation(() => {});
+
+    // VS Code would install the new version at NEW_PATH
+    // On Windows getHookScriptPath builds: /c/PROGRA~1/nodejs/node.exe /<drive><rest>
+    // We need the context to resolve to a path that produces NEW_SCRIPT_BASE_WIN.
+    // The function hard-codes the node prefix, so we set extensionPath to a value
+    // that will produce NEW_PATH after drive-letter conversion.
+    // NEW_PATH = "/c/Users/chris/.vscode/extensions/conductor-0.2.0"
+    // → Windows equivalent: C:\Users\chris\.vscode\extensions\conductor-0.2.0
+    const winExtPath = "C:\\Users\\chris\\.vscode\\extensions\\conductor-0.2.0";
+    const context = makeContext(winExtPath);
+
+    const { window } = await import("../test/mocks/vscode.js");
+    const showInfoSpy = vi.spyOn(window, "showInformationMessage");
+
+    const result = await ensureHooksInstalled(context);
+
+    expect(result).toBe(true);
+    // writeFileSync should have been called (settings were rewritten)
+    expect(writeMock).toHaveBeenCalled();
+    // showInformationMessage must NOT have been called with the consent prompt
+    const consentCallArgs = showInfoSpy.mock.calls.find((args) =>
+      String(args[0]).includes("requires adding hooks")
+    );
+    expect(consentCallArgs).toBeUndefined();
+    // But a subtle info message about the update must have been shown
+    const updateCallArgs = showInfoSpy.mock.calls.find((args) =>
+      String(args[0]).includes("updated for new extension version")
+    );
+    expect(updateCallArgs).toBeDefined();
+  });
+
+  it("does not write settings when paths are already up to date", async () => {
+    // The NEW context path is the same as what's already in the settings
+    const winExtPath = "C:\\Users\\chris\\.vscode\\extensions\\conductor-0.2.0";
+    const currentSettings = makeSettingsWithHooks(NEW_SCRIPT_BASE_WIN);
+    (fs.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(
+      JSON.stringify(currentSettings)
+    );
+    const writeMock = fs.writeFileSync as ReturnType<typeof vi.fn>;
+    writeMock.mockImplementation(() => {});
+
+    const context = makeContext(winExtPath);
+    const result = await ensureHooksInstalled(context);
+
+    expect(result).toBe(true);
+    expect(writeMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `hooksUpToDate()` and `reconcileHookPaths()` helpers in `src/hookInstaller.ts` so extension activation detects stale hook paths (embedded in `~/.claude/settings.json` from a previous install dir) and silently rewrites them to the current `extensionPath`.
- Keeps `hooksInstalled()` unchanged — it still answers the "are our hooks present at all?" question. The new helper answers "are they still pointing at the right script?"
- No re-prompt: initial install already captured consent. A subtle info message confirms the auto-update.

## Why
Every extension update moved VS Code's install directory, leaving hook commands pointing at a deleted `session-state.js`. All hooks failed silently until the user manually ran `Remove → Setup Hooks`. See #64 for the full diagnosis.

## Test plan
- [x] Regression test: settings with old paths + new `expectedScriptBase` → all three hook entries (Notification/idle, UserPromptSubmit/active, Stop/stop) rewritten
- [x] `hooksUpToDate()` covers Windows git-bash form (`/c/PROGRA~1/nodejs/node.exe /c/...`) and POSIX form (`node /path/...`)
- [x] Idempotence: no settings write when paths are already current
- [x] Full CI-equivalent suite locally: `npm run lint`, typecheck, `npm test` (29/29), `npm run compile` — all clean
- [x] README "How Idle Detection Works" updated

Closes #64

---
🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*