### PR TITLE
feat: group sidebar panels by project with worktrees as children

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ Running Claude Code against several projects at once is painful in a plain termi
 
 A dedicated "Claude Conductor" panel with two sections:
 
-- **Active Sessions** — currently running Claude terminals. Click to focus. A green terminal icon means the session is working; an orange bell means it's waiting for your input.
-- **Recent Projects** — your VS Code recently opened folders plus any configured extras. Click to launch a new session.
+- **Active Sessions** — currently running Claude terminals. Sessions are grouped by project root; click a project row to expand it and see its sessions. Click a session leaf to focus it. A green terminal icon means the session is working; an orange bell means it's waiting for your input.
+- **Recent Projects** — your VS Code recently opened folders plus any configured extras, grouped by project root. Click a project row to expand it and see its worktrees. Click a folder leaf to launch a new session.
+
+Both panels render as a **two-level tree**: project roots are collapsed by default (showing a child count), with their `.worktrees/<branch>` subdirectories nested underneath. When a worktree's parent project root is not present in Recent Projects, the group row is shown with a dimmed folder icon and a "(not in recents)" label so you can tell at a glance that the root itself isn't tracked.
 
 ### Quick-Pick Launcher
 

--- a/src/projectGrouping.ts
+++ b/src/projectGrouping.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure grouping helper — zero VS Code dependencies.
+ *
+ * Detects which items in a flat list are worktrees under a shared project root
+ * and groups them into a two-level structure that both ActiveSessionsProvider
+ * and RecentProjectsProvider can consume.
+ *
+ * Detection rule (per spec):
+ *   A path P is a worktree of root R iff:
+ *     normalise(P) === normalise(R) + sep + ".worktrees" + sep + <branch-segment>
+ *   where <branch-segment> is exactly ONE path segment (no further slashes).
+ *   Both "\" and "/" are treated as separators; comparison is case-insensitive.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ProjectGroup<T> {
+  /** The project root path (may be phantom — not present in the original input). */
+  root: string;
+  /**
+   * True when no item in the input matches `root` exactly. The root was
+   * synthesised from a worktree path.
+   */
+  isPhantom: boolean;
+  /** Worktree children (.worktrees/<branch>) under this root. */
+  children: T[];
+  /** The item whose path equals `root`, or null when isPhantom. */
+  top: T | null;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Normalise separators to "/" and lowercase for comparison only. */
+function normKey(p: string): string {
+  return p.replace(/\\/g, "/").toLowerCase();
+}
+
+/** Normalise a path string to forward slashes only (preserves case). */
+function toForwardSlashes(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+/**
+ * If `p` is a worktree path (i.e. ends with `/.worktrees/<single-segment>`),
+ * return the project root path (same casing as the input) and branch name.
+ * Returns null if `p` does not match the pattern.
+ */
+function parseWorktreePath(p: string): { root: string; branch: string } | null {
+  // Normalise to forward slashes for the regex. The original string and the
+  // normalised version have the same length (backslash ↔ forward slash are
+  // both one byte), so we can use segment counts to reconstruct the root.
+  const fwd = toForwardSlashes(p);
+  // Match exactly: <anything>/.worktrees/<single-segment-no-slash>
+  const m = fwd.match(/^(.+)\/.worktrees\/([^/]+)$/i);
+  if (!m) {
+    return null;
+  }
+  const rootFwd = m[1];
+  const branch = m[2];
+
+  // Count segments in the forward-slash root to slice the original path.
+  // Split original on both separators; take the same number of parts.
+  const rootSegmentCount = rootFwd.split("/").length;
+  const allParts = p.split(/[\\/]/);
+  const rootParts = allParts.slice(0, rootSegmentCount);
+  // Preserve the original separator style so the root looks native.
+  const sep = p.includes("\\") ? "\\" : "/";
+  const root = rootParts.join(sep);
+
+  return { root, branch };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Group a flat list of items into project root + worktree-children buckets.
+ *
+ * @param items   Flat list of items to group.
+ * @param getPath Extracts the filesystem path from an item.
+ * @returns       One ProjectGroup per unique project root, in the order the
+ *                root was first encountered (either directly or via a worktree).
+ */
+export function groupByProjectRoot<T>(
+  items: T[],
+  getPath: (item: T) => string
+): ProjectGroup<T>[] {
+  // Map from normalised root key → group (mutable during construction).
+  const groupMap = new Map<string, ProjectGroup<T>>();
+
+  // Canonical (original-case) root string per key — first root encountered wins.
+  const canonicalRoot = new Map<string, string>();
+
+  /** Get-or-create a group for `rootKey`, using `rootStr` as canonical name. */
+  const getOrCreate = (rootKey: string, rootStr: string): ProjectGroup<T> => {
+    if (!groupMap.has(rootKey)) {
+      groupMap.set(rootKey, {
+        root: rootStr,
+        isPhantom: true, // will be set false if a top item is found
+        children: [],
+        top: null,
+      });
+      canonicalRoot.set(rootKey, rootStr);
+    }
+    return groupMap.get(rootKey)!;
+  };
+
+  for (const item of items) {
+    const p = getPath(item);
+    const parsed = parseWorktreePath(p);
+
+    if (parsed !== null) {
+      // This item is a worktree — add it as a child of its root.
+      const rootKey = normKey(parsed.root);
+      const group = getOrCreate(rootKey, parsed.root);
+      group.children.push(item);
+    } else {
+      // This item is a regular path — it becomes the `top` of its own group.
+      const rootKey = normKey(p);
+      const group = getOrCreate(rootKey, p);
+      group.top = item;
+      group.isPhantom = false;
+      // Prefer the canonical spelling from the top item itself.
+      group.root = p;
+      canonicalRoot.set(rootKey, p);
+    }
+  }
+
+  return Array.from(groupMap.values());
+}

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -2,14 +2,49 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { SessionManager, ActiveSession } from "./sessionManager";
 import { getAllFolders, FolderEntry } from "./folderSource";
+import { groupByProjectRoot, ProjectGroup } from "./projectGrouping";
 
+// ---------------------------------------------------------------------------
+// Active Sessions — tree items
+// ---------------------------------------------------------------------------
+
+/**
+ * A group row in the Active Sessions panel.
+ * Collapsed by default; description shows the child count for this panel.
+ */
+class ActiveGroupItem extends vscode.TreeItem {
+  readonly group: ProjectGroup<ActiveSession>;
+
+  constructor(group: ProjectGroup<ActiveSession>) {
+    const label = path.basename(group.root);
+    super(label, vscode.TreeItemCollapsibleState.Collapsed);
+    this.group = group;
+
+    const count = group.children.length + (group.top !== null ? 1 : 0);
+    this.description = `(${count})`;
+    // Folder icon — no command so click only expands/collapses.
+    this.iconPath = new vscode.ThemeIcon("folder");
+    this.tooltip = group.root;
+  }
+}
+
+/**
+ * A leaf row for one active session, shown under its group.
+ * When the session is a worktree child, description shows the branch name
+ * (the parent context is already given by the group row).
+ */
 class ActiveSessionItem extends vscode.TreeItem {
   readonly session: ActiveSession;
 
-  constructor(session: ActiveSession) {
+  constructor(session: ActiveSession, isWorktreeChild: boolean) {
     super(session.folderName, vscode.TreeItemCollapsibleState.None);
     this.session = session;
-    this.description = path.dirname(session.folderPath);
+    // Worktree children: show the branch segment (basename of worktree path)
+    // as the description — the parent is already implied by the group row.
+    // Top-level items (non-worktree): keep the original parent directory.
+    this.description = isWorktreeChild
+      ? path.basename(session.folderPath)
+      : path.dirname(session.folderPath);
     this.tooltip = `${session.folderPath}\nStarted: ${session.startedAt.toLocaleTimeString()}`;
     this.iconPath = session.isIdle
       ? new vscode.ThemeIcon("bell", new vscode.ThemeColor("editorWarning.foreground"))
@@ -23,13 +58,102 @@ class ActiveSessionItem extends vscode.TreeItem {
   }
 }
 
+type ActiveTreeNode = ActiveGroupItem | ActiveSessionItem;
+
+export class ActiveSessionsProvider
+  implements vscode.TreeDataProvider<ActiveTreeNode>
+{
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  constructor(private readonly sessionManager: SessionManager) {
+    sessionManager.onDidChangeSessions(() => this._onDidChangeTreeData.fire());
+  }
+
+  getTreeItem(element: ActiveTreeNode): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: ActiveTreeNode): ActiveTreeNode[] {
+    if (element instanceof ActiveGroupItem) {
+      // Return the leaves for this group.
+      const { group } = element;
+      const leaves: ActiveSessionItem[] = [];
+      if (group.top !== null) {
+        // The root itself is a non-worktree item — description shows parent dir.
+        leaves.push(new ActiveSessionItem(group.top, false));
+      }
+      for (const child of group.children) {
+        // Worktree children — description shows branch name.
+        leaves.push(new ActiveSessionItem(child, true));
+      }
+      return leaves;
+    }
+
+    // Top level: return one group row per project root.
+    const sessions = this.sessionManager.activeSessions;
+    const groups = groupByProjectRoot(sessions, (s) => s.folderPath);
+    return groups.map((g) => new ActiveGroupItem(g));
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Recent Projects — tree items
+// ---------------------------------------------------------------------------
+
+/**
+ * A group row in the Recent Projects panel.
+ * Phantom groups (root not present in recents) get a dimmed icon and a
+ * "(not in recents)" suffix so they are visually distinguishable.
+ *
+ * Icon choice: "folder" with `disabledForeground` ThemeColor.
+ * This is the most recognisable "muted folder" available as a codicon + color
+ * pair that does not require an extra icon registration.
+ */
+class RecentGroupItem extends vscode.TreeItem {
+  readonly group: ProjectGroup<FolderEntry>;
+
+  constructor(group: ProjectGroup<FolderEntry>) {
+    const label = path.basename(group.root);
+    super(label, vscode.TreeItemCollapsibleState.Collapsed);
+    this.group = group;
+
+    const count = group.children.length + (group.top !== null ? 1 : 0);
+
+    if (group.isPhantom) {
+      this.description = `(${count}) (not in recents)`;
+      // Dimmed folder icon — signals that the root itself is not in Recent Projects.
+      this.iconPath = new vscode.ThemeIcon(
+        "folder",
+        new vscode.ThemeColor("disabledForeground")
+      );
+    } else {
+      this.description = `(${count})`;
+      this.iconPath = new vscode.ThemeIcon("folder");
+    }
+
+    this.tooltip = group.root;
+  }
+}
+
+/**
+ * A leaf row for one recent-project folder, shown under its group.
+ * Worktree children: description is the branch name (parent implied by group).
+ * Non-worktree top items: description is the parent directory.
+ */
 class RecentProjectItem extends vscode.TreeItem {
   readonly folderPath: string;
 
-  constructor(entry: FolderEntry) {
+  constructor(entry: FolderEntry, isWorktreeChild: boolean) {
     super(entry.name, vscode.TreeItemCollapsibleState.None);
     this.folderPath = entry.folderPath;
-    this.description = entry.parentDir;
+    this.description = isWorktreeChild
+      ? path.basename(entry.folderPath)
+      : entry.parentDir;
     this.tooltip = `${entry.folderPath} (${entry.source})`;
     this.iconPath = new vscode.ThemeIcon("folder");
     this.contextValue = "recentProject";
@@ -41,7 +165,11 @@ class RecentProjectItem extends vscode.TreeItem {
   }
 }
 
-export class ActiveSessionsProvider implements vscode.TreeDataProvider<ActiveSessionItem> {
+type RecentTreeNode = RecentGroupItem | RecentProjectItem;
+
+export class RecentProjectsProvider
+  implements vscode.TreeDataProvider<RecentTreeNode>
+{
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
@@ -49,40 +177,31 @@ export class ActiveSessionsProvider implements vscode.TreeDataProvider<ActiveSes
     sessionManager.onDidChangeSessions(() => this._onDidChangeTreeData.fire());
   }
 
-  getTreeItem(element: ActiveSessionItem): vscode.TreeItem {
+  getTreeItem(element: RecentTreeNode): vscode.TreeItem {
     return element;
   }
 
-  getChildren(): ActiveSessionItem[] {
-    return this.sessionManager.activeSessions.map((s) => new ActiveSessionItem(s));
-  }
+  async getChildren(element?: RecentTreeNode): Promise<RecentTreeNode[]> {
+    if (element instanceof RecentGroupItem) {
+      // Return the leaves for this group.
+      const { group } = element;
+      const leaves: RecentProjectItem[] = [];
+      if (group.top !== null) {
+        leaves.push(new RecentProjectItem(group.top, false));
+      }
+      for (const child of group.children) {
+        leaves.push(new RecentProjectItem(child, true));
+      }
+      return leaves;
+    }
 
-  refresh(): void {
-    this._onDidChangeTreeData.fire();
-  }
-}
-
-export class RecentProjectsProvider implements vscode.TreeDataProvider<RecentProjectItem> {
-  private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
-  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
-
-  constructor(private readonly sessionManager: SessionManager) {
-    sessionManager.onDidChangeSessions(() => this._onDidChangeTreeData.fire());
-  }
-
-  getTreeItem(element: RecentProjectItem): vscode.TreeItem {
-    return element;
-  }
-
-  async getChildren(): Promise<RecentProjectItem[]> {
+    // Top level: fetch all folders, group them, return one group row per root.
+    // Note: the dedup filter (exclude active-session paths) has been REMOVED
+    // by design — the same folder may appear in both Active Sessions and Recent
+    // Projects simultaneously.
     const folders = await getAllFolders();
-    const activeSet = new Set(
-      this.sessionManager.activeSessions.map((s) => s.folderPath.toLowerCase())
-    );
-
-    return folders
-      .filter((f) => !activeSet.has(f.folderPath.toLowerCase()))
-      .map((f) => new RecentProjectItem(f));
+    const groups = groupByProjectRoot(folders, (f) => f.folderPath);
+    return groups.map((g) => new RecentGroupItem(g));
   }
 
   refresh(): void {

--- a/test/projectGrouping.test.ts
+++ b/test/projectGrouping.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for the groupByProjectRoot helper (src/projectGrouping.ts).
+ *
+ * This module is pure — no VS Code dependencies — so tests run in plain Node
+ * without any mocks.
+ */
+
+import { describe, it, expect } from "vitest";
+import { groupByProjectRoot } from "../src/projectGrouping";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a simple item whose path is the string itself. */
+const item = (p: string) => p;
+const getPath = (p: string) => p;
+
+// ---------------------------------------------------------------------------
+// Basic grouping
+// ---------------------------------------------------------------------------
+
+describe("groupByProjectRoot — basic grouping", () => {
+  it("single project with no worktrees → one group, top set, children empty, isPhantom false", () => {
+    const items = ["/home/user/my-project"];
+    const groups = groupByProjectRoot(items, getPath);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].root).toBe("/home/user/my-project");
+    expect(groups[0].top).toBe("/home/user/my-project");
+    expect(groups[0].children).toHaveLength(0);
+    expect(groups[0].isPhantom).toBe(false);
+  });
+
+  it("single project + 2 worktrees → one group with 2 children", () => {
+    const root = "/home/user/my-project";
+    const wt1 = "/home/user/my-project/.worktrees/feature-a";
+    const wt2 = "/home/user/my-project/.worktrees/fix-b";
+    const items = [root, wt1, wt2];
+
+    const groups = groupByProjectRoot(items, getPath);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].root).toBe(root);
+    expect(groups[0].top).toBe(root);
+    expect(groups[0].isPhantom).toBe(false);
+    expect(groups[0].children).toContain(wt1);
+    expect(groups[0].children).toContain(wt2);
+    expect(groups[0].children).toHaveLength(2);
+  });
+
+  it("two projects interleaved → two groups, children correctly routed", () => {
+    const rootA = "/home/user/project-a";
+    const wtA1 = "/home/user/project-a/.worktrees/branch-1";
+    const rootB = "/home/user/project-b";
+    const wtB1 = "/home/user/project-b/.worktrees/branch-x";
+    const items = [rootA, rootB, wtA1, wtB1];
+
+    const groups = groupByProjectRoot(items, getPath);
+
+    expect(groups).toHaveLength(2);
+
+    const groupA = groups.find((g) => g.root === rootA);
+    const groupB = groups.find((g) => g.root === rootB);
+
+    expect(groupA).toBeDefined();
+    expect(groupA!.children).toContain(wtA1);
+    expect(groupA!.children).not.toContain(wtB1);
+
+    expect(groupB).toBeDefined();
+    expect(groupB!.children).toContain(wtB1);
+    expect(groupB!.children).not.toContain(wtA1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phantom parents
+// ---------------------------------------------------------------------------
+
+describe("groupByProjectRoot — phantom parents", () => {
+  it("only a worktree in input → one group, top null, isPhantom true, root derived correctly", () => {
+    const wt = "/home/user/my-project/.worktrees/feature-a";
+    const groups = groupByProjectRoot([wt], getPath);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].root).toBe("/home/user/my-project");
+    expect(groups[0].top).toBeNull();
+    expect(groups[0].isPhantom).toBe(true);
+    expect(groups[0].children).toContain(wt);
+    expect(groups[0].children).toHaveLength(1);
+  });
+
+  it("top-level item that has no worktree relation → own group, isPhantom false, top set, children empty", () => {
+    const plain = "/home/user/some-folder";
+    const groups = groupByProjectRoot([plain], getPath);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].root).toBe(plain);
+    expect(groups[0].top).toBe(plain);
+    expect(groups[0].isPhantom).toBe(false);
+    expect(groups[0].children).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Windows path handling
+// ---------------------------------------------------------------------------
+
+describe("groupByProjectRoot — Windows paths", () => {
+  it("Windows paths with backslash separators produce the same grouping as forward slashes", () => {
+    const root = "C:\\Users\\chris\\my-project";
+    const wt = "C:\\Users\\chris\\my-project\\.worktrees\\feature-branch";
+    const items = [root, wt];
+
+    const groups = groupByProjectRoot(items, getPath);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].top).toBe(root);
+    expect(groups[0].children).toContain(wt);
+    expect(groups[0].isPhantom).toBe(false);
+  });
+
+  it("case-insensitive matching on Windows-style paths: worktree groups under its parent regardless of case", () => {
+    const root = "C:\\Repo";
+    const wt = "c:\\repo\\.worktrees\\x";
+    const items = [root, wt];
+
+    const groups = groupByProjectRoot(items, getPath);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].children).toContain(wt);
+    expect(groups[0].top).toBe(root);
+  });
+
+  it("phantom parent derived correctly from Windows backslash path", () => {
+    const wt = "C:\\Users\\chris\\my-project\\.worktrees\\feature-branch";
+    const groups = groupByProjectRoot([wt], getPath);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].root.toLowerCase()).toBe("c:\\users\\chris\\my-project");
+    expect(groups[0].isPhantom).toBe(true);
+    expect(groups[0].top).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Not-a-worktree edge cases
+// ---------------------------------------------------------------------------
+
+describe("groupByProjectRoot — not-a-worktree edge cases", () => {
+  it("path with .worktrees two levels deep does NOT count as a child (out of spec)", () => {
+    const root = "/home/user/my-project";
+    const deepNested = "/home/user/my-project/.worktrees/a/b";
+    const items = [root, deepNested];
+
+    const groups = groupByProjectRoot(items, getPath);
+
+    // The deep-nested path is NOT a direct worktree child of root,
+    // so it should form its own group (or be ungrouped as a standalone item).
+    const rootGroup = groups.find((g) => g.root === root);
+    expect(rootGroup!.children).not.toContain(deepNested);
+  });
+
+  it("folder literally named '.worktrees' at project root is not treated as a worktree", () => {
+    // A path like /home/user/my-project/.worktrees (no branch segment after)
+    // has nothing after .worktrees so it cannot be a worktree.
+    const root = "/home/user/my-project";
+    const worktreesDir = "/home/user/my-project/.worktrees";
+    const items = [root, worktreesDir];
+
+    const groups = groupByProjectRoot(items, getPath);
+
+    const rootGroup = groups.find((g) => g.root === root);
+    // The .worktrees dir itself should NOT be counted as a child worktree
+    expect(rootGroup!.children).not.toContain(worktreesDir);
+  });
+});

--- a/test/treeView.test.ts
+++ b/test/treeView.test.ts
@@ -134,7 +134,7 @@ describe("ActiveSessionsProvider — grouped tree", () => {
     const [group] = provider.getChildren(undefined);
     const children = provider.getChildren(group);
 
-    const wtChild = children.find((c) => c.label === "feature-a" || (c.description ?? "").includes("feature-a"));
+    const wtChild = children.find((c) => c.label === "feature-a" || String(c.description ?? "").includes("feature-a"));
     // The worktree leaf should reference the branch name somehow (label or description)
     const wtSession = sessions.find((s) => s.folderPath === wt1)!;
     const wtLeaf = children.find(

--- a/test/treeView.test.ts
+++ b/test/treeView.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for the grouped tree-view providers (src/treeView.ts).
+ *
+ * These tests exercise:
+ *  - ActiveSessionsProvider: getChildren(undefined) returns group items;
+ *    getChildren(group) returns leaf sessions.
+ *  - RecentProjectsProvider: same two-level pattern.
+ *  - Child-count in description for both phantom and non-phantom roots.
+ *  - Phantom root: dimmed icon + "(not in recents)" suffix.
+ *  - Dedup filter removed: active-session folders still appear in Recent Projects.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ActiveSession } from "../src/sessionManager";
+import type { FolderEntry } from "../src/folderSource";
+
+// ---------------------------------------------------------------------------
+// Minimal stubs — keep them local so this test file is self-contained.
+// ---------------------------------------------------------------------------
+
+function makeSession(folderPath: string): ActiveSession {
+  return {
+    terminal: {
+      name: `claude · ${folderPath.split(/[\\/]/).pop()}`,
+      show: vi.fn(),
+      sendText: vi.fn(),
+      dispose: vi.fn(),
+      processId: Promise.resolve(undefined),
+      shellIntegration: undefined,
+      creationOptions: { cwd: folderPath },
+    } as unknown as import("vscode").Terminal,
+    folderPath,
+    folderName: folderPath.split(/[\\/]/).pop() ?? "",
+    startedAt: new Date(),
+    isIdle: false,
+  };
+}
+
+function makeFolder(folderPath: string): FolderEntry {
+  const parts = folderPath.split(/[\\/]/);
+  return {
+    folderPath,
+    name: parts[parts.length - 1] ?? "",
+    parentDir: parts.slice(0, -1).join("/"),
+    source: "recent" as const,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Minimal SessionManager stub
+// ---------------------------------------------------------------------------
+
+function makeSessionManager(sessions: ActiveSession[]) {
+  const listeners: Array<() => void> = [];
+  return {
+    get activeSessions() { return sessions; },
+    onDidChangeSessions: (cb: () => void) => {
+      listeners.push(cb);
+      return { dispose: () => {} };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Import providers under test (after vi.mock declarations)
+// ---------------------------------------------------------------------------
+
+// We need getAllFolders to be mockable. Do this before the import.
+vi.mock("../src/folderSource", () => ({
+  getAllFolders: vi.fn(),
+}));
+
+import { ActiveSessionsProvider, RecentProjectsProvider } from "../src/treeView";
+import { getAllFolders } from "../src/folderSource";
+import {
+  TreeItemCollapsibleState,
+  ThemeIcon,
+  ThemeColor,
+} from "./mocks/vscode";
+
+// ---------------------------------------------------------------------------
+// ActiveSessionsProvider
+// ---------------------------------------------------------------------------
+
+describe("ActiveSessionsProvider — grouped tree", () => {
+  const root = "/home/user/my-project";
+  const wt1 = "/home/user/my-project/.worktrees/feature-a";
+  const wt2 = "/home/user/my-project/.worktrees/fix-b";
+
+  it("getChildren(undefined) returns group-level items (not flat sessions)", () => {
+    const sessions = [makeSession(root), makeSession(wt1), makeSession(wt2)];
+    const mgr = makeSessionManager(sessions);
+    const provider = new ActiveSessionsProvider(mgr as never);
+
+    const topLevel = provider.getChildren(undefined);
+
+    // Should return 1 group item, not 3 flat items
+    expect(topLevel).toHaveLength(1);
+    // Group item must be collapsible (Collapsed by default)
+    expect(topLevel[0].collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
+  });
+
+  it("getChildren(groupItem) returns the group's session leaf items", () => {
+    const sessions = [makeSession(root), makeSession(wt1), makeSession(wt2)];
+    const mgr = makeSessionManager(sessions);
+    const provider = new ActiveSessionsProvider(mgr as never);
+
+    const topLevel = provider.getChildren(undefined);
+    const children = provider.getChildren(topLevel[0]);
+
+    // 3 sessions under one root → group has 3 children
+    expect(children).toHaveLength(3);
+    // Each child should be a leaf (None collapsible state)
+    for (const child of children) {
+      expect(child.collapsibleState).toBe(TreeItemCollapsibleState.None);
+    }
+  });
+
+  it("child count N appears in the group row description", () => {
+    const sessions = [makeSession(root), makeSession(wt1)];
+    const mgr = makeSessionManager(sessions);
+    const provider = new ActiveSessionsProvider(mgr as never);
+
+    const topLevel = provider.getChildren(undefined);
+
+    expect(topLevel[0].description).toContain("2");
+  });
+
+  it("worktree leaf description shows branch name, not parent directory", () => {
+    const sessions = [makeSession(root), makeSession(wt1)];
+    const mgr = makeSessionManager(sessions);
+    const provider = new ActiveSessionsProvider(mgr as never);
+
+    const [group] = provider.getChildren(undefined);
+    const children = provider.getChildren(group);
+
+    const wtChild = children.find((c) => c.label === "feature-a" || (c.description ?? "").includes("feature-a"));
+    // The worktree leaf should reference the branch name somehow (label or description)
+    const wtSession = sessions.find((s) => s.folderPath === wt1)!;
+    const wtLeaf = children.find(
+      (c) => c.label === "feature-a" || c.label === wtSession.folderName
+    );
+    expect(wtLeaf).toBeDefined();
+    // Its description should be the branch name, NOT the full parent path
+    expect(wtLeaf!.description).not.toContain("/home/user/my-project/.worktrees");
+  });
+
+  it("two different project roots → two group items at top level", () => {
+    const rootB = "/home/user/project-b";
+    const sessions = [makeSession(root), makeSession(rootB)];
+    const mgr = makeSessionManager(sessions);
+    const provider = new ActiveSessionsProvider(mgr as never);
+
+    const topLevel = provider.getChildren(undefined);
+    expect(topLevel).toHaveLength(2);
+  });
+
+  it("single session with no worktrees still returns a group with 1 child", () => {
+    const sessions = [makeSession(root)];
+    const mgr = makeSessionManager(sessions);
+    const provider = new ActiveSessionsProvider(mgr as never);
+
+    const topLevel = provider.getChildren(undefined);
+    expect(topLevel).toHaveLength(1);
+    expect(topLevel[0].collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
+
+    const children = provider.getChildren(topLevel[0]);
+    expect(children).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RecentProjectsProvider
+// ---------------------------------------------------------------------------
+
+describe("RecentProjectsProvider — grouped tree", () => {
+  const root = "/home/user/my-project";
+  const wt1 = "/home/user/my-project/.worktrees/feature-a";
+
+  beforeEach(() => {
+    vi.mocked(getAllFolders).mockResolvedValue([]);
+  });
+
+  it("getChildren(undefined) returns group items when folders include worktrees", async () => {
+    vi.mocked(getAllFolders).mockResolvedValue([makeFolder(root), makeFolder(wt1)]);
+    const mgr = makeSessionManager([]);
+    const provider = new RecentProjectsProvider(mgr as never);
+
+    const topLevel = await provider.getChildren(undefined);
+
+    expect(topLevel).toHaveLength(1);
+    expect(topLevel[0].collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
+  });
+
+  it("getChildren(groupItem) returns the group's folder leaf items", async () => {
+    vi.mocked(getAllFolders).mockResolvedValue([makeFolder(root), makeFolder(wt1)]);
+    const mgr = makeSessionManager([]);
+    const provider = new RecentProjectsProvider(mgr as never);
+
+    const topLevel = await provider.getChildren(undefined);
+    const children = await provider.getChildren(topLevel[0]);
+
+    expect(children).toHaveLength(2);
+    for (const child of children) {
+      expect(child.collapsibleState).toBe(TreeItemCollapsibleState.None);
+    }
+  });
+
+  it("child count appears in group description for non-phantom root", async () => {
+    vi.mocked(getAllFolders).mockResolvedValue([makeFolder(root), makeFolder(wt1)]);
+    const mgr = makeSessionManager([]);
+    const provider = new RecentProjectsProvider(mgr as never);
+
+    const topLevel = await provider.getChildren(undefined);
+
+    expect(topLevel[0].description).toContain("2");
+  });
+
+  it("phantom root has (not in recents) suffix in description", async () => {
+    // Only the worktree is in recents — the root itself is absent
+    vi.mocked(getAllFolders).mockResolvedValue([makeFolder(wt1)]);
+    const mgr = makeSessionManager([]);
+    const provider = new RecentProjectsProvider(mgr as never);
+
+    const topLevel = await provider.getChildren(undefined);
+
+    expect(topLevel).toHaveLength(1);
+    expect(topLevel[0].description).toContain("not in recents");
+  });
+
+  it("phantom root has a dimmed icon", async () => {
+    vi.mocked(getAllFolders).mockResolvedValue([makeFolder(wt1)]);
+    const mgr = makeSessionManager([]);
+    const provider = new RecentProjectsProvider(mgr as never);
+
+    const topLevel = await provider.getChildren(undefined);
+    const icon = topLevel[0].iconPath as ThemeIcon;
+
+    // Must be a ThemeIcon with a muted color token
+    expect(icon).toBeInstanceOf(ThemeIcon);
+    expect(icon.color).toBeInstanceOf(ThemeColor);
+    expect(icon.color!.id).toContain("disabled");
+  });
+
+  it("active-session folders are NOT filtered out of Recent Projects (dedup removed)", async () => {
+    // Previously the dedup filter excluded active-session paths from recents.
+    // After this change, the same path may appear in both panels.
+    vi.mocked(getAllFolders).mockResolvedValue([makeFolder(root)]);
+    const mgr = makeSessionManager([makeSession(root)]);
+    const provider = new RecentProjectsProvider(mgr as never);
+
+    const topLevel = await provider.getChildren(undefined);
+
+    // root should appear in Recent Projects even though it has an active session
+    expect(topLevel).toHaveLength(1);
+    const allItems = [...topLevel, ...(await provider.getChildren(topLevel[0]))];
+    const hasFolderPath = allItems.some(
+      (item) => (item as { folderPath?: string }).folderPath === root ||
+                item.label === "my-project"
+    );
+    expect(hasFolderPath).toBe(true);
+  });
+
+  it("two project roots → two group items at top level", async () => {
+    const rootB = "/home/user/project-b";
+    vi.mocked(getAllFolders).mockResolvedValue([makeFolder(root), makeFolder(rootB)]);
+    const mgr = makeSessionManager([]);
+    const provider = new RecentProjectsProvider(mgr as never);
+
+    const topLevel = await provider.getChildren(undefined);
+    expect(topLevel).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Both **Active Sessions** and **Recent Projects** sidebar panels now render as a two-level tree: project roots (collapsed by default) with `.worktrees/<branch>` children underneath.
- New shared helper `src/projectGrouping.ts` — pure, VS-Code-free, generic over item type — so both providers use the same detection rule. Worktree = path matches `<root>/.worktrees/<branch>` exactly one level deep.
- Project-root rows show `(N)` child count in the description (per panel — Active Sessions counts active sessions, Recent Projects counts recents).
- **Phantom parents**: when a worktree appears but its root does not, a non-launchable synthesized row is shown with a dimmed `folder` icon and description suffix `(not in recents)`.
- Removed the dedup filter that hid active-session folders from Recent Projects — same folder may now appear in both panels (intentional).

## Why
With 6+ active worktrees on this repo alone, the flat-list sidebars made it hard to tell at a glance which sessions/folders belonged to which project. Grouping restores the mental model and sets up the data shape needed for any future per-project features.

## Interaction with #46
Decision #1 (child count on group rows) delivers the visual part of what #46 contemplated — but as a simple per-panel child count, not cross-panel active-session injection. The structural question #46 was really asking (project-as-first-class-entity) is untouched by this PR. After merge, consider either closing #46 if the simple count satisfies the need, or narrowing it to the remaining architectural question.

## Test plan
- [x] `groupByProjectRoot()` unit tests: single project, multiple projects, phantom parents, top-level non-worktrees, Windows `\` separators, case-insensitive Windows match, nested `.worktrees` paths (not a direct child).
- [x] Provider tests: group rows returned at root, children returned under group, child count in description, phantom row indicators (dimmed icon + suffix), dedup removal verified.
- [x] Full CI-equivalent suite locally: `npm run lint`, typecheck, `npm test` (52/52), `npm run compile` — all clean.
- [x] README "Activity Bar Sidebar" section updated.

Closes #45

---
🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*