### PR TITLE
fix: focus existing session when "Open in New Window" targets the current window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to the Claude Conductor extension are documented here.
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Fixed
+- **Open in New Window no longer silently no-ops on the current window** — when the command is invoked on a session whose folder is already the active workspace, VS Code would receive the `vscode://` URI, route it back to the same window, and the user would perceive no change. The command now detects this case via a case-insensitive folder comparison, shows a dismissible info toast ("You're already in this project's window — focused the session instead."), and focuses the session tab instead of firing the URI. Fixes #66.
 
 ## [1.3.0] — 2026-04-23
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Powered by [Claude Code hooks](https://docs.anthropic.com/claude-code/hooks) —
 
 Each active session has an "Open in New Window" button that launches a dedicated VS Code window scoped to that project, with Claude auto-starting. Good for focused deep-work sessions when you want the rest of VS Code out of the way.
 
+If the session's folder is already the current workspace, clicking the button will show a brief notification and focus the existing session tab instead of opening a redundant window.
+
 ### Terminal Link Provider
 
 File paths in Claude's terminal output are clickable — open them directly in the editor without copy-pasting.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { StatusBar } from "./statusBar";
 import { ClaudeTerminalLinkProvider } from "./terminalLinks";
 import { StateWatcher } from "./stateWatcher";
 import { ensureHooksInstalled, setupHooksCommand, uninstallHooks } from "./hookInstaller";
+import { isSameWorkspaceFolder } from "./workspaceMatch";
 
 let sessionManager: SessionManager;
 
@@ -65,7 +66,7 @@ class SessionUriHandler implements vscode.UriHandler {
 
     // Check if this folder is already the workspace — if not, open it
     const currentFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-    if (!currentFolder || currentFolder.toLowerCase() !== folderPath.toLowerCase()) {
+    if (!isSameWorkspaceFolder(currentFolder, folderPath)) {
       // Save a flag so the extension auto-launches after VS Code reloads
       await this.globalState.update(AUTO_LAUNCH_KEY, folderPath);
       // Open folder in a new window
@@ -154,9 +155,22 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("claudeConductor.openInNewWindow", (arg?: unknown) => {
       const session = resolveSession(arg);
       const folderPath = session?.folderPath;
-      if (!folderPath) {
+      if (!folderPath || !session) {
         return;
       }
+
+      // If the target folder is already the current workspace, opening a new
+      // URI would round-trip back to this window and do nothing visible.
+      // Instead, show a dismissible info toast and focus the session tab.
+      const currentFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      if (isSameWorkspaceFolder(currentFolder, folderPath)) {
+        void vscode.window.showInformationMessage(
+          "You're already in this project's window — focused the session instead."
+        );
+        sessionManager.focusSession(session);
+        return;
+      }
+
       const encodedPath = encodeURIComponent(folderPath);
       const uri = vscode.Uri.parse(
         `vscode://cbeaulieu-gt.claude-conductor/launch?folder=${encodedPath}`

--- a/src/workspaceMatch.ts
+++ b/src/workspaceMatch.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure helper for comparing VS Code workspace folder paths.
+ *
+ * Uses case-insensitive exact matching to handle Windows drives where the same
+ * path may be reported with different casing by different VS Code APIs.
+ */
+
+/**
+ * Returns true when `currentFolder` and `targetFolder` refer to the same
+ * directory via case-insensitive exact comparison.
+ *
+ * @param currentFolder - The fsPath of the first workspace folder, or undefined
+ *                        when no workspace is open.
+ * @param targetFolder  - The folder path to compare against.
+ */
+export function isSameWorkspaceFolder(
+  currentFolder: string | undefined,
+  targetFolder: string
+): boolean {
+  if (!currentFolder) {
+    return false;
+  }
+  return currentFolder.toLowerCase() === targetFolder.toLowerCase();
+}

--- a/test/workspaceMatch.test.ts
+++ b/test/workspaceMatch.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for isSameWorkspaceFolder helper (src/workspaceMatch.ts).
+ *
+ * This helper is pure (no VS Code dependencies), so no mocks are needed.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isSameWorkspaceFolder } from "../src/workspaceMatch";
+
+describe("isSameWorkspaceFolder", () => {
+  it("returns true when paths are identical", () => {
+    expect(isSameWorkspaceFolder("/home/user/project", "/home/user/project")).toBe(true);
+  });
+
+  it("returns true for case-insensitive match (Windows paths)", () => {
+    expect(isSameWorkspaceFolder("C:\\Users\\foo\\Project", "c:\\users\\foo\\project")).toBe(true);
+  });
+
+  it("returns true when only casing differs on Unix-style paths", () => {
+    expect(isSameWorkspaceFolder("/Home/User/Project", "/home/user/project")).toBe(true);
+  });
+
+  it("returns false when paths are different", () => {
+    expect(isSameWorkspaceFolder("/home/user/project-a", "/home/user/project-b")).toBe(false);
+  });
+
+  it("returns false when currentFolder is undefined", () => {
+    expect(isSameWorkspaceFolder(undefined, "/home/user/project")).toBe(false);
+  });
+
+  it("returns false when currentFolder is an empty string", () => {
+    expect(isSameWorkspaceFolder("", "/home/user/project")).toBe(false);
+  });
+
+  it("returns false when only one has a trailing separator", () => {
+    // Exact match semantics — we do not normalise trailing slashes here
+    expect(isSameWorkspaceFolder("/home/user/project/", "/home/user/project")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a pure helper `isSameWorkspaceFolder` (new `src/workspaceMatch.ts`) that performs case-insensitive exact path comparison — the same logic previously inlined twice in `SessionUriHandler.handleUri`.
- Refactors `SessionUriHandler.handleUri` to use the helper instead of the inline comparison.
- Extends the `claudeConductor.openInNewWindow` command handler to call the helper before firing the `vscode://` URI. When the session's folder is already the current workspace, the command now shows a dismissible info toast ("You're already in this project's window — focused the session instead.") and calls `sessionManager.focusSession()` — without firing the URI.
- Adds 7 unit tests for `isSameWorkspaceFolder` covering exact match, case-insensitive match (Windows and Unix paths), undefined/empty current folder, mismatched paths, and trailing-separator edge case.

Command-level behavior tests (asserting toast + focusSession are called from the registered command) are not included because `registerCommand` in the VS Code mock returns a plain `Disposable` and does not expose a callable handle; adding that infrastructure would be a larger test-harness change. The helper unit tests cover the decision logic in full.

## Test plan

- [ ] All 59 unit tests pass (`npm test` — 7 pass/7 added in `test/workspaceMatch.test.ts`, 52 existing unchanged)
- [ ] `npm run lint` exits clean (no TypeScript errors)
- [ ] `npx tsc --noEmit -p tsconfig.test.json` exits clean
- [ ] `npm run compile` exits clean
- [ ] Manual: invoke "Open in New Window" on a session whose folder is the current workspace → info toast appears, session tab gains focus, no new window opens
- [ ] Manual: invoke "Open in New Window" on a session in a *different* folder → new VS Code window opens as before

Closes #66

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*