### PR TITLE
feat: add debug logging for session close-detection diagnostics (#68 phase A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Claude Conductor extension are documented here.
 
 ## [Unreleased]
 
+### Added
+- **`claudeConductor.debugLogging` setting** — when enabled, emits verbose structured `key=value` diagnostic lines to the "Claude Conductor" output channel for every session-lifecycle event: terminal tracking (`[track]`, `[track:pid]`), close-detection tier outcomes (`[close]`, `[close:tier1]`, `[close:tier2]`, `[close:tier3]`, `[close:tier3:no-pid]`), PID index mutations (`[pid:delete]`), and reconcile poll results (`[reconcile]`, `[reconcile:evict]`, `[reconcile:clean]`). Default off; intended for diagnosing missed editor-tab close events (refs #68 phase A).
+
 ### Fixed
 - **Open in New Window no longer silently no-ops on the current window** — when the command is invoked on a session whose folder is already the active workspace, VS Code would receive the `vscode://` URI, route it back to the same window, and the user would perceive no change. The command now detects this case via a case-insensitive folder comparison, shows a dismissible info toast ("You're already in this project's window — focused the session instead."), and focuses the session tab instead of firing the URI. Fixes #66.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ Cycles through Claude tabs only, not every terminal or editor tab.
 | `claudeConductor.reuseExistingTerminal` | `true` | Focus an existing session tab instead of opening a duplicate |
 | `claudeConductor.enableNotifications` | `true` | Show notifications when a session is waiting for input |
 | `claudeConductor.extraFolders` | `[]` | Additional folder paths to show in the launcher |
+| `claudeConductor.debugLogging` | `false` | Enable verbose diagnostic logging for session lifecycle (see Debug logging below) |
+
+### Debug logging
+
+Set `claudeConductor.debugLogging` to `true` to enable verbose diagnostic output for session lifecycle events including close-detection. All output appears in the **"Claude Conductor"** output channel (open it via **View → Output**, then select "Claude Conductor" from the dropdown).
+
+When enabled, the extension logs structured `key=value` lines for every terminal-open, terminal-close (including which of the three fallback tiers matched), reconcile poll tick, and PID index write/delete. This is useful for diagnosing missed editor-tab close events (tracked in [#68](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/68)).
+
+This setting is off by default and has no effect on normal operation. Disable it after capturing the logs you need.
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -176,6 +176,11 @@
           "default": 500,
           "minimum": 0,
           "description": "Milliseconds to wait before sending the claude command when shell integration is unavailable (VS Code < 1.93 or shell integration disabled). Increase if your shell profile is slow to initialise."
+        },
+        "claudeConductor.debugLogging": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable verbose diagnostic logging for session lifecycle (Active Sessions panel close-detection diagnostics). Default off."
         }
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,3 +29,7 @@ export function getLaunchDelayMs(): number {
   const raw = getConfig().get<number>("launchDelayMs", 500);
   return Math.max(0, raw);
 }
+
+export function getDebugLogging(): boolean {
+  return getConfig().get<boolean>("debugLogging", false);
+}

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { getDebugLogging } from "./config";
 
 const CHANNEL_NAME = "Claude Conductor";
 
@@ -16,4 +17,16 @@ export function getOutputChannel(): vscode.OutputChannel {
 export function log(message: string): void {
   const ts = new Date().toISOString();
   getOutputChannel().appendLine(`[${ts}] ${message}`);
+}
+
+/**
+ * Append a debug-prefixed line to the output channel, but only when
+ * `claudeConductor.debugLogging` is enabled. All debug output routes
+ * through the existing channel so users have one place to copy-paste from.
+ */
+export function debugLog(message: string): void {
+  if (!getDebugLogging()) {
+    return;
+  }
+  log(`[debug] ${message}`);
 }

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
 import { getClaudeCommand, getReuseTerminal, getLaunchDelayMs } from "./config";
-import { log } from "./output";
+import { log, debugLog } from "./output";
 
 /** Prefix used for all Claude session terminal names */
 export const SESSION_NAME_PREFIX = "claude · ";
@@ -201,14 +201,20 @@ export class SessionManager implements vscode.Disposable {
    */
   reconcile(): void {
     const liveTerminals = new Set(vscode.window.terminals);
+    debugLog(`[reconcile] sessions=${this._sessions.size} liveTerminals=${vscode.window.terminals.length}`);
     let changed = false;
 
     for (const [terminal, session] of this._sessions) {
       if (!liveTerminals.has(terminal)) {
+        debugLog(`[reconcile:evict] name=${JSON.stringify(terminal.name)} folderPath=${JSON.stringify(session.folderPath)}`);
         this._sessions.delete(terminal);
         this._cleanupStateFile(session.folderPath);
         changed = true;
       }
+    }
+
+    if (!changed) {
+      debugLog(`[reconcile:clean] no evictions`);
     }
 
     if (changed) {
@@ -233,12 +239,16 @@ export class SessionManager implements vscode.Disposable {
   /** Track a terminal if it's a Claude session. */
   private _trackIfClaudeSession(terminal: vscode.Terminal): void {
     if (!this._isClaudeSession(terminal)) {
+      debugLog(`[track] skip name=${JSON.stringify(terminal.name)} reason=not-claude sessions=${this._sessions.size} pids=${this._pidToTerminal.size}`);
       return;
     }
     const folderPath = this._extractFolderPath(terminal);
     if (!folderPath) {
+      debugLog(`[track] skip name=${JSON.stringify(terminal.name)} reason=no-cwd sessions=${this._sessions.size} pids=${this._pidToTerminal.size}`);
       return;
     }
+
+    debugLog(`[track] tracking name=${JSON.stringify(terminal.name)} folderPath=${JSON.stringify(folderPath)} sessions=${this._sessions.size} pids=${this._pidToTerminal.size}`);
 
     this._sessions.set(terminal, {
       terminal,
@@ -253,8 +263,15 @@ export class SessionManager implements vscode.Disposable {
     // avoid blocking the synchronous tracking path.
     // Use two-argument .then() because PromiseLike lacks .catch().
     terminal.processId.then(
-      (pid) => { if (pid !== undefined) { this._pidToTerminal.set(pid, terminal); } },
-      () => { /* PID unavailable for this terminal */ }
+      (pid) => {
+        if (pid !== undefined) {
+          this._pidToTerminal.set(pid, terminal);
+          debugLog(`[track:pid] resolved pid=${pid} name=${JSON.stringify(terminal.name)} pids=${this._pidToTerminal.size}`);
+        } else {
+          debugLog(`[track:pid] pid=undefined name=${JSON.stringify(terminal.name)} — not indexed`);
+        }
+      },
+      () => { debugLog(`[track:pid] processId rejected name=${JSON.stringify(terminal.name)}`); }
     );
 
     this._onDidChangeSessions.fire();
@@ -267,19 +284,27 @@ export class SessionManager implements vscode.Disposable {
    * 3. PID match (handles the editor-tab X case where name becomes "").
    */
   private _handleTerminalClose(terminal: vscode.Terminal): void {
+    debugLog(`[close] event name=${JSON.stringify(terminal.name)} sessionsBefore=${this._sessions.size} pids=${this._pidToTerminal.size}`);
+
     // Tier 1 — identity
     if (this._removeByKey(terminal)) {
+      debugLog(`[close:tier1] hit name=${JSON.stringify(terminal.name)}`);
       return;
     }
+    debugLog(`[close:tier1] miss name=${JSON.stringify(terminal.name)}`);
 
     // Tier 2 — name match (only when name is non-empty)
     if (terminal.name) {
       for (const [key, session] of this._sessions) {
         if (session.terminal.name === terminal.name) {
+          debugLog(`[close:tier2] hit name=${JSON.stringify(terminal.name)} matchedSession=${JSON.stringify(session.folderPath)}`);
           this._removeByKey(key);
           return;
         }
       }
+      debugLog(`[close:tier2] miss name=${JSON.stringify(terminal.name)} checkedSessions=${this._sessions.size}`);
+    } else {
+      debugLog(`[close:tier2] skip name="" (empty — cannot match by name)`);
     }
 
     // Tier 3 — PID match. processId is a Thenable; we must handle it async.
@@ -287,13 +312,20 @@ export class SessionManager implements vscode.Disposable {
     // Falls back to reconcile() on the next poll tick if this also misses.
     terminal.processId.then(
       (pid) => {
-        if (pid === undefined) { return; }
+        if (pid === undefined) {
+          debugLog(`[close:tier3:no-pid] processId=undefined name=${JSON.stringify(terminal.name)} — deferring to reconcile()`);
+          return;
+        }
         const trackedTerminal = this._pidToTerminal.get(pid);
-        if (trackedTerminal && this._sessions.has(trackedTerminal)) {
+        const sessionStillExists = trackedTerminal ? this._sessions.has(trackedTerminal) : false;
+        debugLog(`[close:tier3] pid=${pid} name=${JSON.stringify(terminal.name)} inPidIndex=${trackedTerminal !== undefined} sessionStillExists=${sessionStillExists}`);
+        if (trackedTerminal && sessionStillExists) {
           this._removeByKey(trackedTerminal);
         }
       },
-      () => { /* PID unavailable — reconcile() will catch it */ }
+      () => {
+        debugLog(`[close:tier3:no-pid] processId rejected name=${JSON.stringify(terminal.name)} — deferring to reconcile()`);
+      }
     );
   }
 
@@ -304,13 +336,20 @@ export class SessionManager implements vscode.Disposable {
   private _removeByKey(terminal: vscode.Terminal): boolean {
     const session = this._sessions.get(terminal);
     if (!session) {
+      debugLog(`[remove] miss name=${JSON.stringify(terminal.name)} — key already gone (possible double-fire)`);
       return false;
     }
     this._sessions.delete(terminal);
+    debugLog(`[remove] success folderPath=${JSON.stringify(session.folderPath)} sessionsAfter=${this._sessions.size}`);
 
     // Remove from PID index (two-argument .then() because PromiseLike lacks .catch())
     terminal.processId.then(
-      (pid) => { if (pid !== undefined) { this._pidToTerminal.delete(pid); } },
+      (pid) => {
+        if (pid !== undefined) {
+          this._pidToTerminal.delete(pid);
+          debugLog(`[pid:delete] pid=${pid} pidsAfter=${this._pidToTerminal.size}`);
+        }
+      },
       () => { /* ignore */ }
     );
 

--- a/test/debugLog.test.ts
+++ b/test/debugLog.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Tests for debugLog() in src/output.ts.
+ *
+ * Strategy: call getOutputChannel() once to force channel creation, then spy
+ * on the channel's appendLine. Control getDebugLogging() by spying on
+ * workspace.getConfiguration. Between tests, restore spies and clear call
+ * history on appendLine.
+ *
+ * We cannot use vi.resetModules() here because the vscode alias would resolve
+ * to a fresh copy of the mock — distinct from the vscodeMock object we hold
+ * references to — so spies set on vscodeMock would not affect the freshly-
+ * imported output.ts's vscode reference.
+ */
+
+import * as vscodeMock from "./mocks/vscode";
+import { log, debugLog, getOutputChannel } from "../src/output";
+
+// Force channel creation so createOutputChannel.mock.results[0] is populated.
+getOutputChannel();
+
+const channel = (vscodeMock.window.createOutputChannel as ReturnType<typeof vi.fn>).mock.results[0]
+  ?.value as { appendLine: ReturnType<typeof vi.fn>; dispose: ReturnType<typeof vi.fn> };
+
+describe("debugLog", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    channel.appendLine.mockClear();
+  });
+
+  it("does NOT write to the output channel when claudeConductor.debugLogging is false", () => {
+    vi.spyOn(vscodeMock.workspace, "getConfiguration").mockReturnValue({
+      get: <T>(section: string, defaultValue: T): T => {
+        if (section === "debugLogging") return false as unknown as T;
+        return defaultValue;
+      },
+      update: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import("vscode").WorkspaceConfiguration);
+
+    debugLog("should not appear");
+
+    expect(channel.appendLine).not.toHaveBeenCalled();
+  });
+
+  it("writes a [debug]-prefixed message to the output channel when claudeConductor.debugLogging is true", () => {
+    vi.spyOn(vscodeMock.workspace, "getConfiguration").mockReturnValue({
+      get: <T>(section: string, defaultValue: T): T => {
+        if (section === "debugLogging") return true as unknown as T;
+        return defaultValue;
+      },
+      update: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import("vscode").WorkspaceConfiguration);
+
+    debugLog("test message");
+
+    expect(channel.appendLine).toHaveBeenCalledOnce();
+    const written: string = channel.appendLine.mock.calls[0][0];
+    expect(written).toContain("[debug]");
+    expect(written).toContain("test message");
+  });
+
+  it("log() always writes regardless of debugLogging setting", () => {
+    vi.spyOn(vscodeMock.workspace, "getConfiguration").mockReturnValue({
+      get: <T>(section: string, defaultValue: T): T => {
+        if (section === "debugLogging") return false as unknown as T;
+        return defaultValue;
+      },
+      update: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import("vscode").WorkspaceConfiguration);
+
+    log("always visible");
+
+    expect(channel.appendLine).toHaveBeenCalledOnce();
+    expect(channel.appendLine.mock.calls[0][0]).toContain("always visible");
+    expect(channel.appendLine.mock.calls[0][0]).not.toContain("[debug]");
+  });
+});

--- a/test/sessionManager.debugLog.test.ts
+++ b/test/sessionManager.debugLog.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as vscodeMock from "./mocks/vscode";
+import { getOutputChannel } from "../src/output";
+import { SessionManager } from "../src/sessionManager";
+
+// Ensure the output channel singleton is created so we can spy on it.
+getOutputChannel();
+
+const channel = (vscodeMock.window.createOutputChannel as ReturnType<typeof vi.fn>).mock.results[0]
+  ?.value as { appendLine: ReturnType<typeof vi.fn>; dispose: ReturnType<typeof vi.fn> };
+
+/**
+ * Verify that _handleTerminalClose emits at least one [close: log line when
+ * debugLogging is enabled. This is a wiring test — it asserts the
+ * instrumentation is plumbed in, not that every tier outcome is logged
+ * (those are covered by close-tier behaviour tests).
+ */
+describe("SessionManager close-detection debug logging", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    channel.appendLine.mockClear();
+
+    // Enable debug logging
+    vi.spyOn(vscodeMock.workspace, "getConfiguration").mockReturnValue({
+      get: <T>(section: string, defaultValue: T): T => {
+        if (section === "debugLogging") return true as unknown as T;
+        return defaultValue;
+      },
+      update: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import("vscode").WorkspaceConfiguration);
+  });
+
+  it("emits at least one [close: log line when a terminal-close event fires", () => {
+    // Build a mock terminal that looks like a tracked Claude session
+    const mockTerminal = {
+      name: "claude · test-repo",
+      show: vi.fn(),
+      sendText: vi.fn(),
+      dispose: vi.fn(),
+      processId: Promise.resolve(42),
+      shellIntegration: undefined,
+      creationOptions: { cwd: "/tmp/test-repo" },
+    } as unknown as import("vscode").Terminal;
+
+    // Capture the onDidCloseTerminal callback so we can invoke it directly
+    let closeCallback: ((t: import("vscode").Terminal) => void) | undefined;
+    vi.spyOn(vscodeMock.window, "onDidCloseTerminal").mockImplementation(
+      (cb: (t: import("vscode").Terminal) => void) => {
+        closeCallback = cb;
+        return new vscodeMock.Disposable(() => {});
+      }
+    );
+
+    // Also intercept onDidOpenTerminal (needed for SessionManager constructor)
+    vi.spyOn(vscodeMock.window, "onDidOpenTerminal").mockReturnValue(
+      new vscodeMock.Disposable(() => {})
+    );
+
+    const manager = new SessionManager();
+
+    // Manually insert the session so _handleTerminalClose has something to match
+    // We do this by triggering onDidOpenTerminal with a claude-prefixed terminal.
+    // But onDidOpenTerminal is now mocked to a no-op. Instead we call the
+    // captured close callback directly on a terminal that was NOT tracked —
+    // that exercises all three tiers (all miss) and still emits [close: lines.
+    expect(closeCallback).toBeDefined();
+    closeCallback!(mockTerminal);
+
+    // At least one [close: line should have been written
+    const calls = channel.appendLine.mock.calls.map((c) => c[0] as string);
+    const hasCloseLine = calls.some((line) => line.includes("[close:") || line.includes("[close]"));
+    expect(hasCloseLine).toBe(true);
+
+    manager.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `claudeConductor.debugLogging` boolean setting (default `false`) to `package.json` contributes and `src/config.ts`
- Adds `debugLog()` helper in `src/output.ts` — gates on `getDebugLogging()`, prefixes every line with `[debug]`, routes through the existing output channel (no second channel)
- Instruments `src/sessionManager.ts` with structured `key=value` log lines at every session-lifecycle decision point — tracking, close-detection tier outcomes (all three tiers), PID index writes/deletes, and reconcile poll ticks. **Zero logic changes** — instrumentation only
- 4 new tests: 3 in `test/debugLog.test.ts` (gate behaviour) + 1 wiring test in `test/sessionManager.debugLog.test.ts`

## Log prefix reference

| Prefix | Where emitted |
|---|---|
| `[track]` / `[track:pid]` | `_trackIfClaudeSession` — on track or skip, and when PID resolves |
| `[close]` | `_handleTerminalClose` — entry with `sessionsBefore` count |
| `[close:tier1]` / `[close:tier2]` / `[close:tier3]` | Per-tier hit or miss detail |
| `[close:tier3:no-pid]` | PID resolved to `undefined` or `processId` rejected |
| `[remove]` | `_removeByKey` — success with `sessionsAfter`, or double-fire miss |
| `[pid:delete]` | PID removed from index with `pidsAfter` count |
| `[reconcile]` | Reconcile entry with session and live-terminal counts |
| `[reconcile:evict]` | Each terminal evicted by reconcile |
| `[reconcile:clean]` | Reconcile tick with no evictions |

## Testing instructions for the user

To capture logs for #68 diagnosis:

1. Open VS Code Settings and set `claudeConductor.debugLogging` to `true`
2. Launch a Claude Conductor session normally (or let an existing one run)
3. Leave it running for several hours
4. When the bug occurs (session still shown in Active Sessions panel after closing the editor tab via X), immediately open **View → Output** and select **"Claude Conductor"** from the dropdown
5. Copy the full contents of the output channel and paste them into a comment on #68
6. In particular, look for `[close:` lines near the time the X was clicked — or their absence, which would indicate the `onDidCloseTerminal` event was never fired

Key diagnostic questions the logs answer:
- Did any `[close:` line fire at all? (If not: VS Code never fired `onDidCloseTerminal`)
- If `[close:tier1]` / `[close:tier2]` / `[close:tier3]` all show `miss`: reconcile should catch it on the next poll tick — look for `[reconcile:evict]`
- Compare `[track:pid]` name/pid pairs with `[close:tier3]` pid values to verify the PID index was populated correctly before the close fired

Refs #68

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*