### PR TITLE
fix: refuse to launch sessions when cwd no longer exists (#71)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-conductor",
-  "version": "1.1.5",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-conductor",
-      "version": "1.1.5",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -16,7 +16,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "vscode": "^1.85.0"
+        "vscode": "^1.93.0"
       }
     },
     "node_modules/@azure/abort-controller": {

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -76,6 +76,15 @@ export class SessionManager implements vscode.Disposable {
   async launchSession(folderPath: string): Promise<void> {
     const normalized = path.normalize(folderPath);
 
+    // Guard: refuse to create a terminal for a cwd that no longer exists on
+    // disk.  This prevents VS Code from emitting "Starting directory does not
+    // exist" errors when a stale _sessions entry (whose directory has since
+    // been deleted or moved) is somehow passed here.
+    if (!fs.existsSync(normalized)) {
+      log(`[launch] skipping — cwd does not exist: ${normalized}`);
+      return;
+    }
+
     if (getReuseTerminal()) {
       const existing = this._findSessionByFolder(normalized);
       if (existing) {

--- a/test/addFolderPrompt.stale.test.ts
+++ b/test/addFolderPrompt.stale.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Regression tests for issue #71: stale-cwd guard in SessionManager.launchSession.
+ *
+ * Precondition:  A Claude session for PATH_A (old location) is tracked in
+ *                SessionManager._sessions but PATH_A's directory no longer
+ *                exists on disk.
+ *
+ * Symptom:       VS Code surfaced "Starting directory (cwd) <PATH_A> does not
+ *                exist" because launchSession had no existence check before
+ *                calling createTerminal.
+ *
+ * Fix contracts tested here:
+ *  1. addFolderPrompt (no manager arg, reverted to main signature) with a stale
+ *     terminal in vscode.window.terminals — createTerminal is NEVER called as a
+ *     side-effect of Add Folder. The only side-effects are config.update and the
+ *     info-message toast.
+ *  2. launchSession invoked directly with a deleted cwd — early-returns without
+ *     calling createTerminal.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+
+// Mock the entire `fs` module so we can control existsSync / statSync / readdirSync
+// without touching the real filesystem. Same pattern used in hookInstaller.test.ts.
+vi.mock("fs");
+
+import * as vscodeMock from "./mocks/vscode";
+import { SessionManager } from "../src/sessionManager";
+import { addFolderPrompt } from "../src/quickPick";
+
+const PATH_A = "I:\\Web Development\\career-ops"; // old, deleted path
+const PATH_B = "D:\\projects\\new-location";       // new, valid path
+
+describe("addFolderPrompt — stale _sessions entry (issue #71)", () => {
+  // Shared config mock — reused across all getConfiguration() calls per test
+  // so that assertions on `update` see the same mock fn that addFolderPrompt called.
+  let configUpdateMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    configUpdateMock = vi.fn().mockResolvedValue(undefined);
+
+    // Reset the mock terminal list each test
+    (vscodeMock.window as Record<string, unknown>).terminals = [];
+
+    // fs.existsSync: PATH_A does NOT exist on disk; everything else does.
+    vi.mocked(fs.existsSync).mockImplementation((p) => {
+      const s = String(p);
+      if (s.toLowerCase().includes("career-ops") || s.toLowerCase().includes("web development")) {
+        return false;
+      }
+      return true;
+    });
+
+    // fs.statSync: PATH_B is a valid directory; PATH_A throws ENOENT.
+    vi.mocked(fs.statSync).mockImplementation((p) => {
+      const s = String(p);
+      if (s.toLowerCase().includes("career-ops") || s.toLowerCase().includes("web development")) {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      }
+      return { isDirectory: () => true } as fs.Stats;
+    });
+
+    // fs.readdirSync: empty state directory (no session-state files to process)
+    vi.mocked(fs.readdirSync).mockReturnValue([]);
+
+    // workspace.getConfiguration: returns the same config object every time so
+    // that assertions on `configUpdateMock` observe the calls made inside addFolderPrompt.
+    vi.spyOn(vscodeMock.workspace, "getConfiguration").mockReturnValue({
+      get: <T>(key: string, defaultValue: T): T => {
+        if (key === "extraFolders") return [] as unknown as T;
+        if (key === "reuseExistingTerminal") return true as unknown as T;
+        if (key === "claudeCommand") return "claude" as unknown as T;
+        if (key === "launchDelayMs") return 0 as unknown as T;
+        if (key === "debugLogging") return false as unknown as T;
+        return defaultValue;
+      },
+      update: configUpdateMock,
+    } as unknown as import("vscode").WorkspaceConfiguration);
+
+    // showInputBox: simulate user entering PATH_B (with validateInput bypass for the
+    // test — validateInput calls statSync which is mocked to succeed for PATH_B)
+    vi.spyOn(vscodeMock.window, "showInputBox").mockImplementation(
+      async (opts?: import("vscode").InputBoxOptions) => {
+        // Exercise validateInput so the fs mock is verified to work correctly
+        if (opts?.validateInput) {
+          const result = opts.validateInput(PATH_B);
+          if (result != null) {
+            throw new Error(`validateInput unexpectedly rejected PATH_B: ${String(result)}`);
+          }
+        }
+        return PATH_B;
+      }
+    );
+
+    // showInformationMessage: no-op (swallow the "Added: …" toast)
+    vi.spyOn(vscodeMock.window, "showInformationMessage").mockResolvedValue(undefined);
+
+    // onDidOpenTerminal / onDidCloseTerminal: capture callbacks so SessionManager
+    // constructs without errors.  We do not fire them in this test.
+    vi.spyOn(vscodeMock.window, "onDidOpenTerminal").mockReturnValue(
+      new vscodeMock.Disposable(() => {})
+    );
+    vi.spyOn(vscodeMock.window, "onDidCloseTerminal").mockReturnValue(
+      new vscodeMock.Disposable(() => {})
+    );
+    vi.spyOn(vscodeMock.window, "onDidChangeTerminalShellIntegration").mockReturnValue(
+      new vscodeMock.Disposable(() => {})
+    );
+    vi.spyOn(vscodeMock.commands, "executeCommand").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not call createTerminal during addFolderPrompt — only persists config and shows toast", async () => {
+    // -------------------------------------------------------------------------
+    // ARRANGE: inject a stale terminal for PATH_A into vscode.window.terminals.
+    //
+    // This replicates the real repro: a Claude terminal was created for PATH_A
+    // before the folder was deleted.  The terminal proxy is still alive in VS
+    // Code's list even though the cwd is gone.
+    // -------------------------------------------------------------------------
+    const staleTerminal = {
+      name: "claude · career-ops",
+      show: vi.fn(),
+      sendText: vi.fn(),
+      dispose: vi.fn(),
+      processId: Promise.resolve(42),
+      shellIntegration: undefined,
+      creationOptions: { cwd: PATH_A },
+    } as unknown as import("vscode").Terminal;
+
+    (vscodeMock.window as Record<string, unknown>).terminals = [staleTerminal];
+
+    // Clear any prior createTerminal invocations before the act step
+    vi.mocked(vscodeMock.window.createTerminal).mockClear();
+
+    // -------------------------------------------------------------------------
+    // ACT: user runs "Add Folder" for PATH_B.
+    // addFolderPrompt takes no argument (reverted to main signature).
+    // -------------------------------------------------------------------------
+    await addFolderPrompt();
+
+    // -------------------------------------------------------------------------
+    // ASSERT 1: createTerminal was NEVER called.
+    //
+    // addFolderPrompt's only job is to persist the folder and show a toast.
+    // Launching a session is a separate action. If createTerminal fires here
+    // that means the add-and-launch over-reach crept back in.
+    // -------------------------------------------------------------------------
+    expect(
+      vi.mocked(vscodeMock.window.createTerminal),
+      "createTerminal must not be called — Add Folder should only persist config, not launch a session"
+    ).not.toHaveBeenCalled();
+
+    // -------------------------------------------------------------------------
+    // ASSERT 2: config.update was called with PATH_B in the extraFolders list.
+    //
+    // This is the one real side-effect the function SHOULD produce.
+    // configUpdateMock is the same fn reference injected via the getConfiguration
+    // spy, so it captures the call that addFolderPrompt made.
+    // -------------------------------------------------------------------------
+    expect(configUpdateMock).toHaveBeenCalledWith(
+      "extraFolders",
+      expect.arrayContaining([PATH_B]),
+      expect.anything()
+    );
+  });
+
+  it("launchSession with a deleted cwd early-returns without calling createTerminal", async () => {
+    // -------------------------------------------------------------------------
+    // ARRANGE: construct a fresh SessionManager with no terminals.
+    // PATH_A is mocked as non-existent on disk via fs.existsSync above.
+    // -------------------------------------------------------------------------
+    const manager = new SessionManager();
+
+    vi.mocked(vscodeMock.window.createTerminal).mockClear();
+
+    // -------------------------------------------------------------------------
+    // ACT: call launchSession directly with the stale/deleted path.
+    // -------------------------------------------------------------------------
+    let threw = false;
+    try {
+      await manager.launchSession(PATH_A);
+    } catch {
+      threw = true;
+    }
+
+    // -------------------------------------------------------------------------
+    // ASSERT 1: no exception — early-return must be silent.
+    // -------------------------------------------------------------------------
+    expect(threw, "launchSession must not throw when cwd does not exist").toBe(false);
+
+    // -------------------------------------------------------------------------
+    // ASSERT 2: createTerminal was not called.
+    // -------------------------------------------------------------------------
+    expect(
+      vi.mocked(vscodeMock.window.createTerminal),
+      "createTerminal must not be called for a non-existent cwd"
+    ).not.toHaveBeenCalled();
+
+    manager.dispose();
+  });
+});


### PR DESCRIPTION
Closes #71.

## Summary

Adds an `fs.existsSync` guard at the top of `SessionManager.launchSession` so that callers passing a stale folder path — e.g. a tracked `_sessions` entry whose directory has since been deleted or moved — do not trigger VS Code's *"The terminal process failed to launch: Starting directory (cwd) X does not exist"* error.

The bug surfaced in #71's repro (move project A → B on disk, then run **Add Folder** with B), where the user saw the error reference the OLD path A even though they had just entered path B. Root cause: the OLD session was still in `_sessions` because its terminal proxy was still alive in `vscode.window.terminals`, and a downstream caller could pass the now-deleted path A back into `launchSession`. The cwd guard makes that impossible regardless of caller, which is why the fix is a single defensive check rather than chasing a specific call site.

## Scope discipline

An earlier draft of this branch also made `addFolderPrompt` call `launchSession` after persisting (an "Add Folder also launches a session" UX change). That contradicted #71's explicit *Expected Behavior* — *"No terminal-launch attempt occurs as a side-effect of Add Folder"* — and was removed from this PR. The auto-launch UX is now tracked separately as #72 with its own open-question list.

## Changes

| File | Change |
|---|---|
| `src/sessionManager.ts` | Add cwd-existence guard at the top of `launchSession`. If `fs.existsSync(normalized)` is false, log and return early. |
| `test/addFolderPrompt.stale.test.ts` | New regression test file. Two tests: (1) `addFolderPrompt` does not call `createTerminal` even when a stale `_sessions` entry exists for a deleted path; (2) `launchSession` invoked directly with a deleted cwd early-returns without calling `createTerminal`. |
| `package-lock.json` | Incidental drift cleanup — `npm install` synced stale entries (`1.1.5`→`1.3.0`, `vscode ^1.85.0`→`^1.93.0`) that were missed during PRs #25 and #61. Not strictly part of the fix but kept here rather than carried as orphan working-tree drift. |

## Test plan

- [x] `npm run lint` — clean (typecheck pass)
- [x] `npm test` — 65/65 pass (63 existing + 2 new)
- [x] `npm run compile` — clean
- [ ] Manual repro: with a Claude session active for path A, move path A on disk to B, then run **Claude Conductor: Add Folder** with B. The terminal-launch error referencing A should no longer appear.

## Related

- Spawned #72 — *Enhancement: auto-launch a Claude session after Add Folder* — captures the UX question that was reverted out of this PR.
- Adjacent to #68 — close-detection spike. The cwd guard makes a tracked-but-deleted-cwd terminal harmless on the launch path; #68 still owns the broader question of when to evict such terminals from `_sessions`.

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*