### PR TITLE
feat: reattach Claude sessions on VS Code startup (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,17 @@ All notable changes to the Claude Conductor extension are documented here.
 ## [Unreleased]
 
 ### Added
+- **Reattach Claude sessions on VS Code startup** (#43). Conductor now detects restored session tabs whose inner shell was replaced (after a system restart, ptyhost crash, or VS Code with persistent-session revival off) and dispatches `claude` into each tab automatically. Gated by the new `claudeConductor.relaunchOnStartup` setting (default `true`).
+- First-activation consent toast when the official Claude Code extension (`Anthropic.claude-code`) is detected. Lets users opt out of reattach to avoid Conductor injecting keystrokes into the official extension's sessions.
 - **`claudeConductor.debugLogging` setting** — when enabled, emits verbose structured `key=value` diagnostic lines to the "Claude Conductor" output channel for every session-lifecycle event: terminal tracking (`[track]`, `[track:pid]`), close-detection tier outcomes (`[close]`, `[close:tier1]`, `[close:tier2]`, `[close:tier3]`, `[close:tier3:no-pid]`), PID index mutations (`[pid:delete]`), and reconcile poll results (`[reconcile]`, `[reconcile:evict]`, `[reconcile:clean]`). Default off; intended for diagnosing missed editor-tab close events (refs #68 phase A).
 
 ### Fixed
 - **Open in New Window no longer silently no-ops on the current window** — when the command is invoked on a session whose folder is already the active workspace, VS Code would receive the `vscode://` URI, route it back to the same window, and the user would perceive no change. The command now detects this case via a case-insensitive folder comparison, shows a dismissible info toast ("You're already in this project's window — focused the session instead."), and focuses the session tab instead of firing the URI. Fixes #66.
+
+### Notes
+- **Windows shell limitation**: the buffered-input clear-prefix used on the delay-fallback dispatch path uses Ctrl-C + Ctrl-U, which is interpreted as line-clear on POSIX shells and Windows PowerShell with PSReadLine (the default). On legacy cmd.exe and PowerShell-without-PSReadLine, the clear is a no-op — set `claudeConductor.relaunchOnStartup: false` if affected.
+- **First launch after upgrade**: existing Claude tabs whose shells survived your last VS Code restart may receive a one-time stray `claude` keystroke (no stored PID baseline). Subsequent activations are race-free.
+- **Day-1 collision with the official Claude Code extension**: if you install the official extension *after* Conductor's first activation, the consent toast won't retroactively fire. Set `claudeConductor.relaunchOnStartup: false` manually if needed.
 
 ## [1.3.0] — 2026-04-23
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ File paths in Claude's terminal output are clickable — open them directly in t
 
 Cycles through Claude tabs only, not every terminal or editor tab.
 
+### Reattach on VS Code Startup
+
+When VS Code restarts and Claude session tabs are restored with fresh shells, Conductor automatically dispatches `claude` into each tab so your sessions come back without manual relaunch. Gated by `claudeConductor.relaunchOnStartup` (default `true`).
+
 ## Getting Started
 
 1. Install the extension
@@ -75,6 +79,7 @@ Cycles through Claude tabs only, not every terminal or editor tab.
 | `claudeConductor.enableNotifications` | `true` | Show notifications when a session is waiting for input |
 | `claudeConductor.extraFolders` | `[]` | Additional folder paths to show in the launcher |
 | `claudeConductor.debugLogging` | `false` | Enable verbose diagnostic logging for session lifecycle (see Debug logging below) |
+| `claudeConductor.relaunchOnStartup` | `true` | When VS Code restarts, dispatch `claude` into restored Conductor session tabs whose inner shell was replaced. Disable if you also use the official Claude Code extension and Conductor mis-fires into its sessions, or on Windows shells (cmd.exe / PowerShell without PSReadLine) where the buffered-input clear-prefix is not interpreted as kill-line. |
 
 ### Debug logging
 
@@ -120,6 +125,7 @@ To remove the hooks at any time: run `Claude Conductor: Remove Notification Hook
 - Session tracking only works within a single VS Code window (sessions in other windows aren't visible in the sidebar)
 - The idle notification fires after Claude Code's built-in ~60-second idle threshold — not tunable from the extension
 - VS Code terminal tabs cannot change color or flash after creation, so "attention" is communicated via sidebar bell icons and notifications rather than tab-level indicators
+- **Reattach on cmd.exe / PowerShell without PSReadLine**: when the buffered-input clear-prefix on the delay-fallback dispatch path is not interpreted as line-clear (legacy Windows shells without modern line editing), a stray `claude` keystroke could land in any buffered prompt input. Disable `claudeConductor.relaunchOnStartup` if affected.
 
 ## Contributing / Development
 

--- a/docs/superpowers/plans/2026-04-27-43-reattach-on-startup.md
+++ b/docs/superpowers/plans/2026-04-27-43-reattach-on-startup.md
@@ -1,0 +1,2014 @@
+# Reattach Claude Sessions on VS Code Startup — Implementation Plan (#43)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When VS Code restarts and Claude session tab envelopes are restored with fresh shells inside, automatically dispatch `claude` into each restored tab — gated by `claudeConductor.relaunchOnStartup` (default `true`), with proactive day-1 collision detection for users running the official Claude Code extension.
+
+**Architecture:** A new "reattach pass" runs at the end of `SessionManager`'s constructor. For each tracked Claude terminal, an async per-session routine compares the current shell PID against a previously-persisted PID for the same folder path. PIDs are stored in `workspaceState` via a serialized write queue. When the comparison shows a fresh shell, the routine dispatches `claude` via a variant of the existing `_dispatchClaudeCommand` that clears any buffered prompt input on the delay-fallback path. Dead-cwd tabs are disposed and aggregated into one toast.
+
+**Tech Stack:** TypeScript (strict), VS Code Extension API (`vscode` module), vitest for tests. CI runs `npm run lint` (`tsc --noEmit`), `npm test` (`vitest run`), and `npm run compile` (`tsc -p ./`) — all three must pass.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-27-43-reattach-on-startup-design.md` (commit `216ce95`). Read it before starting; this plan implements the v3 design exactly as approved.
+
+**Branch:** `43-reattach-on-startup` (worktree at `I:/other/vscode-claude-conductor/.worktrees/43-reattach-on-startup`).
+
+---
+
+### Task 1: Foundation — config setting + Memento mock + globalState/extensions mocks
+
+**Files:**
+- Modify: `package.json` — add `claudeConductor.relaunchOnStartup` configuration property
+- Modify: `src/config.ts` — add `getRelaunchOnStartup()`
+- Modify: `test/mocks/vscode.ts` — add `Memento` mock, `extensions.getExtension` mock, `globalState`-style Memento factory
+
+This task lays groundwork that subsequent tasks need. No behavior changes yet — just plumbing.
+
+- [ ] **Step 1: Add the configuration property to `package.json`**
+
+In `contributes.configuration.properties`, after the `claudeConductor.debugLogging` block, add:
+
+```json
+        "claudeConductor.relaunchOnStartup": {
+          "type": "boolean",
+          "default": true,
+          "description": "On VS Code startup, automatically run 'claude' in any Claude Conductor terminal tab whose inner shell was replaced (e.g. after a system restart or ptyhost crash). Set to false to disable, or if Conductor reattaches into terminals owned by another extension."
+        }
+```
+
+- [ ] **Step 2: Add `getRelaunchOnStartup()` to `src/config.ts`**
+
+After the `getDebugLogging` function, add:
+
+```typescript
+export function getRelaunchOnStartup(): boolean {
+  return getConfig().get<boolean>("relaunchOnStartup", true);
+}
+```
+
+- [ ] **Step 3: Add `Memento` mock factory to `test/mocks/vscode.ts`**
+
+Append after the `OutputChannelStub` class:
+
+```typescript
+// ---------------------------------------------------------------------------
+// Memento (workspaceState / globalState) factory
+//
+// Tests use this to construct mock Mementos with per-call control over
+// `update` (e.g. via vi.mockImplementationOnce). The default `update`
+// resolves to undefined and writes through to the internal Map; tests can
+// override by calling `update.mockImplementationOnce(...)`.
+// ---------------------------------------------------------------------------
+
+export interface MementoMock {
+  get: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  keys: ReturnType<typeof vi.fn>;
+  /** Direct access to the backing store for assertions in tests */
+  readonly _store: Map<string, unknown>;
+}
+
+export function createMemento(initial: Record<string, unknown> = {}): MementoMock {
+  const store = new Map<string, unknown>(Object.entries(initial));
+  const get = vi.fn(<T>(key: string, defaultValue?: T): T | undefined => {
+    return (store.has(key) ? store.get(key) : defaultValue) as T | undefined;
+  });
+  const update = vi.fn(async (key: string, value: unknown): Promise<void> => {
+    if (value === undefined) {
+      store.delete(key);
+    } else {
+      store.set(key, value);
+    }
+  });
+  const keys = vi.fn(() => Array.from(store.keys()));
+  return { get, update, keys, _store: store };
+}
+```
+
+- [ ] **Step 4: Add `extensions` namespace mock to `test/mocks/vscode.ts`**
+
+Append at the end of the file (after `env`):
+
+```typescript
+// ---------------------------------------------------------------------------
+// extensions namespace
+// ---------------------------------------------------------------------------
+
+export const extensions = {
+  getExtension: vi.fn().mockReturnValue(undefined),
+};
+```
+
+- [ ] **Step 5: Run lint + compile to verify no regressions**
+
+Run from worktree root:
+```bash
+npm run lint
+npm run compile
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 6: Run existing test suite to confirm no regression**
+
+Run from worktree root:
+```bash
+npm test
+```
+
+Expected: all existing tests still pass (the mock additions are additive — nothing imports the new symbols yet).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json src/config.ts test/mocks/vscode.ts
+git commit -m "feat: add relaunchOnStartup config + Memento/extensions test mocks (#43)
+
+Foundation for issue #43 reattach work: register the new
+claudeConductor.relaunchOnStartup boolean setting (default true),
+add getRelaunchOnStartup() config helper, and extend the vscode test
+mock with a Memento factory and an extensions.getExtension stub.
+
+No behavior change — subsequent commits wire these in."
+```
+
+---
+
+### Task 2: SessionManager constructor signature + migrate existing tests
+
+**Files:**
+- Modify: `src/sessionManager.ts` — constructor accepts `workspaceState: vscode.Memento`; add `_disposed` flag; add `_pidWriteQueue`; add private constant `PID_KEY`
+- Modify: `src/extension.ts` — pass `context.workspaceState` to `new SessionManager(...)`
+- Modify: `test/sessionManager.debugLog.test.ts`, `test/sessionManager.focusSession.test.ts`, `test/addFolderPrompt.stale.test.ts` — pass mock Memento to constructor
+
+The signature change has to land in one commit because every existing test that constructs `SessionManager` will fail to compile otherwise.
+
+- [ ] **Step 1: Update `SessionManager` constructor in `src/sessionManager.ts`**
+
+Add the `PID_KEY` constant near the top of the file (after `STATE_DIR`):
+
+```typescript
+/** workspaceState key for the PID record. */
+const PID_KEY = "claudeConductor.sessionPids";
+```
+
+Replace the constructor (currently lines ~45–60) and add new private fields:
+
+```typescript
+  /** Set when dispose() is called — guards async-resolved writes. */
+  private _disposed = false;
+
+  /**
+   * Serialized write queue for PID persistence. Each call extends the chain
+   * with a leading .catch() so a prior rejection doesn't poison subsequent
+   * writes, and an inner try/catch logs and swallows transient failures.
+   */
+  private _pidWriteQueue: Promise<void> = Promise.resolve();
+
+  /** workspaceState injected by the extension activator. */
+  private readonly _workspaceState: vscode.Memento;
+
+  constructor(workspaceState: vscode.Memento) {
+    this._workspaceState = workspaceState;
+
+    // Pick up any Claude terminals that already exist (e.g., extension reloaded)
+    for (const terminal of vscode.window.terminals) {
+      this._trackIfClaudeSession(terminal);
+    }
+
+    this._disposables.push(
+      vscode.window.onDidOpenTerminal((terminal) => {
+        this._trackIfClaudeSession(terminal);
+      }),
+      vscode.window.onDidCloseTerminal((terminal) => {
+        this._handleTerminalClose(terminal);
+      }),
+      this._onDidChangeSessions
+    );
+  }
+```
+
+Replace `dispose()` (currently lines ~417–423):
+
+```typescript
+  dispose(): void {
+    this._disposed = true;
+    for (const d of this._disposables) {
+      d.dispose();
+    }
+    this._sessions.clear();
+    this._pidToTerminal.clear();
+  }
+```
+
+- [ ] **Step 2: Pass `context.workspaceState` in `src/extension.ts`**
+
+Modify the `activate()` body (line ~83). Change:
+
+```typescript
+  sessionManager = new SessionManager();
+```
+
+to:
+
+```typescript
+  sessionManager = new SessionManager(context.workspaceState);
+```
+
+- [ ] **Step 3: Update `test/sessionManager.debugLog.test.ts`**
+
+Read the file first. At every `new SessionManager()` call, change to `new SessionManager(createMemento())`. Add the import at the top:
+
+```typescript
+import { createMemento } from "./mocks/vscode";
+```
+
+(Adjust the import path if the test file is in a subdirectory — should be `"./mocks/vscode"` since it's a sibling to `test/mocks/`.)
+
+- [ ] **Step 4: Update `test/sessionManager.focusSession.test.ts`**
+
+Same migration as Step 3.
+
+- [ ] **Step 5: Update `test/addFolderPrompt.stale.test.ts`**
+
+Same migration as Step 3.
+
+- [ ] **Step 6: Run lint, test, compile to verify migration**
+
+```bash
+npm run lint
+npm test
+npm run compile
+```
+
+Expected: all three exit 0. Test count unchanged from before (constructor migration is purely mechanical).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/sessionManager.ts src/extension.ts test/sessionManager.debugLog.test.ts test/sessionManager.focusSession.test.ts test/addFolderPrompt.stale.test.ts
+git commit -m "refactor: SessionManager takes workspaceState arg (#43)
+
+Threads context.workspaceState into SessionManager so the upcoming
+reattach logic can persist PID baselines. Adds a _disposed flag and
+_pidWriteQueue (unused yet — populated in a follow-up commit).
+
+Migrates the three existing tests to construct with a mock Memento
+via createMemento().
+
+Behavior unchanged — pure plumbing."
+```
+
+---
+
+### Task 3: PID persistence helpers (`_normalizePersistKey`, `_persistSessionPid`, `_clearSessionPid`)
+
+**Files:**
+- Modify: `src/sessionManager.ts` — add three private methods
+- Create: `test/sessionManagerPidPersistence.test.ts` — tests for the helpers in isolation
+
+TDD: write the tests first, run to confirm they fail, then implement.
+
+- [ ] **Step 1: Create the test file `test/sessionManagerPidPersistence.test.ts`**
+
+```typescript
+/**
+ * Unit tests for SessionManager PID persistence helpers (#43).
+ *
+ * Covers _persistSessionPid, _clearSessionPid, _normalizePersistKey, the
+ * _disposed guard, and the write-queue rejection-recovery path.
+ *
+ * These tests reach into SessionManager via `as any` to call private methods
+ * directly — that's intentional. The public surface for these helpers is
+ * exercised through the reattach-pass integration tests.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as vscodeMock from "./mocks/vscode";
+import { createMemento, MementoMock } from "./mocks/vscode";
+import { SessionManager } from "../src/sessionManager";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Private = any;
+
+const PID_KEY = "claudeConductor.sessionPids";
+
+describe("SessionManager PID persistence", () => {
+  let mem: MementoMock;
+  let sm: SessionManager;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    (vscodeMock.window as Record<string, unknown>).terminals = [];
+    mem = createMemento();
+    sm = new SessionManager(mem as unknown as import("vscode").Memento);
+  });
+
+  it("_normalizePersistKey preserves case", () => {
+    const result = (sm as Private)._normalizePersistKey("D:\\Projects\\MyApp");
+    expect(result.toLowerCase()).not.toBe(result); // sanity: input has uppercase
+    expect(result).toBe("D:\\Projects\\MyApp");
+  });
+
+  it("_persistSessionPid writes through to workspaceState", async () => {
+    (sm as Private)._persistSessionPid("D:\\proj\\foo", 42);
+    // Wait for the queue chain to drain
+    await (sm as Private)._pidWriteQueue;
+    expect(mem.update).toHaveBeenCalledWith(PID_KEY, { "D:\\proj\\foo": 42 });
+  });
+
+  it("_persistSessionPid is no-op after dispose()", async () => {
+    sm.dispose();
+    (sm as Private)._persistSessionPid("D:\\proj\\foo", 42);
+    await (sm as Private)._pidWriteQueue;
+    expect(mem.update).not.toHaveBeenCalled();
+  });
+
+  it("_clearSessionPid removes the entry", async () => {
+    (sm as Private)._persistSessionPid("D:\\proj\\foo", 42);
+    (sm as Private)._persistSessionPid("D:\\proj\\bar", 43);
+    await (sm as Private)._pidWriteQueue;
+    (sm as Private)._clearSessionPid("D:\\proj\\foo");
+    await (sm as Private)._pidWriteQueue;
+    expect(mem._store.get(PID_KEY)).toEqual({ "D:\\proj\\bar": 43 });
+  });
+
+  it("_clearSessionPid is no-op after dispose()", async () => {
+    (sm as Private)._persistSessionPid("D:\\proj\\foo", 42);
+    await (sm as Private)._pidWriteQueue;
+    sm.dispose();
+    (sm as Private)._clearSessionPid("D:\\proj\\foo");
+    await (sm as Private)._pidWriteQueue;
+    expect(mem._store.get(PID_KEY)).toEqual({ "D:\\proj\\foo": 42 });
+  });
+
+  it("queue self-heals after a workspaceState.update rejection", async () => {
+    mem.update.mockImplementationOnce(() => Promise.reject(new Error("disk full")));
+    (sm as Private)._persistSessionPid("D:\\proj\\foo", 42);
+    (sm as Private)._persistSessionPid("D:\\proj\\bar", 43);
+    await (sm as Private)._pidWriteQueue;
+    // First update rejected; second update should still have run.
+    expect(mem.update).toHaveBeenCalledTimes(2);
+    expect(mem._store.get(PID_KEY)).toEqual({ "D:\\proj\\bar": 43 });
+  });
+
+  it("preserves persisted-key case (does not lowercase)", async () => {
+    (sm as Private)._persistSessionPid("D:\\Project\\MyApp", 42);
+    await (sm as Private)._pidWriteQueue;
+    const stored = mem._store.get(PID_KEY) as Record<string, number>;
+    expect(Object.keys(stored)).toEqual(["D:\\Project\\MyApp"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test file to confirm it fails**
+
+```bash
+npx vitest run test/sessionManagerPidPersistence.test.ts
+```
+
+Expected: tests fail with `_normalizePersistKey is not a function` or similar — methods don't exist yet.
+
+- [ ] **Step 3: Implement the three methods in `src/sessionManager.ts`**
+
+Add `import { log } from "./output"` if not already imported (it is). Add the methods inside the `SessionManager` class, near the other private methods (e.g., after `_findSessionByFolder`):
+
+```typescript
+  /**
+   * Normalize a folder path for use as a persistence key.
+   * Case is PRESERVED — see "Persistence vs in-memory key" in the design spec.
+   * Lower-case folding applies only to in-memory `_findSessionByFolder` lookups,
+   * NOT to keys persisted in workspaceState.
+   */
+  private _normalizePersistKey(folderPath: string): string {
+    return path.normalize(folderPath);
+  }
+
+  /**
+   * Write the (folderPath -> pid) entry to workspaceState[PID_KEY].
+   * No-op after dispose().
+   *
+   * Writes are serialized through `_pidWriteQueue` to prevent read-modify-write
+   * races between concurrent reattach routines and `launchSession` flows. The
+   * leading `.catch(() => undefined)` ensures a prior rejection doesn't poison
+   * subsequent writes; the inner try/catch logs and swallows transient failures.
+   */
+  private _persistSessionPid(folderPath: string, pid: number): void {
+    if (this._disposed) return;
+    this._pidWriteQueue = this._pidWriteQueue
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          const current = this._workspaceState.get<Record<string, number>>(PID_KEY) ?? {};
+          current[this._normalizePersistKey(folderPath)] = pid;
+          await this._workspaceState.update(PID_KEY, current);
+        } catch (err) {
+          log(`[reattach] failed to persist PID for ${folderPath}: ${String(err)}`);
+        }
+      });
+  }
+
+  /**
+   * Remove the entry for `folderPath` from workspaceState[PID_KEY].
+   * Same queue + rejection semantics as `_persistSessionPid`. No-op after dispose().
+   */
+  private _clearSessionPid(folderPath: string): void {
+    if (this._disposed) return;
+    this._pidWriteQueue = this._pidWriteQueue
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          const current = this._workspaceState.get<Record<string, number>>(PID_KEY) ?? {};
+          delete current[this._normalizePersistKey(folderPath)];
+          await this._workspaceState.update(PID_KEY, current);
+        } catch (err) {
+          log(`[reattach] failed to clear PID for ${folderPath}: ${String(err)}`);
+        }
+      });
+  }
+```
+
+- [ ] **Step 4: Run the test file to confirm it passes**
+
+```bash
+npx vitest run test/sessionManagerPidPersistence.test.ts
+```
+
+Expected: 7/7 tests pass.
+
+- [ ] **Step 5: Run full lint + test + compile**
+
+```bash
+npm run lint
+npm test
+npm run compile
+```
+
+Expected: all three exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sessionManager.ts test/sessionManagerPidPersistence.test.ts
+git commit -m "feat: PID persistence helpers with serialized write queue (#43)
+
+Adds _normalizePersistKey, _persistSessionPid, and _clearSessionPid as
+private methods on SessionManager. Writes go through _pidWriteQueue,
+which serializes them and self-heals from individual workspaceState
+update failures via the .catch(() => undefined).then(...) pattern.
+
+Both writers honor the _disposed flag so async-resolved writes after
+dispose() no-op cleanly.
+
+Persisted keys are case-preserved (path.normalize, no toLowerCase) to
+avoid collisions on case-sensitive filesystems.
+
+Includes 7 unit tests covering: case preservation, write-through,
+disposed guards, clear, queue rejection self-healing."
+```
+
+---
+
+### Task 4: Wire PID persistence into `launchSession` and `_removeByKey`
+
+**Files:**
+- Modify: `src/sessionManager.ts` — call `_persistSessionPid` after a new session's `processId` resolves; call `_clearSessionPid` from `_removeByKey`
+- Modify: `test/sessionManagerPidPersistence.test.ts` — add tests for the integration points
+
+- [ ] **Step 1: Add tests for the integration points**
+
+Append to `test/sessionManagerPidPersistence.test.ts` inside the `describe` block:
+
+```typescript
+  it("launchSession persists PID after the new terminal's processId resolves", async () => {
+    // Mock createTerminal to return a fake terminal whose processId resolves to 999
+    const fakeTerminal = {
+      name: "claude · proj",
+      show: vi.fn(),
+      sendText: vi.fn(),
+      dispose: vi.fn(),
+      processId: Promise.resolve(999),
+      shellIntegration: undefined,
+      creationOptions: { cwd: "D:\\proj" },
+    };
+    vi.mocked(vscodeMock.window.createTerminal).mockReturnValue(
+      fakeTerminal as unknown as import("vscode").Terminal
+    );
+    // fs.existsSync must return true for launchSession's cwd guard
+    const fs = await import("fs");
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+
+    await sm.launchSession("D:\\proj");
+    // launchSession schedules the persist — drain the queue
+    await (sm as Private)._pidWriteQueue;
+
+    const stored = mem._store.get(PID_KEY) as Record<string, number>;
+    expect(stored).toEqual({ "D:\\proj": 999 });
+  });
+
+  it("_removeByKey clears the PID entry on session close", async () => {
+    // Seed _sessions and PID record
+    const fakeTerminal = {
+      name: "claude · proj",
+      processId: Promise.resolve(123),
+      creationOptions: { cwd: "D:\\proj" },
+    } as unknown as import("vscode").Terminal;
+    (sm as Private)._sessions.set(fakeTerminal, {
+      terminal: fakeTerminal,
+      folderPath: "D:\\proj",
+      folderName: "proj",
+      startedAt: new Date(),
+      isIdle: false,
+    });
+    (sm as Private)._persistSessionPid("D:\\proj", 123);
+    await (sm as Private)._pidWriteQueue;
+    expect(mem._store.get(PID_KEY)).toEqual({ "D:\\proj": 123 });
+
+    // Trigger close cleanup
+    (sm as Private)._removeByKey(fakeTerminal);
+    await (sm as Private)._pidWriteQueue;
+
+    expect(mem._store.get(PID_KEY)).toEqual({});
+  });
+```
+
+- [ ] **Step 2: Run the new tests to confirm they fail**
+
+```bash
+npx vitest run test/sessionManagerPidPersistence.test.ts -t "launchSession persists"
+npx vitest run test/sessionManagerPidPersistence.test.ts -t "_removeByKey clears"
+```
+
+Expected: both fail — `launchSession` doesn't write the PID yet, `_removeByKey` doesn't call `_clearSessionPid`.
+
+- [ ] **Step 3: Update `launchSession` to persist the PID**
+
+In `src/sessionManager.ts`, find the end of `launchSession` (after `await this._dispatchClaudeCommand(terminal)`). Add:
+
+```typescript
+    // Persist the new shell's PID so the next activation's reattach pass
+    // has a baseline. processId is a Thenable; we don't block here.
+    terminal.processId.then(
+      (pid) => {
+        if (pid !== undefined) {
+          this._persistSessionPid(normalized, pid);
+        }
+      },
+      () => { /* ignore — best-effort persistence */ }
+    );
+```
+
+- [ ] **Step 4: Update `_removeByKey` to clear the PID**
+
+In `src/sessionManager.ts`, find `_removeByKey` (around line 345). Inside the method, after `this._sessions.delete(terminal);` and the existing `terminal.processId.then` block (which clears `_pidToTerminal`), add a call to `_clearSessionPid`:
+
+The simplest place is right after the existing PID-index cleanup. Modify the method to:
+
+```typescript
+  private _removeByKey(terminal: vscode.Terminal): boolean {
+    const session = this._sessions.get(terminal);
+    if (!session) {
+      debugLog(`[remove] miss name=${JSON.stringify(terminal.name)} — key already gone (possible double-fire)`);
+      return false;
+    }
+    this._sessions.delete(terminal);
+    debugLog(`[remove] success folderPath=${JSON.stringify(session.folderPath)} sessionsAfter=${this._sessions.size}`);
+
+    // Remove from PID index (two-argument .then() because PromiseLike lacks .catch())
+    terminal.processId.then(
+      (pid) => {
+        if (pid !== undefined) {
+          this._pidToTerminal.delete(pid);
+          debugLog(`[pid:delete] pid=${pid} pidsAfter=${this._pidToTerminal.size}`);
+        }
+      },
+      () => { /* ignore */ }
+    );
+
+    // Clear the persisted PID for this folder so the next activation's
+    // reattach pass doesn't see a stale baseline. Runs UNCONDITIONALLY
+    // (regardless of relaunchOnStartup setting) to prevent stale baselines
+    // when the user toggles the setting off then back on.
+    this._clearSessionPid(session.folderPath);
+
+    this._cleanupStateFile(session.folderPath);
+    this._onDidChangeSessions.fire();
+    return true;
+  }
+```
+
+- [ ] **Step 5: Run the new tests to confirm they pass**
+
+```bash
+npx vitest run test/sessionManagerPidPersistence.test.ts
+```
+
+Expected: 9/9 tests pass.
+
+- [ ] **Step 6: Run full lint + test + compile**
+
+```bash
+npm run lint
+npm test
+npm run compile
+```
+
+Expected: all three exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/sessionManager.ts test/sessionManagerPidPersistence.test.ts
+git commit -m "feat: persist session PID on launch and clear on close (#43)
+
+launchSession schedules a _persistSessionPid call once the new terminal's
+processId resolves, capturing the baseline shell PID for the next
+activation's reattach decision.
+
+_removeByKey calls _clearSessionPid unconditionally on session close so
+toggling relaunchOnStartup off then back on doesn't leave stale baselines
+in the persistence record.
+
+Adds 2 integration tests."
+```
+
+---
+
+### Task 5: `_dispatchClaudeIntoRestoredTerminal` — buffered-input mitigation
+
+**Files:**
+- Modify: `src/sessionManager.ts` — add the new private method
+- Create: `test/dispatchClaudeIntoRestoredTerminal.test.ts` — tests for each dispatch tier
+
+The reattach helper reuses the 3-tier dispatch logic from `_dispatchClaudeCommand` but inserts a clear-prefix (`\u0003\u0015` = Ctrl-C, Ctrl-U) only on the **delay-fallback path**. This avoids racing against shell-integration's command-boundary marker on the fast/slow paths.
+
+- [ ] **Step 1: Create the test file `test/dispatchClaudeIntoRestoredTerminal.test.ts`**
+
+```typescript
+/**
+ * Tests for SessionManager._dispatchClaudeIntoRestoredTerminal (#43).
+ *
+ * Verifies the three dispatch tiers and that the buffered-input clear-prefix
+ * (\u0003\u0015) is sent ONLY on the delay-fallback path — not on the
+ * shell-integration fast or slow paths, where executeCommand handles command
+ * boundaries safely.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as vscodeMock from "./mocks/vscode";
+import { createMemento } from "./mocks/vscode";
+import { SessionManager } from "../src/sessionManager";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Private = any;
+
+describe("_dispatchClaudeIntoRestoredTerminal", () => {
+  let sm: SessionManager;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    (vscodeMock.window as Record<string, unknown>).terminals = [];
+    sm = new SessionManager(createMemento() as unknown as import("vscode").Memento);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fast path: shell integration active → executeCommand called once, no clear-prefix", async () => {
+    const executeCommand = vi.fn();
+    const sendText = vi.fn();
+    const terminal = {
+      name: "claude · foo",
+      sendText,
+      shellIntegration: { executeCommand },
+      creationOptions: { cwd: "D:\\foo" },
+    } as unknown as import("vscode").Terminal;
+
+    await (sm as Private)._dispatchClaudeIntoRestoredTerminal(terminal);
+
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    expect(executeCommand).toHaveBeenCalledWith("claude");
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
+  it("slow path: shell integration activates within window → executeCommand called", async () => {
+    const executeCommand = vi.fn();
+    const sendText = vi.fn();
+    const terminal = {
+      name: "claude · foo",
+      sendText,
+      shellIntegration: undefined as unknown,
+      creationOptions: { cwd: "D:\\foo" },
+    } as unknown as import("vscode").Terminal;
+
+    // Capture the listener registered by the slow path
+    let registeredListener: ((e: { terminal: unknown; shellIntegration: { executeCommand: typeof executeCommand } }) => void) | undefined;
+    vi.spyOn(vscodeMock.window, "onDidChangeTerminalShellIntegration").mockImplementation((cb) => {
+      registeredListener = cb as typeof registeredListener;
+      return new vscodeMock.Disposable(() => {});
+    });
+
+    const dispatchPromise = (sm as Private)._dispatchClaudeIntoRestoredTerminal(terminal);
+
+    // Fire the activation event with a fresh shellIntegration object
+    const activated = { executeCommand: vi.fn() };
+    expect(registeredListener).toBeDefined();
+    registeredListener!({ terminal, shellIntegration: activated });
+
+    await dispatchPromise;
+
+    expect(activated.executeCommand).toHaveBeenCalledWith("claude");
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
+  it("delay fallback: no shell integration → clear-prefix sent, then claude after delay", async () => {
+    vi.useFakeTimers();
+    const sendText = vi.fn();
+    const terminal = {
+      name: "claude · foo",
+      sendText,
+      shellIntegration: undefined as unknown,
+      creationOptions: { cwd: "D:\\foo" },
+    } as unknown as import("vscode").Terminal;
+
+    // The slow-path listener is registered but never fires
+    vi.spyOn(vscodeMock.window, "onDidChangeTerminalShellIntegration").mockReturnValue(
+      new vscodeMock.Disposable(() => {})
+    );
+
+    const dispatchPromise = (sm as Private)._dispatchClaudeIntoRestoredTerminal(terminal);
+
+    // Advance 2000ms → slow-path times out
+    await vi.advanceTimersByTimeAsync(2000);
+    // Advance 50ms breather between clear-prefix and dispatch
+    await vi.advanceTimersByTimeAsync(50);
+    // Advance launchDelayMs (default 500ms) → delay-fallback fires sendText("claude")
+    await vi.advanceTimersByTimeAsync(500);
+    await dispatchPromise;
+
+    // Two sendText calls in order:
+    //   1. clear-prefix \u0003\u0015 with addNewLine: false (2 args)
+    //   2. "claude" with implicit newline (1 arg)
+    expect(sendText).toHaveBeenCalledTimes(2);
+    expect(sendText).toHaveBeenNthCalledWith(1, "\u0003\u0015", false);
+    expect(sendText).toHaveBeenNthCalledWith(2, "claude");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test file to confirm it fails**
+
+```bash
+npx vitest run test/dispatchClaudeIntoRestoredTerminal.test.ts
+```
+
+Expected: tests fail — `_dispatchClaudeIntoRestoredTerminal is not a function`.
+
+- [ ] **Step 3: Implement `_dispatchClaudeIntoRestoredTerminal` in `src/sessionManager.ts`**
+
+Add inside the `SessionManager` class, after `_dispatchClaudeCommand`:
+
+```typescript
+  /**
+   * Variant of `_dispatchClaudeCommand` for restored terminals.
+   *
+   * Same 3-tier path, but the delay-fallback prepends `\u0003\u0015` (Ctrl-C,
+   * Ctrl-U) before sending `claude`, with a 50ms breather. On POSIX shells
+   * and Windows PowerShell with PSReadLine (default), this clears any
+   * buffered prompt input the user typed before VS Code closed. On legacy
+   * cmd.exe and PowerShell-without-PSReadLine these escape sequences are
+   * not interpreted as kill-line — see "Known limitations" in the design.
+   *
+   * The clear-prefix is NOT sent on the fast or slow paths because
+   * shell-integration's `executeCommand` handles command boundaries
+   * safely; sending raw bytes there could race the integration handshake.
+   */
+  private async _dispatchClaudeIntoRestoredTerminal(terminal: vscode.Terminal): Promise<void> {
+    const cmd = getClaudeCommand();
+
+    // Fast path: shell integration already active
+    if (terminal.shellIntegration) {
+      log(`[reattach:dispatch] fast path — shell integration already active`);
+      terminal.shellIntegration.executeCommand(cmd);
+      return;
+    }
+
+    // Slow path: wait up to 2 s for shell integration to activate
+    const shellIntegrationAvailable = await new Promise<boolean>((resolve) => {
+      let disposed = false;
+
+      const timeoutHandle = setTimeout(() => {
+        if (!disposed) {
+          disposed = true;
+          listener.dispose();
+          log(`[reattach:dispatch] slow path timed out — falling back to delay sendText`);
+          resolve(false);
+        }
+      }, 2000);
+
+      const listener = vscode.window.onDidChangeTerminalShellIntegration((e) => {
+        if (e.terminal === terminal && !disposed) {
+          disposed = true;
+          clearTimeout(timeoutHandle);
+          listener.dispose();
+          log(`[reattach:dispatch] slow path — shell integration activated`);
+          e.shellIntegration.executeCommand(cmd);
+          resolve(true);
+        }
+      });
+    });
+
+    if (shellIntegrationAvailable) {
+      return;
+    }
+
+    // Delay fallback — CLEAR-PREFIX REQUIRED HERE.
+    //  (Ctrl-C) signals the running foreground command; no-op on a clean prompt.
+    //  (Ctrl-U) clears the current input line on POSIX shells and PowerShell+PSReadLine.
+    log(`[reattach:dispatch] delay fallback — sending clear-prefix then claude`);
+    terminal.sendText("\u0003\u0015", false);
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    const delayMs = getLaunchDelayMs();
+    await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+    terminal.sendText(cmd);
+  }
+```
+
+- [ ] **Step 4: Run the test file to confirm it passes**
+
+```bash
+npx vitest run test/dispatchClaudeIntoRestoredTerminal.test.ts
+```
+
+Expected: 3/3 tests pass.
+
+- [ ] **Step 5: Run full lint + test + compile**
+
+```bash
+npm run lint
+npm test
+npm run compile
+```
+
+Expected: all three exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sessionManager.ts test/dispatchClaudeIntoRestoredTerminal.test.ts
+git commit -m "feat: dispatch helper for restored terminals with buffered-input clear (#43)
+
+_dispatchClaudeIntoRestoredTerminal mirrors _dispatchClaudeCommand's
+3-tier dispatch but prepends \u0003\u0015 (Ctrl-C, Ctrl-U) before the
+delay-fallback sendText. Clears any buffered prompt input the user
+typed before VS Code closed, on shells where those escape sequences are
+interpreted as line-clear (POSIX shells, PowerShell+PSReadLine).
+
+The clear-prefix is NOT sent on the fast/slow paths — executeCommand
+there handles command boundaries safely; sending raw bytes would race
+the integration handshake.
+
+3 tests cover each dispatch tier."
+```
+
+---
+
+### Task 6: `_reattachRestoredSessions` skeleton — setting gate + snapshot iteration + orchestration
+
+**Files:**
+- Modify: `src/sessionManager.ts` — add the new async method (skeleton); wire into the constructor
+- Create: `test/reattachOnStartup.test.ts` — tests for the orchestration shell
+
+This task lands the orchestrator. Per-session decision logic and dead-cwd handling come in subsequent tasks; the skeleton here just iterates a snapshot of `_sessions.values()`, awaits `Promise.allSettled`, and returns. The setting gate also lands here.
+
+- [ ] **Step 1: Create the test file `test/reattachOnStartup.test.ts` with two skeleton tests**
+
+```typescript
+/**
+ * Integration tests for SessionManager reattach-on-startup (#43).
+ *
+ * Tests are organized by spec scenario number (see design doc test table).
+ * Scenarios are added incrementally as plan tasks 6-9 land.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as vscodeMock from "./mocks/vscode";
+import { createMemento } from "./mocks/vscode";
+import { SessionManager } from "../src/sessionManager";
+import * as config from "../src/config";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Private = any;
+
+const PID_KEY = "claudeConductor.sessionPids";
+
+function makeTerminal(opts: {
+  name: string;
+  cwd: string;
+  pid?: number;
+  shellIntegration?: { executeCommand: ReturnType<typeof vi.fn> };
+}): unknown {
+  return {
+    name: opts.name,
+    show: vi.fn(),
+    sendText: vi.fn(),
+    dispose: vi.fn(),
+    processId: Promise.resolve(opts.pid ?? 1234),
+    shellIntegration: opts.shellIntegration,
+    creationOptions: { cwd: opts.cwd },
+  };
+}
+
+describe("reattach on startup — orchestration", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    (vscodeMock.window as Record<string, unknown>).terminals = [];
+  });
+
+  // Scenario 12 from the design spec
+  it("setting off → reattach is a no-op (no dispatch, no toast)", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(false);
+    const term = makeTerminal({ name: "claude · foo", cwd: "D:\\foo", pid: 42 });
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+
+    const sm = new SessionManager(createMemento() as unknown as import("vscode").Memento);
+    // Wait for any reattach work to complete (it shouldn't have started)
+    await (sm as Private)._reattachPromise;
+
+    expect((term as { sendText: ReturnType<typeof vi.fn> }).sendText).not.toHaveBeenCalled();
+    expect(vscodeMock.window.showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  // Scenario 19 from the design spec
+  it("snapshot iteration: onDidOpenTerminal mid-reattach is not included", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const original = makeTerminal({ name: "claude · foo", cwd: "D:\\foo", pid: 42 });
+    (vscodeMock.window as Record<string, unknown>).terminals = [original];
+
+    // Capture onDidOpenTerminal callback so we can fire a synthetic event
+    let openCallback: ((t: unknown) => void) | undefined;
+    vi.spyOn(vscodeMock.window, "onDidOpenTerminal").mockImplementation((cb) => {
+      openCallback = cb as typeof openCallback;
+      return new vscodeMock.Disposable(() => {});
+    });
+
+    const mem = createMemento();
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+
+    // Fire onDidOpenTerminal for a NEW Claude terminal during reattach
+    const newTerm = makeTerminal({ name: "claude · bar", cwd: "D:\\bar", pid: 99 });
+    expect(openCallback).toBeDefined();
+    openCallback!(newTerm);
+
+    await (sm as Private)._reattachPromise;
+
+    // The reattach iteration only saw the original (snapshot). The new terminal
+    // is tracked in _sessions but no reattach dispatch fires for it.
+    expect((newTerm as { sendText: ReturnType<typeof vi.fn> }).sendText).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+```bash
+npx vitest run test/reattachOnStartup.test.ts
+```
+
+Expected: tests fail — `_reattachPromise` doesn't exist; reattach not wired.
+
+- [ ] **Step 3: Add the orchestrator skeleton to `src/sessionManager.ts`**
+
+Add the import for the new config helper at the top of the file:
+
+```typescript
+import { getClaudeCommand, getReuseTerminal, getLaunchDelayMs, getRelaunchOnStartup } from "./config";
+```
+
+Add a new private field next to `_pidWriteQueue`:
+
+```typescript
+  /**
+   * Promise from the reattach pass kicked off in the constructor.
+   * Tests await this to verify reattach completed; production callers
+   * fire-and-forget.
+   */
+  private _reattachPromise: Promise<void> = Promise.resolve();
+```
+
+Update the constructor's body — after the existing `_disposables.push(...)` block, add:
+
+```typescript
+    // Kick off reattach pass for restored Claude tabs (gated by setting).
+    // Fire-and-forget — _reattachPromise is exposed for tests.
+    if (getRelaunchOnStartup()) {
+      this._reattachPromise = this._reattachRestoredSessions();
+    }
+```
+
+Add the orchestrator method inside the class (after `_dispatchClaudeIntoRestoredTerminal`):
+
+```typescript
+  /**
+   * Reattach pass for restored Claude session tabs (#43).
+   *
+   * Runs once at the end of the constructor when relaunchOnStartup is on.
+   * Iterates a SYNCHRONOUS SNAPSHOT of _sessions.values() taken at entry
+   * (defensive against onDidOpenTerminal mid-iteration mutation), kicks
+   * off per-session async routines, awaits Promise.allSettled, and shows
+   * an aggregate dead-cwd toast when applicable.
+   *
+   * The toast is gated on !this._disposed so a dispose() that lands during
+   * the routines doesn't surface a stale warning.
+   *
+   * Per-session decision logic, dispatch, and cwd-missing handling are
+   * implemented in subsequent tasks of this plan.
+   */
+  private async _reattachRestoredSessions(): Promise<void> {
+    debugLog(`[reattach] starting pass — sessions=${this._sessions.size}`);
+    const snapshot = Array.from(this._sessions.values());
+    const deadCwds: string[] = [];
+
+    await Promise.allSettled(
+      snapshot.map((session) => this._reattachOneSession(session, deadCwds))
+    );
+
+    if (!this._disposed && deadCwds.length > 0) {
+      const shown = deadCwds.slice(0, 3);
+      const overflow = deadCwds.length - shown.length;
+      const folderList = shown.join(", ") + (overflow > 0 ? `, and ${overflow} more` : "");
+      const noun = deadCwds.length === 1 ? "session" : "sessions";
+      vscode.window.showInformationMessage(
+        `Could not restore ${deadCwds.length} ${noun} — folder${deadCwds.length === 1 ? "" : "s"} no longer exist: ${folderList}`
+      );
+    }
+
+    debugLog(`[reattach] pass complete — deadCwds=${deadCwds.length}`);
+  }
+
+  /**
+   * Per-session reattach decision. Mutates `deadCwds` in place when the
+   * session's cwd no longer exists on disk.
+   *
+   * Skeleton implementation in this task — full decision logic lands in
+   * Task 7 (PID compare/dispatch) and Task 8 (cwd-missing handling).
+   */
+  private async _reattachOneSession(
+    session: ActiveSession,
+    deadCwds: string[]
+  ): Promise<void> {
+    // Placeholder — will be filled in by Task 7 and Task 8.
+    void session;
+    void deadCwds;
+  }
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+```bash
+npx vitest run test/reattachOnStartup.test.ts
+```
+
+Expected: 2/2 tests pass.
+
+- [ ] **Step 5: Run full lint + test + compile**
+
+```bash
+npm run lint
+npm test
+npm run compile
+```
+
+Expected: all three exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sessionManager.ts test/reattachOnStartup.test.ts
+git commit -m "feat: reattach orchestrator skeleton with setting gate (#43)
+
+Adds _reattachRestoredSessions, kicked off from the SessionManager
+constructor when claudeConductor.relaunchOnStartup is true. Iterates a
+synchronous snapshot of _sessions.values() (defensive against
+onDidOpenTerminal mid-iteration), awaits Promise.allSettled on per-
+session routines, and shows an aggregate dead-cwd toast gated on
+!this._disposed.
+
+Per-session decision logic (PID compare, dispatch, cwd-missing) is a
+stub here — implemented in subsequent commits.
+
+Tests: setting off no-ops; snapshot iteration excludes mid-reattach
+opens (scenarios 12 and 19 from the design spec)."
+```
+
+---
+
+### Task 7: Per-session reattach decision — PID compare + dispatch
+
+**Files:**
+- Modify: `src/sessionManager.ts` — fill in `_reattachOneSession`
+- Modify: `test/reattachOnStartup.test.ts` — add scenarios 1, 2, 5, 8, 9
+
+The decision logic is the heart of the feature. PID match → skip + refresh persistence; PID differ or no PID → dispatch + persist; undefined/rejected → skip.
+
+- [ ] **Step 1: Add scenario tests to `test/reattachOnStartup.test.ts`**
+
+Append inside the `describe` block:
+
+```typescript
+  // Scenario 1: same PID → no dispatch, but PID re-persisted
+  it("same PID → no dispatch, record refreshed", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const term = makeTerminal({ name: "claude · foo", cwd: "D:\\foo", pid: 42 });
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    const mem = createMemento({ [PID_KEY]: { "D:\\foo": 42 } });
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+    await (sm as Private)._pidWriteQueue;
+
+    expect((term as { sendText: ReturnType<typeof vi.fn> }).sendText).not.toHaveBeenCalled();
+    // Record refreshed (re-written even though PID matched)
+    expect(mem.update).toHaveBeenCalled();
+    expect(mem._store.get(PID_KEY)).toEqual({ "D:\\foo": 42 });
+  });
+
+  // Scenario 2: different PID → dispatch via shell-integration fast path
+  it("different PID → fast-path dispatch + PID written", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const executeCommand = vi.fn();
+    const term = makeTerminal({
+      name: "claude · foo",
+      cwd: "D:\\foo",
+      pid: 42,
+      shellIntegration: { executeCommand },
+    });
+    // Mock fs.existsSync for the cwd check (needed in Task 8 — make it pass here)
+    const fs = await import("fs");
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    const mem = createMemento({ [PID_KEY]: { "D:\\foo": 99 } });
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+    await (sm as Private)._pidWriteQueue;
+
+    expect(executeCommand).toHaveBeenCalledWith("claude");
+    expect((term as { sendText: ReturnType<typeof vi.fn> }).sendText).not.toHaveBeenCalled();
+    expect(mem._store.get(PID_KEY)).toEqual({ "D:\\foo": 42 });
+  });
+
+  // Scenario 5: no stored PID → dispatch + PID written
+  it("no stored PID → dispatch + PID written", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const executeCommand = vi.fn();
+    const term = makeTerminal({
+      name: "claude · foo",
+      cwd: "D:\\foo",
+      pid: 42,
+      shellIntegration: { executeCommand },
+    });
+    const fs = await import("fs");
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    const mem = createMemento(); // empty record
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+    await (sm as Private)._pidWriteQueue;
+
+    expect(executeCommand).toHaveBeenCalledWith("claude");
+    expect(mem._store.get(PID_KEY)).toEqual({ "D:\\foo": 42 });
+  });
+
+  // Scenario 8: processId resolves to undefined → no dispatch
+  it("processId undefined → no dispatch, no dispose, no PID write", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const term = {
+      name: "claude · foo",
+      show: vi.fn(),
+      sendText: vi.fn(),
+      dispose: vi.fn(),
+      processId: Promise.resolve(undefined),
+      shellIntegration: { executeCommand: vi.fn() },
+      creationOptions: { cwd: "D:\\foo" },
+    };
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    const mem = createMemento();
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+
+    expect(term.shellIntegration.executeCommand).not.toHaveBeenCalled();
+    expect(term.sendText).not.toHaveBeenCalled();
+    expect(term.dispose).not.toHaveBeenCalled();
+    expect(mem._store.get(PID_KEY)).toBeUndefined();
+  });
+
+  // Scenario 9: processId rejects → no dispatch
+  it("processId rejects → no dispatch, no dispose", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const term = {
+      name: "claude · foo",
+      show: vi.fn(),
+      sendText: vi.fn(),
+      dispose: vi.fn(),
+      processId: Promise.reject(new Error("rejected")),
+      shellIntegration: { executeCommand: vi.fn() },
+      creationOptions: { cwd: "D:\\foo" },
+    };
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    const mem = createMemento();
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+
+    expect(term.shellIntegration.executeCommand).not.toHaveBeenCalled();
+    expect(term.sendText).not.toHaveBeenCalled();
+    expect(term.dispose).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: Run the new tests to confirm they fail**
+
+```bash
+npx vitest run test/reattachOnStartup.test.ts
+```
+
+Expected: scenarios 1, 2, 5, 8, 9 fail — `_reattachOneSession` is still a stub.
+
+- [ ] **Step 3: Implement `_reattachOneSession` decision logic**
+
+Replace the stub `_reattachOneSession` method in `src/sessionManager.ts`:
+
+```typescript
+  private async _reattachOneSession(
+    session: ActiveSession,
+    deadCwds: string[]
+  ): Promise<void> {
+    // 1. Resolve current PID (await — Thenable)
+    let currentPid: number | undefined;
+    try {
+      currentPid = await session.terminal.processId;
+    } catch {
+      currentPid = undefined;
+    }
+
+    if (currentPid === undefined) {
+      debugLog(`[reattach:one] folderPath=${session.folderPath} pid=undefined — skip`);
+      return;
+    }
+
+    // 2. Read previously-stored PID from workspaceState
+    const record =
+      this._workspaceState.get<Record<string, number>>(PID_KEY) ?? {};
+    const storedPid = record[this._normalizePersistKey(session.folderPath)];
+
+    // 3. PID match → shell survived, refresh record only, no dispatch
+    if (storedPid === currentPid) {
+      debugLog(`[reattach:one] folderPath=${session.folderPath} pid=${currentPid} match — skip dispatch`);
+      this._persistSessionPid(session.folderPath, currentPid);
+      return;
+    }
+
+    // 4. Cwd missing? Dispose and queue for the aggregate toast.
+    //    (Task 8 finishes this branch — for now, fall through to dispatch.)
+    if (!fs.existsSync(session.folderPath)) {
+      debugLog(`[reattach:one] folderPath=${session.folderPath} cwd missing — dispose`);
+      deadCwds.push(session.folderPath);
+      session.terminal.dispose();
+      return;
+    }
+
+    // 5. Fresh shell — dispatch claude, then persist new PID
+    debugLog(`[reattach:one] folderPath=${session.folderPath} stored=${storedPid} current=${currentPid} — dispatch`);
+    await this._dispatchClaudeIntoRestoredTerminal(session.terminal);
+    this._persistSessionPid(session.folderPath, currentPid);
+  }
+```
+
+- [ ] **Step 4: Run the new tests to confirm they pass**
+
+```bash
+npx vitest run test/reattachOnStartup.test.ts
+```
+
+Expected: 7/7 tests pass (scenarios 12, 19 from Task 6 plus 1, 2, 5, 8, 9).
+
+- [ ] **Step 5: Run full lint + test + compile**
+
+```bash
+npm run lint
+npm test
+npm run compile
+```
+
+Expected: all three exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sessionManager.ts test/reattachOnStartup.test.ts
+git commit -m "feat: per-session reattach decision — PID compare + dispatch (#43)
+
+_reattachOneSession reads the stored PID for the session's folder from
+workspaceState, compares against the awaited current PID, and:
+- PID match → skip dispatch but refresh the persistence record
+- PID differ or no stored PID → dispatch via _dispatchClaudeIntoRestoredTerminal,
+  then persist the new PID
+- processId undefined or rejected → skip
+- cwd missing → queue for the aggregate toast and dispose the terminal
+  (the dead-cwd path is finished in the next commit)
+
+5 scenario tests (1, 2, 5, 8, 9 from the design spec) cover each
+decision branch."
+```
+
+---
+
+### Task 8: Cwd-missing handling — aggregate toast + dispose
+
+**Files:**
+- Modify: `test/reattachOnStartup.test.ts` — add scenarios 6, 7
+
+Task 7's implementation already handles cwd-missing by adding to `deadCwds` and disposing. Task 6's orchestrator already shows the aggregate toast. This task verifies both ends and the truncation behavior.
+
+- [ ] **Step 1: Add scenario 6 and 7 tests to `test/reattachOnStartup.test.ts`**
+
+Append inside the `describe` block:
+
+```typescript
+  // Scenario 6: cwd missing for one tab → dispose + single-entry toast
+  it("cwd missing (single tab) → dispose + toast with one folder", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const fs = await import("fs");
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    const term = makeTerminal({ name: "claude · foo", cwd: "D:\\foo", pid: 42 });
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+
+    const sm = new SessionManager(createMemento() as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+
+    expect((term as { dispose: ReturnType<typeof vi.fn> }).dispose).toHaveBeenCalled();
+    expect((term as { sendText: ReturnType<typeof vi.fn> }).sendText).not.toHaveBeenCalled();
+    expect(vscodeMock.window.showInformationMessage).toHaveBeenCalledTimes(1);
+    expect(vscodeMock.window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining("D:\\foo")
+    );
+  });
+
+  // Scenario 7: 5 dead cwds → ONE toast with first 3 names + "and 2 more"
+  it("5 cwds missing → ONE aggregate toast with truncation", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const fs = await import("fs");
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    const folders = ["D:\\a", "D:\\b", "D:\\c", "D:\\d", "D:\\e"];
+    const terms = folders.map((cwd, i) =>
+      makeTerminal({ name: `claude · ${cwd}`, cwd, pid: 100 + i })
+    );
+    (vscodeMock.window as Record<string, unknown>).terminals = terms;
+
+    const sm = new SessionManager(createMemento() as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+
+    // All 5 disposed
+    for (const t of terms) {
+      expect((t as { dispose: ReturnType<typeof vi.fn> }).dispose).toHaveBeenCalled();
+    }
+
+    // ONE toast with first 3 folder names + "and 2 more"
+    expect(vscodeMock.window.showInformationMessage).toHaveBeenCalledTimes(1);
+    const msg = vi.mocked(vscodeMock.window.showInformationMessage).mock.calls[0][0];
+    expect(msg).toContain("D:\\a");
+    expect(msg).toContain("D:\\b");
+    expect(msg).toContain("D:\\c");
+    expect(msg).toContain("and 2 more");
+    // d and e should NOT appear by name
+    expect(msg).not.toContain("D:\\d");
+    expect(msg).not.toContain("D:\\e");
+  });
+```
+
+- [ ] **Step 2: Run the tests to confirm they pass (the implementation is already in place from Tasks 6 + 7)**
+
+```bash
+npx vitest run test/reattachOnStartup.test.ts
+```
+
+Expected: 9/9 tests pass.
+
+- [ ] **Step 3: Run full lint + test + compile**
+
+```bash
+npm run lint
+npm test
+npm run compile
+```
+
+Expected: all three exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/reattachOnStartup.test.ts
+git commit -m "test: cwd-missing aggregation behavior (#43)
+
+Verifies scenarios 6 and 7 from the design spec:
+- 1 dead cwd → 1 toast naming the folder
+- 5 dead cwds → 1 toast with first 3 names + 'and 2 more'
+
+Implementation was added in earlier commits (orchestrator in Task 6,
+per-session dispose in Task 7); these tests lock the contract."
+```
+
+---
+
+### Task 9: Day-1 collision — proactive consent toast
+
+**Files:**
+- Create: `src/onboarding.ts` — encapsulates the first-activation consent flow
+- Modify: `src/extension.ts` — call onboarding before `new SessionManager(...)`
+- Create: `test/onboarding.test.ts` — scenarios 16, 17, 18
+
+The onboarding logic lives in its own module (`src/onboarding.ts`) so it's independently testable without dragging the rest of `extension.ts` into the test setup.
+
+- [ ] **Step 1: Create `test/onboarding.test.ts`**
+
+```typescript
+/**
+ * Tests for the day-1 collision proactive-detection flow (#43, scenarios 16–18).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as vscodeMock from "./mocks/vscode";
+import { createMemento, MementoMock } from "./mocks/vscode";
+import { runReattachOnboarding } from "../src/onboarding";
+
+const ONBOARDING_KEY = "claudeConductor.reattachOnboardingShown";
+
+describe("reattach onboarding (#43)", () => {
+  let globalState: MementoMock;
+  let configUpdate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    globalState = createMemento();
+    configUpdate = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(vscodeMock.workspace, "getConfiguration").mockReturnValue({
+      get: vi.fn(),
+      update: configUpdate,
+    } as unknown as import("vscode").WorkspaceConfiguration);
+  });
+
+  // Scenario 16
+  it("official extension installed + first activation + user clicks Disable → setting set to false, flag set", async () => {
+    vi.mocked(vscodeMock.extensions.getExtension).mockReturnValue(
+      { id: "Anthropic.claude-code" } as unknown as import("vscode").Extension<unknown>
+    );
+    vi.mocked(vscodeMock.window.showInformationMessage).mockResolvedValue(
+      "Disable" as unknown as import("vscode").MessageItem
+    );
+
+    await runReattachOnboarding(globalState as unknown as import("vscode").Memento);
+
+    expect(vscodeMock.window.showInformationMessage).toHaveBeenCalledTimes(1);
+    expect(configUpdate).toHaveBeenCalledWith(
+      "relaunchOnStartup",
+      false,
+      expect.anything() // ConfigurationTarget.Global
+    );
+    expect(globalState._store.get(ONBOARDING_KEY)).toBe(true);
+  });
+
+  // Scenario 16 — user clicks Enable instead → no setting update, flag still set
+  it("official extension installed + Enable click → no setting update, flag set", async () => {
+    vi.mocked(vscodeMock.extensions.getExtension).mockReturnValue(
+      { id: "Anthropic.claude-code" } as unknown as import("vscode").Extension<unknown>
+    );
+    vi.mocked(vscodeMock.window.showInformationMessage).mockResolvedValue(
+      "Enable" as unknown as import("vscode").MessageItem
+    );
+
+    await runReattachOnboarding(globalState as unknown as import("vscode").Memento);
+
+    expect(configUpdate).not.toHaveBeenCalled();
+    expect(globalState._store.get(ONBOARDING_KEY)).toBe(true);
+  });
+
+  // Scenario 17
+  it("no official extension → no toast, flag still set", async () => {
+    vi.mocked(vscodeMock.extensions.getExtension).mockReturnValue(undefined);
+
+    await runReattachOnboarding(globalState as unknown as import("vscode").Memento);
+
+    expect(vscodeMock.window.showInformationMessage).not.toHaveBeenCalled();
+    expect(configUpdate).not.toHaveBeenCalled();
+    expect(globalState._store.get(ONBOARDING_KEY)).toBe(true);
+  });
+
+  // Scenario 18
+  it("already shown → no toast, no flag write, no setting change", async () => {
+    globalState._store.set(ONBOARDING_KEY, true);
+    vi.mocked(vscodeMock.extensions.getExtension).mockReturnValue(
+      { id: "Anthropic.claude-code" } as unknown as import("vscode").Extension<unknown>
+    );
+
+    await runReattachOnboarding(globalState as unknown as import("vscode").Memento);
+
+    expect(vscodeMock.window.showInformationMessage).not.toHaveBeenCalled();
+    expect(configUpdate).not.toHaveBeenCalled();
+    // Flag was already true; no NEW write should happen, but value still true
+    expect(globalState._store.get(ONBOARDING_KEY)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test file to confirm it fails (`runReattachOnboarding` doesn't exist)**
+
+```bash
+npx vitest run test/onboarding.test.ts
+```
+
+Expected: tests fail — module `../src/onboarding` not found.
+
+- [ ] **Step 3: Create `src/onboarding.ts`**
+
+```typescript
+import * as vscode from "vscode";
+
+/** globalState key set after the onboarding toast has been considered. */
+const ONBOARDING_KEY = "claudeConductor.reattachOnboardingShown";
+
+/** Marketplace ID of the official Anthropic Claude Code VS Code extension. */
+const OFFICIAL_CLAUDE_EXT_ID = "Anthropic.claude-code";
+
+/**
+ * First-activation consent flow for the reattach feature (#43).
+ *
+ * If the user has the official Claude Code extension installed AND we have
+ * not yet shown this onboarding toast, surface a one-time prompt asking
+ * them to opt in or out of reattach. Their choice flips
+ * `claudeConductor.relaunchOnStartup` accordingly.
+ *
+ * The flag is set regardless of outcome so the toast appears at most once.
+ * If the user dismisses the toast without clicking, the setting stays at
+ * its default (true).
+ */
+export async function runReattachOnboarding(
+  globalState: vscode.Memento
+): Promise<void> {
+  const alreadyShown = globalState.get<boolean>(ONBOARDING_KEY, false);
+  if (alreadyShown) {
+    return;
+  }
+
+  const officialExt = vscode.extensions.getExtension(OFFICIAL_CLAUDE_EXT_ID);
+  if (!officialExt) {
+    // No collision risk — mark as shown and move on.
+    await globalState.update(ONBOARDING_KEY, true);
+    return;
+  }
+
+  // Surface the consent toast.
+  const message =
+    "Claude Conductor reattaches Claude sessions on VS Code restart by typing " +
+    "`claude` into restored terminal tabs. We detected the official Claude " +
+    "Code extension is also installed — Conductor may inject `claude` into " +
+    "its sessions until issue #33 ships. Enable reattach for Conductor sessions?";
+  const choice = await vscode.window.showInformationMessage(
+    message,
+    "Enable",
+    "Disable"
+  );
+
+  if (choice === "Disable") {
+    await vscode.workspace
+      .getConfiguration("claudeConductor")
+      .update("relaunchOnStartup", false, vscode.ConfigurationTarget.Global);
+  }
+  // "Enable" or dismiss → keep default (true), no setting update needed.
+
+  await globalState.update(ONBOARDING_KEY, true);
+}
+```
+
+- [ ] **Step 4: Wire onboarding into `src/extension.ts`**
+
+Add the import at the top:
+
+```typescript
+import { runReattachOnboarding } from "./onboarding";
+```
+
+In `activate()`, before `sessionManager = new SessionManager(...)`, await the onboarding:
+
+```typescript
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  // First-activation consent gate for reattach feature (#43)
+  await runReattachOnboarding(context.globalState);
+
+  sessionManager = new SessionManager(context.workspaceState);
+  context.subscriptions.push(sessionManager);
+
+  // ... rest of activate body unchanged ...
+```
+
+> **Note**: `activate()` was previously synchronous (returned `void`). The signature change to `async` / `Promise<void>` is supported by VS Code's extension API.
+
+- [ ] **Step 5: Run all tests to confirm onboarding tests pass and nothing else breaks**
+
+```bash
+npx vitest run test/onboarding.test.ts
+npm test
+```
+
+Expected: 4 onboarding tests pass; full suite green.
+
+- [ ] **Step 6: Run lint + compile**
+
+```bash
+npm run lint
+npm run compile
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/onboarding.ts src/extension.ts test/onboarding.test.ts
+git commit -m "feat: day-1 collision onboarding for reattach (#43)
+
+On first activation post-install, if the official Claude Code extension
+(Anthropic.claude-code) is detected, surface a one-time consent toast
+with Enable/Disable buttons. Disable flips claudeConductor.relaunchOnStartup
+to false via workspace config update; Enable or dismiss keeps the default
+(true).
+
+The globalState flag claudeConductor.reattachOnboardingShown ensures the
+toast appears at most once. Without the official extension, the flag is
+set silently — no user-visible behavior.
+
+Onboarding lives in src/onboarding.ts so it's independently testable.
+4 tests cover: Disable click, Enable click, no extension, already-shown."
+```
+
+---
+
+### Task 10: Catch-all integration tests — scenarios 14, 15, 11
+
+**Files:**
+- Modify: `test/reattachOnStartup.test.ts` — add scenarios 14 (AUTO_LAUNCH_KEY ordering), 15 (dispose race), 11 (queue rejection at integration level), 13 (PID cleanup with setting on AND off)
+
+Some of these scenarios test interactions that span multiple subsystems. They're integration-level rather than unit-level and live alongside the orchestrator tests.
+
+- [ ] **Step 1: Add scenarios 11, 13, 14, 15 to `test/reattachOnStartup.test.ts`**
+
+Append inside the `describe` block:
+
+```typescript
+  // Scenario 14: AUTO_LAUNCH_KEY interaction
+  // Reattach dispatches first; AUTO_LAUNCH_KEY launchSession finds the
+  // session and focuses it (no duplicate createTerminal).
+  it("AUTO_LAUNCH_KEY + reattach for the same folder → one dispatch + one focus, no duplicate terminal", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    vi.spyOn(config, "getReuseTerminal").mockReturnValue(true);
+    const executeCommand = vi.fn();
+    const term = makeTerminal({
+      name: "claude · foo",
+      cwd: "D:\\foo",
+      pid: 42,
+      shellIntegration: { executeCommand },
+    });
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    const fs = await import("fs");
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    const mem = createMemento({ [PID_KEY]: { "D:\\foo": 99 } });
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+
+    // Dispatch happened
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    const dispatchCallOrder = executeCommand.mock.invocationCallOrder[0];
+
+    // Now simulate the AUTO_LAUNCH_KEY block — call launchSession for the same folder.
+    // Because reuseExistingTerminal is true, this should focus the existing
+    // session, not create a new terminal.
+    const showSpy = vi.spyOn(term as { show: ReturnType<typeof vi.fn> }, "show");
+    await sm.launchSession("D:\\foo");
+
+    // No new terminal created — createTerminal call count unchanged
+    // (showSpy invocation order is AFTER executeCommand)
+    expect(showSpy).toHaveBeenCalled();
+    const focusCallOrder = showSpy.mock.invocationCallOrder[0];
+    expect(focusCallOrder).toBeGreaterThan(dispatchCallOrder);
+    // No new terminal was created via createTerminal beyond the original
+    expect(vscodeMock.window.createTerminal).not.toHaveBeenCalled();
+  });
+
+  // Scenario 15: dispose racing with reattach
+  it("dispose() mid-reattach → no PID write, no toast, no exception", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    // processId resolves after 50ms — gives us time to dispose mid-await
+    let resolveProcessId: (v: number | undefined) => void;
+    const processIdPromise = new Promise<number | undefined>((r) => {
+      resolveProcessId = r;
+    });
+    const term = {
+      name: "claude · foo",
+      show: vi.fn(),
+      sendText: vi.fn(),
+      dispose: vi.fn(),
+      processId: processIdPromise,
+      shellIntegration: { executeCommand: vi.fn() },
+      creationOptions: { cwd: "D:\\foo" },
+    };
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    const fs = await import("fs");
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    const mem = createMemento();
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+
+    // Dispose immediately — _disposed is now set
+    sm.dispose();
+
+    // Resolve the processId so the routine can complete
+    resolveProcessId!(42);
+
+    // Wait for the routine to settle
+    await (sm as Private)._reattachPromise;
+    await (sm as Private)._pidWriteQueue;
+
+    // No PID write — _persistSessionPid no-ops after dispose()
+    expect(mem.update).not.toHaveBeenCalled();
+    // No toast (gated on !_disposed)
+    expect(vscodeMock.window.showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  // Scenario 11: workspaceState.update rejection mid-chain → queue self-heals
+  it("workspaceState.update rejects once → next persist still succeeds", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const executeCommand = vi.fn();
+    const t1 = makeTerminal({
+      name: "claude · a",
+      cwd: "D:\\a",
+      pid: 1,
+      shellIntegration: { executeCommand },
+    });
+    const t2 = makeTerminal({
+      name: "claude · b",
+      cwd: "D:\\b",
+      pid: 2,
+      shellIntegration: { executeCommand },
+    });
+    (vscodeMock.window as Record<string, unknown>).terminals = [t1, t2];
+    const fs = await import("fs");
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    const mem = createMemento();
+    // First update rejects — second + onward succeed
+    mem.update.mockImplementationOnce(() => Promise.reject(new Error("disk full")));
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+    await (sm as Private)._pidWriteQueue;
+
+    // Both dispatches happened
+    expect(executeCommand).toHaveBeenCalledTimes(2);
+    // The second update succeeded → store has at least t2's PID
+    const stored = mem._store.get(PID_KEY) as Record<string, number>;
+    expect(stored).toBeDefined();
+    // Order isn't guaranteed (parallel), but at least one PID landed
+    expect(Object.keys(stored).length).toBeGreaterThanOrEqual(1);
+  });
+
+  // Scenario 13: PID cleanup runs whether the setting is on or off
+  it("_clearSessionPid runs unconditionally (setting off does not gate close cleanup)", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(false);
+    const term = makeTerminal({ name: "claude · foo", cwd: "D:\\foo", pid: 42 });
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    const mem = createMemento({ [PID_KEY]: { "D:\\foo": 42 } });
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+
+    // Reattach didn't fire (setting off). Now simulate close.
+    (sm as Private)._removeByKey(term);
+    await (sm as Private)._pidWriteQueue;
+
+    // PID cleared even though setting is off
+    expect(mem._store.get(PID_KEY)).toEqual({});
+  });
+```
+
+- [ ] **Step 2: Run the new tests to confirm they pass**
+
+```bash
+npx vitest run test/reattachOnStartup.test.ts
+```
+
+Expected: 13/13 tests pass.
+
+- [ ] **Step 3: Run full lint + test + compile**
+
+```bash
+npm run lint
+npm test
+npm run compile
+```
+
+Expected: all three exit 0. Total test count should be 63 (existing) + 7 (PID persistence) + 3 (dispatch helper) + 13 (reattach orchestration) + 4 (onboarding) = ~90.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/reattachOnStartup.test.ts
+git commit -m "test: AUTO_LAUNCH ordering, dispose race, queue rejection, unconditional clear (#43)
+
+Adds scenarios 11, 13, 14, 15 from the design spec:
+- 14: dispatch precedes focus when reattach + AUTO_LAUNCH_KEY both
+  fire for the same folder; no duplicate terminal
+- 15: dispose() mid-reattach prevents PID write and toast, no exception
+- 11: a single workspaceState.update rejection doesn't poison the
+  queue — subsequent persists land
+- 13: _clearSessionPid runs whether setting is on or off (verifies
+  Decision #3 in the spec)"
+```
+
+---
+
+### Task 11: README + CHANGELOG updates
+
+**Files:**
+- Modify: `README.md` — add reattach to Features, document the setting under Configuration, remove or rewrite "Known Limitations" implying sessions don't survive restart, add Windows shell limitation
+- Modify: `CHANGELOG.md` — entry for the new behavior
+
+- [ ] **Step 1: Update `README.md`**
+
+Read the current README first to find the right sections (Features, Configuration, Known Limitations).
+
+Open `README.md`. Locate the **Features** section. Add a new bullet (preserve the existing markdown style — match neighbors):
+
+```markdown
+- **Reattach on VS Code startup**: when VS Code restarts and Claude session tabs are restored with fresh shells, Conductor automatically dispatches `claude` into each tab so your sessions come back without manual relaunch. Gated by `claudeConductor.relaunchOnStartup` (default `true`).
+```
+
+Locate the **Configuration** section (or the table that lists existing config keys — `claudeCommand`, `reuseExistingTerminal`, `enableNotifications`, etc.). Add an entry for `relaunchOnStartup`:
+
+```markdown
+| `claudeConductor.relaunchOnStartup` | boolean | `true` | When VS Code restarts, dispatch `claude` into restored Conductor session tabs whose inner shell was replaced. Disable if you also use the official Claude Code extension and Conductor mis-fires into its sessions, or on Windows shells (cmd.exe / PowerShell without PSReadLine) where the buffered-input clear-prefix is not interpreted as kill-line. |
+```
+
+(Match the existing table format — column count and separators.)
+
+Locate any **Known Limitations** section. If a bullet says something like "sessions don't survive VS Code restart" or "you'll need to manually relaunch claude after restart" — remove or rewrite it. Add a new bullet covering the Windows shell limitation:
+
+```markdown
+- **Reattach on cmd.exe / PowerShell without PSReadLine**: when the buffered-input clear-prefix on the delay-fallback dispatch path is not interpreted as line-clear (legacy Windows shells without modern line editing), a stray `claude` keystroke could land in any buffered prompt input. Disable `claudeConductor.relaunchOnStartup` if affected.
+```
+
+- [ ] **Step 2: Update `CHANGELOG.md`**
+
+Read the current CHANGELOG. Add a new entry under the unreleased / next-version heading. If there's no unreleased section, add one (the existing release-strategy doc dictates format — preserve it).
+
+```markdown
+## Unreleased
+
+### Added
+
+- **Reattach Claude sessions on VS Code startup** (#43). Conductor now detects restored session tabs whose inner shell was replaced (after a system restart, ptyhost crash, or VS Code with persistent-session revival off) and dispatches `claude` into each tab automatically. Gated by the new `claudeConductor.relaunchOnStartup` setting (default `true`).
+- First-activation consent toast when the official Claude Code extension (`Anthropic.claude-code`) is detected. Lets users opt out of reattach to avoid Conductor injecting keystrokes into the official extension's sessions.
+
+### Notes
+
+- **Windows shell limitation**: the buffered-input clear-prefix used on the delay-fallback dispatch path uses `\u0003\u0015` (Ctrl-C, Ctrl-U), which is interpreted as line-clear on POSIX shells and Windows PowerShell with PSReadLine (the default). On legacy cmd.exe and PowerShell-without-PSReadLine, the clear is a no-op — set `claudeConductor.relaunchOnStartup: false` if affected.
+- **First launch after upgrade**: existing Claude tabs whose shells survived your last VS Code restart may receive a one-time stray `claude` keystroke (no stored PID baseline). Subsequent activations are race-free.
+- **Day-1 collision with the official Claude Code extension**: if you install the official extension *after* Conductor's first activation, the consent toast won't retroactively fire. Set `claudeConductor.relaunchOnStartup: false` manually if needed.
+```
+
+- [ ] **Step 3: Run lint + test + compile to verify nothing broke**
+
+```bash
+npm run lint
+npm test
+npm run compile
+```
+
+Expected: all three exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CHANGELOG.md
+git commit -m "docs: README and CHANGELOG entries for reattach feature (#43)
+
+- README Features: document automatic reattach on restart
+- README Configuration: document claudeConductor.relaunchOnStartup
+- README Known Limitations: rewrite any 'sessions don't survive restart'
+  wording; add Windows cmd.exe / PowerShell-without-PSReadLine
+  limitation note
+- CHANGELOG Unreleased: detailed entry covering the new feature, the
+  setting, the day-1 collision behavior, the buffered-input clear-prefix,
+  and the Windows shell limitation"
+```
+
+---
+
+### Task 12: Final verification, manual smoke test, and PR
+
+**Files:**
+- All — final review
+
+This task closes out the branch by running the full CI-equivalent suite, doing a manual smoke test, and opening the PR.
+
+- [ ] **Step 1: Run the complete CI-equivalent suite**
+
+```bash
+npm run lint     # tsc --noEmit
+npm test         # vitest run
+npm run compile  # tsc -p ./
+```
+
+Expected: all three exit 0. Test count is at least 90 (63 existing + ~27 new across PID persistence, dispatch helper, reattach orchestration, onboarding).
+
+- [ ] **Step 2: Build the VSIX for manual smoke test**
+
+```bash
+npm run package
+```
+
+Expected: `claude-conductor-1.3.0.vsix` (or whatever current version) generated in the worktree root.
+
+- [ ] **Step 3: Install the VSIX into VS Code Extension Dev Host or a clean profile**
+
+Open VS Code → Extensions view → `...` menu → "Install from VSIX…" → select the generated file.
+
+> **Important**: install into a *clean profile* or the Extension Dev Host (F5 from this repo). Do NOT install over your daily-driver Conductor — you want to be able to roll back if anything goes wrong, and the upgrade path is one of the things you want to verify.
+
+- [ ] **Step 4: Manual smoke test**
+
+Run through these scenarios. Each should produce the expected behavior; check off as you go.
+
+  - [ ] Open VS Code with the new build. Open the Claude Conductor sidebar. **No active sessions yet** is fine.
+  - [ ] Launch a new Claude session via the command palette. Confirm a `claude · <folder>` tab opens and `claude` runs inside.
+  - [ ] **VS Code restart**: close VS Code completely, reopen it. The session tab should be restored with `claude` running automatically (because PID matched on the surviving shell, OR fresh shell + dispatch fired).
+  - [ ] **Setting off**: set `claudeConductor.relaunchOnStartup: false` in settings. Restart VS Code. Confirm the restored tab is at a bare prompt — no auto-dispatch.
+  - [ ] **Setting back on**: set `claudeConductor.relaunchOnStartup: true`. Restart VS Code. Confirm dispatch fires (auto-`claude`) on the bare-prompt tab.
+  - [ ] **Reload Window**: with claude running, run "Developer: Reload Window" from the command palette. Confirm claude session is preserved in-place — no stray `claude` keystroke landed in the running session.
+  - [ ] **Dead cwd**: launch a session for a folder, then move/rename the folder on disk while VS Code is closed. Restart VS Code. Confirm the dead-cwd tab is disposed and you see the toast naming the folder.
+  - [ ] **Day-1 onboarding**: if you have the official Claude Code extension installed, on the first activation of this build you should see the consent toast. Click Disable; confirm the setting flipped to false. Reset the `claudeConductor.reattachOnboardingShown` globalState entry (via Developer: Inspect Extension State, or just delete via "View > Command Palette > Developer: Reload Window") to test re-showing if needed.
+
+If any scenario fails, file the failure as a sub-issue against #43 and address before merging.
+
+- [ ] **Step 5: Push the branch**
+
+```bash
+git -C .worktrees/43-reattach-on-startup push -u origin 43-reattach-on-startup
+```
+
+- [ ] **Step 6: Open the PR via the GitHub MCP**
+
+The PR body must contain `Closes #43` as plain text (no backticks), the test plan checklist, and the Claude attribution. The router (Claude Code) typically opens the PR via `mcp__plugin_github_github__create_pull_request`. The body template:
+
+```
+Closes #43.
+
+## Summary
+
+Reattach Claude sessions on VS Code startup by dispatching `claude` into restored terminal tabs whose inner shells were replaced. Implements the v3 design at `docs/superpowers/specs/2026-04-27-43-reattach-on-startup-design.md`.
+
+## Architecture
+
+A new `_reattachRestoredSessions` async pass runs at the end of the `SessionManager` constructor (gated by `claudeConductor.relaunchOnStartup`, default `true`). For each tracked Claude terminal, an async per-session routine compares the awaited current shell PID against a previously-persisted PID for the same folder (stored in `workspaceState`). PID match → skip dispatch (claude survived); PID differ or no-stored-PID → dispatch via `_dispatchClaudeIntoRestoredTerminal` (which clears buffered input on the delay-fallback path); cwd missing → dispose + aggregate toast.
+
+Day-1 collision with the official Claude Code extension is handled proactively via `runReattachOnboarding` in `src/onboarding.ts` — first-activation consent toast with Enable/Disable buttons.
+
+## Test plan
+
+- [x] `npm run lint` — clean
+- [x] `npm test` — full suite passes (90+ tests)
+- [x] `npm run compile` — clean
+- [ ] Manual: VS Code close + reopen restores running claude session in place
+- [ ] Manual: setting=false disables auto-dispatch on restart
+- [ ] Manual: dead-cwd tab disposes with aggregate toast
+- [ ] Manual: day-1 onboarding toast shows when official Claude Code extension is detected on first activation
+
+## Notes
+
+- README and CHANGELOG updated per AC.
+- The `_dispatchClaudeIntoRestoredTerminal` clear-prefix (`\u0003\u0015`) is POSIX-shell semantics; cmd.exe and PowerShell-without-PSReadLine fall back to the setting gate as the recovery mechanism. Documented as a known limitation.
+- See `docs/superpowers/specs/2026-04-27-43-reattach-on-startup-design.md` for full design context including the *Known limitations / deferred* section that lists items intentionally not addressed.
+
+🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*
+```
+
+> **Implementer note**: the router opens the PR with the title `feat: reattach Claude sessions on VS Code startup (#43)` (or similar — keep it under ~70 chars). The body must include `Closes #43` as plain text on its own line, no backticks, otherwise GitHub's parser will skip the closing keyword and the issue will stay open after merge.
+
+- [ ] **Step 7: Verify PR opened and CI passes**
+
+After PR creation, watch CI:
+- `lint-and-test` job: should pass within a few minutes
+- `compile` job: should pass
+
+If CI fails, address the failure on the same branch (do not branch off) and push a fixup commit. Do NOT skip hooks or amend already-pushed commits per CLAUDE.md.
+
+- [ ] **Step 8: Final commit (optional — only if needed for fixes)**
+
+If CI surfaces any issue or the manual smoke test fails, address inline on the branch and push. Once CI is green AND manual smoke test passes, the branch is ready for review and merge.

--- a/docs/superpowers/specs/2026-04-27-43-reattach-on-startup-design.md
+++ b/docs/superpowers/specs/2026-04-27-43-reattach-on-startup-design.md
@@ -1,14 +1,30 @@
 # Design — Reattach Claude sessions on VS Code startup (#43)
 
 **Issue**: [#43](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/43)
-**Date**: 2026-04-27
-**Status**: Approved — ready for implementation planning
+**Date**: 2026-04-27 (revised after inquisitor review)
+**Status**: Awaiting user re-approval
+
+---
+
+## Revision history
+
+This spec was reworked after an adversarial inquisitor review identified five critical bugs and a contradiction with issue #43's stated Acceptance Criteria. Notable changes from the first draft:
+
+- **Setting gate restored**. The first draft removed `claudeConductor.relaunchOnStartup` (default `true`) under a "Conductor completely owns these tabs" framing. The issue's AC explicitly requires this setting; it is restored.
+- **PID write ordering reordered to eliminate the read-after-write race**. Tracking-time PID writes are removed. The reattach-decision step is the only writer at activation.
+- **Buffered-input corruption mitigated**. The reattach call site clears the prompt with `Ctrl-C, Ctrl-U` before the dispatch fallback can commit stray input.
+- **Promise-queue rejection handling added**. Each chain step has its own catch handler so a single `workspaceState.update` rejection doesn't permanently halt the queue.
+- **Persistence key separated from in-memory lookup key**. Persisted under `path.normalize(folderPath)` (case preserved); in-memory lookup remains case-folded.
+- **Aggregate dead-cwd toast** instead of one per dead tab.
+- **Dispose paired with `reconcile()`** to force eviction if `onDidCloseTerminal` is missed.
+- **Test table expanded** to exercise every Error handling row.
+- **README updates** added to Rollout per the issue's AC.
 
 ---
 
 ## Problem
 
-When VS Code restarts (close → reopen, or in some configurations after a ptyhost crash or system restart), terminal **tab envelopes** are restored — name, position, icon, and `creationOptions.cwd` survive — but the inner shell process is sometimes replaced with a fresh one. In that case, a Claude Conductor tab labelled `claude · my-project` reopens with a bare prompt and no `claude` running. The user has to remember which tabs need re-launching and type `claude` manually into each.
+When VS Code restarts (close → reopen, or in some configurations after a `ptyhost` crash or system restart), terminal **tab envelopes** are restored — name, position, icon, and `creationOptions.cwd` survive — but the inner shell process is sometimes replaced with a fresh one. In that case, a Claude Conductor tab labelled `claude · my-project` reopens with a bare prompt and no `claude` running. The user has to remember which tabs need re-launching and type `claude` manually into each.
 
 Claude Conductor already detects these tabs (`SessionManager` constructor iterates `vscode.window.terminals` and calls `_trackIfClaudeSession`). The missing piece is **dispatching `claude` into the restored tab when its shell is fresh**, without firing into a tab whose shell survived (where `claude` is still running and dispatch would inject the literal text `"claude"` as user input).
 
@@ -16,37 +32,45 @@ Claude Conductor already detects these tabs (`SessionManager` constructor iterat
 
 1. After VS Code restart, Claude tabs whose shells were replaced come back to a working `claude` session automatically — no user action required.
 2. Tabs whose shells *survived* (the common case under default persistent-session settings) are left untouched.
-3. Tabs whose `cwd` no longer exists on disk are cleaned up (disposed) with a one-time toast, rather than left as silently-broken bare prompts.
+3. Tabs whose `cwd` no longer exists on disk are cleaned up (disposed) with a one-time aggregate toast, rather than left as silently-broken bare prompts.
+4. Tab position, pinning, and editor-group layout are preserved (per AC).
+5. Users who don't want this behavior can disable it via `claudeConductor.relaunchOnStartup: false` (per AC).
 
 ## Non-goals
 
 - **Restoring Claude's in-conversation memory.** That's an Anthropic-side property of Claude Code itself; this design only restores the *session* (a running `claude` process), not its prior context.
 - **Replacing VS Code's terminal model with a custom PTY.** That's [#44](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/44). This design works inside VS Code's terminal API.
-- **Adopting externally-launched `claude · *` sessions.** That's [#33](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/33). This design's PID-record approach is forward-compatible — externally-launched terminals will get tracked and PID-recorded the same way once #33 picks them up.
+- **Adopting externally-launched `claude · *` sessions.** That's [#33](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/33). This design's PID-record approach is forward-compatible — externally-launched terminals will get tracked and PID-recorded the same way once #33 picks them up. Until then, users with both Conductor and the official Claude Code extension installed should set `claudeConductor.relaunchOnStartup: false` (called out in CHANGELOG).
 - **Changing close-detection.** That's [#68](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/68). PID records and close-detection records are decoupled and don't interact.
+- **Moving or rearranging tabs.** Reattach operates strictly in-place on existing terminal references — `terminal.show()`, dispatch into the terminal, no `moveToEditor` calls. Tab position, pinning, and editor-group placement are inherited from VS Code's restoration.
 
 ## Architecture
 
-A single new "reattach pass" runs at the end of `SessionManager`'s constructor, after the existing tracking loop. For each tracked Claude terminal, an async per-session routine compares the terminal's *current* shell PID against a previously-stored PID for the same folder path. The comparison decides whether to dispatch `claude`:
+A new "reattach pass" runs at the end of `SessionManager`'s constructor, after the existing tracking loop, **gated by `claudeConductor.relaunchOnStartup`**. For each tracked Claude terminal, an async per-session routine compares the terminal's *current* shell PID against a previously-stored PID for the same folder path. The comparison decides whether to dispatch `claude`:
 
 | Current PID vs stored PID | Meaning | Action |
 |---|---|---|
 | Match | Shell process survived across the activation boundary; `claude` is most likely still running | **Skip dispatch** |
-| Differ | Shell was replaced; `claude` is gone | **Dispatch `claude`** (existing 3-tier `_dispatchClaudeCommand`) |
+| Differ | Shell was replaced; `claude` is gone | **Dispatch `claude`** (via reattach helper that clears buffered input first) |
 | No stored PID | First activation post-install, or after `workspaceState` was wiped | **Dispatch `claude`** (Option A — see *Decisions* below) |
 | `processId` resolves to `undefined` or rejects | We can't reason about the shell state | **Skip dispatch** (conservative — better a bare prompt than a stray `"claude"` injected into an active session) |
 
-`workspaceState` is the persistence layer for the PID record. The record is keyed on lower-cased normalized folder path, mirroring the existing case-insensitive `_findSessionByFolder` convention.
+`workspaceState` is the persistence layer for the PID record. The record is keyed on `path.normalize(folderPath)` with **case preserved** (case folding applies only to in-memory lookup, not to the persisted key — see *Persistence vs in-memory key* below).
+
+**Setting gate**: when `claudeConductor.relaunchOnStartup` is `false`, the reattach pass returns immediately without iterating sessions. PID persistence still happens for new launches (so toggling the setting back on later still has accurate baselines).
 
 ## Code surfaces
 
 | File | Change |
 |---|---|
-| `src/sessionManager.ts` | Constructor takes a new `workspaceState: vscode.Memento` arg. New private methods `_reattachRestoredSessions()`, `_persistSessionPid(folderPath, pid)`, `_clearSessionPid(folderPath)`. `_dispatchClaudeCommand` is reused as-is — no need to make it public. |
-| `src/extension.ts` | Pass `context.workspaceState` to `new SessionManager(...)`. One-line change to the existing constructor call. |
-| `package.json` | No new settings (unconditional behavior — see *Decisions*). |
+| `src/sessionManager.ts` | Constructor takes new `workspaceState: vscode.Memento` arg. New private methods `_reattachRestoredSessions()`, `_persistSessionPid(folderPath, pid)`, `_clearSessionPid(folderPath)`, `_dispatchClaudeIntoRestoredTerminal(terminal)`. Existing `_dispatchClaudeCommand` reused. |
+| `src/extension.ts` | Pass `context.workspaceState` to `new SessionManager(...)`. One-line change to constructor call. |
+| `src/config.ts` | Add `getRelaunchOnStartup(): boolean` reading `claudeConductor.relaunchOnStartup`. Default `true`. |
+| `package.json` | Register the `claudeConductor.relaunchOnStartup` boolean configuration property under `contributes.configuration.properties` with default `true` and a description. |
 | `test/reattachOnStartup.test.ts` | New file covering the scenarios in *Test coverage* below. |
-| `CHANGELOG.md` | Note the one-time stray-`claude` cost on first activation post-upgrade for users with surviving shells (see *Rollout*). |
+| `test/mocks/vscode.ts` | Add `Memento` mock if not already present (for `workspaceState`). |
+| `README.md` | Update *Features* section: document reattach behavior. Update *Configuration* section: document the new setting. Remove/update any "Known Limitations" wording that implies sessions don't survive restart. |
+| `CHANGELOG.md` | Note the new behavior, the new setting, and the day-1 caveat for users running the official Claude Code extension alongside Conductor. |
 
 ### Why a method on `SessionManager` and not a top-level activation step
 
@@ -60,8 +84,8 @@ Keeps the lifecycle-management logic colocated with the terminal-tracking logic 
 
 ### Activation order
 
-1. Existing constructor loop iterates `vscode.window.terminals` and calls `_trackIfClaudeSession` on each — same as today.
-2. **NEW**: After that loop, `_reattachRestoredSessions()` is invoked. It iterates `_sessions.values()` and for each entry kicks off an async per-session reattach routine. All routines run in parallel via `Promise.allSettled` (no `await` blocks the constructor — terminal output appears as the async routines complete).
+1. Existing constructor loop iterates `vscode.window.terminals` and calls `_trackIfClaudeSession` on each — same as today. **Note**: tracking-time PID writes are *removed* from `_trackIfClaudeSession`; only the in-memory `_pidToTerminal` index is populated, not `workspaceState`. This is the fix for the read-after-write race that the inquisitor identified.
+2. **NEW**: After that loop, if `getRelaunchOnStartup()` returns `true`, `_reattachRestoredSessions()` is invoked. It iterates `_sessions.values()` and kicks off an async per-session routine for each. All routines run via `Promise.allSettled` (no `await` blocks the constructor).
 3. The constructor returns synchronously. Tree views, status bar, etc. bind to a populated `_sessions` map immediately.
 4. The existing `AUTO_LAUNCH_KEY` block in `extension.ts` (lines 94–97) still fires after construction. Because `launchSession` checks `getReuseTerminal()` and finds the just-tracked session, it focuses instead of creating — no double-dispatch.
 
@@ -70,54 +94,106 @@ Keeps the lifecycle-management logic colocated with the terminal-tracking logic 
 ```
 1. await terminal.processId          → currentPid (number | undefined)
 2. read stored PID for folderPath    → storedPid (number | undefined)
+                                       (read from workspaceState — only PREVIOUS
+                                        activation's writes are present, since
+                                        this activation's tracking-time writes
+                                        were removed)
 3. if currentPid === undefined       → log and skip (can't make a decision)
 4. if storedPid === currentPid       → shell survived, claude likely running, skip
-5. if !fs.existsSync(folderPath)     → dispose tab + toast "Could not restore session for <folder> — folder no longer exists"
-6. else                              → call _dispatchClaudeCommand(terminal)
-7. always (steps 4 and 6)            → _persistSessionPid(folderPath, currentPid)
+                                       BUT still call _persistSessionPid(folderPath, currentPid)
+                                       to keep the record fresh for next activation
+5. if !fs.existsSync(folderPath)     → enqueue folderPath into a "dead-cwd" list,
+                                       call terminal.dispose() + reconcile()
+                                       (toast is shown ONCE at end of reattach,
+                                        aggregating all dead cwds)
+6. else                              → call _dispatchClaudeIntoRestoredTerminal(terminal),
+                                       then _persistSessionPid(folderPath, currentPid)
 ```
 
-Step 7 also runs on the survival branch (4) so `workspaceState` is refreshed every activation — keeps the record current even when no dispatch was needed.
+After all routines settle, if any dead-cwd folders were collected:
 
-### PID persistence lifecycle
+```
+7. show ONE showInformationMessage:
+   "Could not restore N session(s) — folder(s) no longer exist: a, b, c"
+   (truncate folder list to first 3, append "and N more" if needed)
+```
 
-| Event | Action |
-|---|---|
-| Session tracked (in `_trackIfClaudeSession`, after `terminal.processId` resolves) | Call `_persistSessionPid(folderPath, pid)` — writes the new entry into `workspaceState` |
-| Session closed (in `_removeByKey`) | Call `_clearSessionPid(folderPath)` — removes the entry. Closed sessions shouldn't leave PID ghosts in state |
-| Reattach decision (step 7 above) | Refresh after every dispatch decision |
+### `_dispatchClaudeIntoRestoredTerminal` — the buffered-input mitigation
 
-### State shape
+The existing `_dispatchClaudeCommand` was designed for the launch path where the terminal was *just created* and is at a clean prompt. For restored terminals, the prompt may have buffered input the user typed before closing VS Code (e.g., a partial `ls -`), and the existing helper's delay-fallback path (`terminal.sendText("claude")`) would commit `ls -claude` to the shell.
 
-Stored under the key `claudeConductor.sessionPids` in `workspaceState`. Type: `Record<string, number>`. Keys are lower-cased normalized folder paths (matching the existing `_findSessionByFolder` convention: `path.normalize(folderPath).toLowerCase()`).
+The reattach call site uses a wrapper that clears any buffered input first:
 
 ```ts
-// Example
-{
-  "i:\\projects\\career-ops": 12345,
-  "i:\\projects\\notes": 67890
+private async _dispatchClaudeIntoRestoredTerminal(terminal: vscode.Terminal): Promise<void> {
+  // Clear any buffered prompt input. Ctrl-C signals the running shell (no-op if
+  // nothing is running); Ctrl-U clears the current line. On a clean prompt this
+  // is a no-op. On a dirty prompt this is a save.
+  // The `false` arg to sendText suppresses the trailing newline — we don't want
+  // to commit anything yet.
+  terminal.sendText("\u0003\u0015", false);
+  // Small breather so the shell processes the clear before we dispatch.
+  await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  await this._dispatchClaudeCommand(terminal);
 }
 ```
 
-### Write serialization
+The 50ms delay is imperceptible and applies even when `_dispatchClaudeCommand` takes the shell-integration fast path. This is acceptable cost for preventing the silent corruption case.
 
-`_persistSessionPid` and `_clearSessionPid` perform read-modify-write on the single shared `claudeConductor.sessionPids` record. Multiple reattach routines run in parallel and each session's tracking-time PID resolution can also fire concurrently, so concurrent writes would race and clobber each other.
+### PID persistence lifecycle
 
-The implementation **must serialize** these writes through an internal promise queue:
+Writes happen at exactly three points — chosen to eliminate the read-after-write race the first draft introduced:
+
+| Event | Action |
+|---|---|
+| Reattach decision (steps 4 and 6 above) | Call `_persistSessionPid(folderPath, currentPid)` |
+| New session launched (after `launchSession` creates a terminal and its `processId` resolves) | Call `_persistSessionPid(folderPath, pid)` |
+| Session closed (in `_removeByKey`) | Call `_clearSessionPid(folderPath)` — removes the entry |
+
+**No tracking-time writes.** `_trackIfClaudeSession` populates the in-memory `_pidToTerminal` index but does not touch `workspaceState`. This is the structural fix for the race: the reattach read at step 2 sees only the previous activation's writes, never this activation's.
+
+### Persistence vs in-memory key
+
+The persisted record is `Record<string, number>` keyed on **`path.normalize(folderPath)`** (case preserved). The in-memory `_findSessionByFolder` lookup continues to use lowercased keys for Windows-friendly matching.
+
+| Use | Key form | Why |
+|---|---|---|
+| `workspaceState["claudeConductor.sessionPids"][...]` (persistence) | `path.normalize(folderPath)` — case preserved | On case-sensitive filesystems (Linux, macOS, NFS), `D:\Project` and `D:\project` are distinct directories that must not collide in the record |
+| `_findSessionByFolder` (in-memory lookup) | `path.normalize(folderPath).toLowerCase()` | On Windows, the user may pass either case; in-memory matching should be case-insensitive |
+
+This is intentional asymmetry, not an oversight. The implementation must keep them separate.
+
+### Write serialization (with rejection handling)
+
+`_persistSessionPid` and `_clearSessionPid` perform read-modify-write on the single shared `claudeConductor.sessionPids` record. Multiple reattach routines and concurrent `launchSession` flows can race on this without serialization.
+
+The implementation serializes writes through an internal promise queue **with explicit rejection handling** so a single `workspaceState.update` failure doesn't permanently halt the queue:
 
 ```ts
 private _pidWriteQueue: Promise<void> = Promise.resolve();
 
 private _persistSessionPid(folderPath: string, pid: number): void {
-  this._pidWriteQueue = this._pidWriteQueue.then(async () => {
-    const current = this._workspaceState.get<Record<string, number>>(PID_KEY) ?? {};
-    current[folderPath] = pid;
-    await this._workspaceState.update(PID_KEY, current);
-  });
+  if (this._disposed) return;
+  this._pidWriteQueue = this._pidWriteQueue
+    .catch(() => undefined)  // swallow prior rejection so chain doesn't stay broken
+    .then(async () => {
+      try {
+        const current = this._workspaceState.get<Record<string, number>>(PID_KEY) ?? {};
+        current[this._normalizePersistKey(folderPath)] = pid;
+        await this._workspaceState.update(PID_KEY, current);
+      } catch (err) {
+        log(`[reattach] failed to persist PID for ${folderPath}: ${String(err)}`);
+        // Swallow — the next call will retry the write under fresh conditions.
+      }
+    });
 }
 ```
 
-Writes complete in order; reads inside the chain see the latest persisted record. Acceptable cost — these writes are infrequent and small.
+Each step has its own try/catch so a transient failure (host I/O error, disk full, schema validation rejection) is logged and the queue continues. The leading `.catch(() => undefined)` ensures even a rejection from the *previous* step doesn't poison the next step.
+
+The `_normalizePersistKey` helper is `path.normalize(folderPath)` (no `.toLowerCase()`), per *Persistence vs in-memory key* above.
+
+The `_disposed` guard prevents a stale `_persistSessionPid` call from a still-resolving async routine from writing to a disposed `Memento` after `SessionManager.dispose()` was invoked.
 
 ## Error handling
 
@@ -125,23 +201,30 @@ Writes complete in order; reads inside the chain see the latest persisted record
 |---|---|
 | `terminal.processId` resolves to `undefined` | Log via `debugLog`, skip dispatch. Conservative — without a PID we can't compare, so we don't risk text injection. |
 | `terminal.processId` rejects | Same as above — skip with a debug log. |
-| `fs.existsSync(folderPath)` returns false | `terminal.dispose()` + `vscode.window.showInformationMessage` with the toast text. The dispose triggers existing close-detection cleanup, so `_sessions` and the PID record both clear automatically via `_handleTerminalClose` → `_removeByKey`. |
-| `_dispatchClaudeCommand` falls through to delay-fallback `sendText` (existing 3-tier path) | Already handled by the existing implementation — terminal sees `claude` keystrokes after the `claudeConductor.launchDelayMs` delay (default 500 ms). Worst case: user gets a slightly slower reattach. Same behavior as new launches today. |
-| `workspaceState` returns wrong-typed data (e.g., user manually edited it, or schema changed) | Defensive: treat as "no stored PID" → fall through to first-install path → dispatch. |
-| Concurrent reattach + new launch race | Won't happen in practice — `launchSession` is only called from user-initiated commands, which can't fire during synchronous constructor execution. The async reattach routines complete naturally before any user input is possible. |
+| `terminal.processId` resolves but the value is the transient bootstrap shell PID rather than the restored shell | Mitigated, not eliminated. If shell integration appears within the slow-path window, the dispatch uses the (safe) shell-integration `executeCommand`; the buffered-input clear-prefix is a no-op when the prompt is clean. The PID-vs-storedPID comparison may be wrong in this narrow window, but the worst case is a stray `claude` keystroke (matched on stale PID) — already documented as the Option-A first-install cost. |
+| `fs.existsSync(folderPath)` returns false | Add to dead-cwd list, call `terminal.dispose()` followed by `reconcile()`. The aggregate toast at the end of reattach surfaces all dead cwds at once. The explicit `reconcile()` call ensures `_sessions` and the PID record are evicted even if `onDidCloseTerminal` does not fire (which the existing close-detection infrastructure already accounts for). |
+| `_dispatchClaudeCommand` falls through to delay-fallback `sendText` | Already handled by the existing implementation — terminal sees `claude` keystrokes after the `claudeConductor.launchDelayMs` delay (default 500 ms). The `_dispatchClaudeIntoRestoredTerminal` wrapper has already cleared buffered input via `Ctrl-C, Ctrl-U`, so the `claude` keystroke commits cleanly. |
+| `workspaceState` returns wrong-typed data | Defensive: treat as "no stored PID" → fall through to first-install path → dispatch. |
+| `workspaceState.update` rejection | Caught and logged within the chain step (see *Write serialization* above). The next write retries under fresh conditions. The queue does not stay broken. |
+| `SessionManager.dispose()` called mid-reattach | The per-session routine completes its work but `_persistSessionPid` no-ops because `_disposed` is set. No write to a disposed `Memento`. |
+| Concurrent reattach + new launch race | Won't happen in practice — `launchSession` is only called from user-initiated commands, which can't fire during synchronous constructor execution. |
 
 ### `AUTO_LAUNCH_KEY` coordination (intentional, not a bug)
 
 When VS Code is opened via a `vscode://` URI for a folder that *also* has a restored Claude tab, both reattach (from the constructor) and `AUTO_LAUNCH_KEY` (from `activate()` in `extension.ts`) fire. The reattach pass dispatches `claude` into the restored tab; then `AUTO_LAUNCH_KEY`'s `launchSession` call finds the now-tracked session and `focusSession`s it instead of creating a duplicate. Net effect: one terminal, one dispatch, one focus. **Intentional and correct** — flagged here so it's not "fixed" by mistake later.
 
-## Decisions made during brainstorming
+## Decisions
 
-These design decisions were resolved during the 2026-04-27 brainstorm:
+These design decisions were resolved during the 2026-04-27 brainstorm and re-affirmed (or revised) after the inquisitor review:
 
-1. **PID comparison is the discriminator** — not "what triggered activation?" The right question is "did the shell process survive?", and PID identity answers it uniformly across VS Code close/open, Reload Window, ptyhost crashes, and system restarts.
-2. **Unconditional behavior — no setting gate.** Reattach is a core property of how Conductor manages sessions. Following the strategic intent of "Conductor completely owns these tabs," there's no `claudeConductor.reattachOnStartup` setting; the behavior just happens.
-3. **Dispose + toast on dead `cwd`.** When a restored tab's `cwd` no longer exists, `terminal.dispose()` removes the tab and a one-time toast informs the user. Cleaner than leaving a silently-broken bare prompt with a non-existent working directory.
-4. **No-stored-PID → dispatch** (Option A). On first activation post-install (or after `workspaceState` reset), absence of a record is treated as "fresh shell, never seen before" and dispatch proceeds. Cost of being wrong is bounded: a one-time stray `"claude"` line in an active session, recoverable by the user. Cost of the alternative ("don't dispatch without positive evidence") is much worse — the feature appears broken on first impression.
+1. **PID comparison is the discriminator** — not "what triggered activation?" The right question is "did the shell process survive?", and PID identity answers it well in the common cases (VS Code close/open, Reload Window, ptyhost crashes, system restarts). The narrow timing-window failure (transient bootstrap PID resolving before the restored shell is wired) is mitigated by the buffered-input clear-prefix and the shell-integration safe-path.
+2. **Setting gate restored** (revised from first draft). `claudeConductor.relaunchOnStartup`, default `true`. Per issue #43's AC. Provides the recovery path for any user-machine-specific reattach regression.
+3. **Dispose + aggregate toast on dead `cwd`** (revised from first draft). When a restored tab's `cwd` no longer exists, `terminal.dispose()` + `reconcile()` removes the tab and clears state. A single aggregate toast is shown at the end of reattach when one or more cwds were dead, listing up to three folders.
+4. **No-stored-PID → dispatch** (Option A). On first activation post-install (or after `workspaceState` reset), absence of a record is treated as "fresh shell, never seen before" and dispatch proceeds. Cost of being wrong is bounded — and reduced further by the buffered-input clear-prefix. Cost of the alternative ("don't dispatch without positive evidence") is much worse — the feature appears broken on first impression. Mitigated by the setting gate: any user who hits the false-positive case can disable.
+5. **Write serialization with rejection handling**. The `_pidWriteQueue` chain pattern, with each step wrapped in its own try/catch and a leading `.catch` swallow, ensures durability under transient failures and avoids the silent-halt failure mode the inquisitor identified.
+6. **Persistence key is `path.normalize` only — not lowercased**. In-memory lookups remain case-folded for Windows ergonomics; persistence preserves case for cross-platform correctness.
+
+The "Conductor completely owns these tabs" framing from the first draft is removed from *Decisions* and demoted to an informative note in *Future direction*. It is descriptive of where the codebase is heading toward #44; it is not load-bearing on this PR's scope.
 
 ## Test coverage
 
@@ -149,47 +232,61 @@ New file: `test/reattachOnStartup.test.ts`.
 
 | # | Scenario | Setup | Assert |
 |---|---|---|---|
-| 1 | Same PID → no dispatch | Mock `vscode.window.terminals` with one `claude · foo` terminal whose `processId` resolves to `42`. Mock `workspaceState.get` to return `{ "/path/to/foo": 42 }`. Construct `SessionManager`. | `createTerminal` not called; `executeCommand("workbench.action.terminal.moveToEditor")` not called; the existing terminal is **not** sent any text via `sendText` or shell-integration `executeCommand`. |
-| 2 | Different PID → dispatch via shell-integration fast path | Same setup, but stored PID is `99`. Mock `terminal.shellIntegration.executeCommand`. | `terminal.shellIntegration.executeCommand("claude")` called once. PID `42` written to `workspaceState`. |
-| 3 | Different PID → dispatch via slow path | Same as 2, but `terminal.shellIntegration` is `undefined` initially. Fire `onDidChangeTerminalShellIntegration` after a short delay with `{ terminal, shellIntegration }`. | `shellIntegration.executeCommand("claude")` called once via the slow-path branch. |
-| 4 | Different PID → dispatch via delay fallback | Same as 2, but neither shell-integration path fires (no event). Use vitest's fake timers. | `terminal.sendText("claude")` called after the configured delay. |
+| 1 | Same PID → no dispatch | Mock one `claude · foo` terminal whose `processId` resolves to `42`. Mock `workspaceState.get` to return `{ "/path/to/foo": 42 }`. Setting on. | `createTerminal` not called. No `sendText` / shell-integration `executeCommand` calls on the existing terminal. PID `42` re-persisted (record refreshed). |
+| 2 | Different PID → dispatch via shell-integration fast path | Same setup, stored PID `99`. Mock `terminal.shellIntegration.executeCommand`. | The buffered-input clear-prefix `\u0003\u0015` is sent (via `sendText` with `addNewLine: false`), then after 50ms `terminal.shellIntegration.executeCommand("claude")` is called once. PID `42` written. |
+| 3 | Different PID → dispatch via slow path | Same as 2, but `shellIntegration` is `undefined` initially; fire `onDidChangeTerminalShellIntegration` after a short delay. | Clear-prefix sent. Then slow path resolves and `executeCommand("claude")` is called once. |
+| 4 | Different PID → dispatch via delay fallback | Same as 2, but no shell-integration ever activates. Use vitest fake timers. | Clear-prefix sent (no newline). After `launchDelayMs`, `terminal.sendText("claude")` is called (with the implicit newline from the default `addNewLine: true`). |
 | 5 | No stored PID → dispatch | Stored map is empty. | Same dispatch behavior as scenario 2. PID written after dispatch. |
-| 6 | Cwd missing → dispose + toast | Mock `fs.existsSync(folderPath)` to return false. | `terminal.dispose()` called. `vscode.window.showInformationMessage` called once with text containing the folder name. No `sendText` / `executeCommand("claude")` calls. |
-| 7 | `processId` resolves to `undefined` | Mock `terminal.processId` to resolve undefined. | No dispatch, no dispose. Debug log emitted. State unchanged. |
-| 8 | Multiple restored sessions in parallel | Three `claude · *` terminals, all with PID mismatches. | All three see their dispatch path called. After all routines settle, `workspaceState.update` reflects all three new PIDs (no clobber — verifies the write-queue serialization). |
-| 9 | PID cleanup on close | Track + dispatch a session, then dispose its terminal. | `workspaceState.update` called with the entry removed. |
-| 10 | `AUTO_LAUNCH_KEY` flow + reattach | Restored terminal for folder F + `AUTO_LAUNCH_KEY` set to F. | One dispatch (from reattach), one focus (from auto-launch's `launchSession` reuse path). No duplicate `createTerminal`. |
+| 6 | Cwd missing (single tab) → dispose + aggregate toast (with one entry) | One terminal, mock `fs.existsSync` to return false. | `terminal.dispose()` called. `reconcile()` called. After all routines settle, `vscode.window.showInformationMessage` called once with text containing the folder name. No clear-prefix. No `claude` dispatch. |
+| 7 | Multiple cwds missing → ONE aggregate toast | Three terminals, all with dead cwds. | Three `dispose()` calls. **One** `showInformationMessage` call, listing the three folder names. (If list grows beyond 3, truncated with "and N more".) |
+| 8 | `processId` resolves to `undefined` | Mock `terminal.processId` to resolve undefined. | No dispatch, no dispose. Debug log emitted. State unchanged. |
+| 9 | `processId` rejects | Mock `terminal.processId` to reject. | Same as 8 — no dispatch, no dispose, debug log. |
+| 10 | Multiple restored sessions in parallel — no PID race | Three `claude · *` terminals, all with PID mismatches. | All three dispatch. After all routines settle, `workspaceState.update` final state reflects all three new PIDs. Verifies the write queue serializes correctly. |
+| 11 | `workspaceState.update` rejects mid-chain | Stub `workspaceState.update` to reject once, then succeed on next call. | Subsequent `_persistSessionPid` calls succeed (queue not poisoned). Error logged. |
+| 12 | Setting off → reattach is a no-op | `getRelaunchOnStartup()` returns false. Three restored terminals tracked. | No `_reattachRestoredSessions` work performed. No dispatches, no toast, no PID writes. Tracking still happens (existing constructor loop). |
+| 13 | PID cleanup on close | Track + dispatch a session, then dispose its terminal. | `workspaceState.update` called with the entry removed. |
+| 14 | `AUTO_LAUNCH_KEY` flow + reattach for the same folder | Restored terminal for folder F + `AUTO_LAUNCH_KEY` set to F. | One dispatch (from reattach), one focus (from auto-launch's `launchSession` reuse path). No duplicate `createTerminal`. |
+| 15 | Deactivation racing with reattach | Construct `SessionManager`, immediately call `dispose()` while async routines are mid-await. Mock `terminal.processId` with a 100ms delay. | After routines resolve, `workspaceState.update` is **not** called (the `_disposed` guard prevents writes). No exceptions thrown. |
 
 ### Mock strategy
 
 - Reuse the existing `test/mocks/vscode.ts` patterns (already used by `addFolderPrompt.stale.test.ts` from PR #73 and the existing `hookInstaller` tests).
 - Add a `Memento` mock for `workspaceState`: `{ get, update, keys }` with an internal `Map<string, unknown>` backing store. Generic enough to live alongside the existing mocks.
-- `terminal.processId` is mocked as `Promise.resolve(<number>)` per-test.
+- `terminal.processId` is mocked as `Promise.resolve(<number>)` per-test. For scenario 15, use a delayed promise.
 - `vi.mock("fs")` for the cwd-existence test (same pattern as the #71 test).
 
-Existing tests stay untouched — the change is additive to `SessionManager`'s constructor, behind a new method that doesn't fire unless a tracked terminal exists at construction time.
+Existing tests stay untouched — the change is additive.
 
 ## Rollout
 
-- **No setting** → no migration.
+- **Setting default** is `true` per AC, so the feature is on for everyone after upgrade. Users who don't want it set `claudeConductor.relaunchOnStartup: false` — the gate makes the feature recoverable without a new release.
 - **First activation after upgrade**: any user who currently has restored Claude tabs sitting at bare prompts will see them auto-dispatch. Users with surviving shells (PIDs match → no dispatch) won't see a behavioral change.
-- **Edge — surviving shells, no stored PIDs**: users upgrading from a pre-#43 version have no persisted PIDs in `workspaceState` yet, so the first activation post-upgrade falls into the "no stored PID → dispatch" branch (Option A above). For users whose shells *did* survive and where claude *is* still running, this means a one-time stray `"claude"` gets sent into the active Claude session per terminal. That's the documented cost of Option A; surfaces once per existing session per upgrade, then never again.
-- **Mention this in the CHANGELOG** so users aren't surprised. Single bullet under the version entry: *"Sessions are now reattached on VS Code startup. On the first launch after upgrade, an existing tab with `claude` already running may receive a stray `claude` keystroke; subsequent launches won't."*
+- **Edge — surviving shells, no stored PIDs**: users upgrading from a pre-#43 version have no persisted PIDs in `workspaceState` yet, so the first activation post-upgrade falls into the "no stored PID → dispatch" branch (Option A). For users whose shells *did* survive and where claude *is* still running, this means a one-time stray `"claude"` per terminal — *but* the buffered-input clear-prefix means it won't corrupt buffered shell input, and the setting provides a recovery path. Subsequent activations are race-free.
+- **Day-1 collision warning** (CHANGELOG): if you also use the official Claude Code VS Code extension, set `claudeConductor.relaunchOnStartup: false` until #33 lands — Conductor's reattach can't yet distinguish its own restored sessions from sessions opened by the official extension.
+- **README updates** (per AC):
+  - *Features*: document the reattach behavior.
+  - *Configuration*: document `claudeConductor.relaunchOnStartup`.
+  - *Known Limitations*: remove (or rewrite) any wording implying sessions don't survive VS Code restart.
+- **CHANGELOG**: note the new feature, the new setting, the day-1 caveat, and the buffered-input clear-prefix as a defensive behavior.
 
 ## Future direction (informative — not part of this PR)
 
-### Strategic note on tab ownership
-
-The unconditional-default and dispose-on-dead-cwd choices reflect a strategic intent surfaced during the brainstorm: **Conductor should completely own Claude session tabs**, rather than passively observing whatever VS Code's terminal API does. This PR is a step toward that: it makes Conductor the active manager of session lifecycle. Future design decisions in this area should default to "Conductor decides" rather than "Conductor adapts to VS Code." Capturing the rationale here so it doesn't get diluted later.
-
 ### #44 — custom PTY wrapper
 
-Once #44 is on the table (Conductor owns the PTY directly), this entire reattach pass collapses into "the Conductor process is alive across VS Code restarts; tabs re-bind to live PTYs without dispatching anything." The work in this PR is not wasted — it makes the per-tab lifecycle ownership explicit, which is a precondition for #44. But the implementation surface (PID record, dispatch logic) will be replaced wholesale by the PTY-ownership design.
+Once #44 is on the table (Conductor owns the PTY directly), this entire reattach pass collapses into "the Conductor process is alive across VS Code restarts; tabs re-bind to live PTYs without dispatching anything." The work in this PR is not wasted — it makes the per-tab lifecycle ownership explicit, which is a precondition for #44. The implementation surface (PID record, dispatch logic) will be replaced wholesale by the PTY-ownership design.
 
 ### #33 — externally-launched session adoption
 
-The PID-record approach is forward-compatible. When #33 picks up `claude · *` terminals that were not created by us, they will be tracked the same way and PID-recorded the same way. The reattach survival check works identically for them — no code change needed in this design's surface to support that future work.
+The PID-record approach is forward-compatible. When #33 picks up `claude · *` terminals that were not created by us, they will be tracked the same way and PID-recorded the same way. The reattach survival check works identically for them — no code change needed in this design's surface to support that future work. Until #33 lands, the day-1 collision risk is mitigated by the user-facing setting (per AC).
 
 ### #68 — close-detection spike
 
 This design does not change close-detection paths. The PID record is keyed on folder path and is cleared on close-detection eviction (via `_removeByKey` → `_clearSessionPid`), so the two systems are decoupled.
+
+### Activation latency / progress signal
+
+Worst case for a heavy user with many restored tabs and no shell integration: the slow path can fire several routines in parallel, each waiting up to 2s + 500ms delay-fallback. During that window, the tree view shows tracked sessions whose `claude` is not yet dispatched. Adding a `dispatchState: "pending" | "ready"` field on `ActiveSession` and rendering "reattaching..." in the tree view would close this UX gap. Not in scope for this PR — flagged as a follow-up if the latency surfaces in user feedback.
+
+### Tab-ownership framing
+
+The first draft of this spec leaned on a "Conductor completely owns these tabs" principle to discharge AC #4. The inquisitor flagged this as misleading: this design *observes* VS Code's terminal restoration and *types into* whatever shell VS Code chose to spawn — Conductor does not control envelope creation, shell selection, or persistence. True ownership is what #44 proposes. The framing is informative for the trajectory but is not load-bearing on this PR's scope, and AC #4's setting gate is restored regardless.

--- a/docs/superpowers/specs/2026-04-27-43-reattach-on-startup-design.md
+++ b/docs/superpowers/specs/2026-04-27-43-reattach-on-startup-design.md
@@ -1,24 +1,32 @@
 # Design — Reattach Claude sessions on VS Code startup (#43)
 
 **Issue**: [#43](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/43)
-**Date**: 2026-04-27 (revised after inquisitor review)
-**Status**: Awaiting user re-approval
+**Date**: 2026-04-27 (revised v3 after second inquisitor pass)
+**Status**: Awaiting user approval (round 3)
 
 ---
 
 ## Revision history
 
-This spec was reworked after an adversarial inquisitor review identified five critical bugs and a contradiction with issue #43's stated Acceptance Criteria. Notable changes from the first draft:
+- **v1** (initial brainstorm output) — first design draft.
+- **v2** (post-inquisitor pass 1) — restored the `claudeConductor.relaunchOnStartup` setting gate (was deleted in v1, contradicted issue #43 AC #4); eliminated PID write-ordering race by removing tracking-time writes; added Ctrl-C/Ctrl-U clear-prefix for buffered-input; rejection handling on the PID write queue; case-preserved persistence keys; aggregate dead-cwd toast; expanded test table; demoted "completely own these tabs" framing.
+- **v3** (this revision, post-inquisitor pass 2) — see *Changes from v2* below.
 
-- **Setting gate restored**. The first draft removed `claudeConductor.relaunchOnStartup` (default `true`) under a "Conductor completely owns these tabs" framing. The issue's AC explicitly requires this setting; it is restored.
-- **PID write ordering reordered to eliminate the read-after-write race**. Tracking-time PID writes are removed. The reattach-decision step is the only writer at activation.
-- **Buffered-input corruption mitigated**. The reattach call site clears the prompt with `Ctrl-C, Ctrl-U` before the dispatch fallback can commit stray input.
-- **Promise-queue rejection handling added**. Each chain step has its own catch handler so a single `workspaceState.update` rejection doesn't permanently halt the queue.
-- **Persistence key separated from in-memory lookup key**. Persisted under `path.normalize(folderPath)` (case preserved); in-memory lookup remains case-folded.
-- **Aggregate dead-cwd toast** instead of one per dead tab.
-- **Dispose paired with `reconcile()`** to force eviction if `onDidCloseTerminal` is missed.
-- **Test table expanded** to exercise every Error handling row.
-- **README updates** added to Rollout per the issue's AC.
+### Changes from v2
+
+| # | Change | Why |
+|---|---|---|
+| 1 | Specify `_normalizePersistKey` on **both** write and read paths; state explicitly that `_sessions[…].folderPath` is case-preserved | v2 named the helper only on the write side; an implementer could mismatch read/write keys and silently miss every record |
+| 2 | Restructure clear-prefix: send only **on the delay-fallback path** (not before all dispatch attempts) | The `\u0003\u0015` (Ctrl-C, Ctrl-U) sequence is POSIX-shell semantics; cmd.exe and PowerShell-without-PSReadLine do not interpret it as kill-line. Restricting the clear to delay-fallback means shell-integration paths use safe `executeCommand` boundaries, and the cmd.exe limitation is documented rather than hidden |
+| 3 | Name `_reattachRestoredSessions` as `async`; specify it awaits its own `Promise.allSettled`; gate the toast on `!_disposed` | v2 said "after all routines settle" without naming who awaits — left orchestration unspecified |
+| 4 | Add explicit AC name-rename trail (`claudeSessions.*` → `claudeConductor.*` per PR #51) | Issue AC literal predates the rename; spec wording was correct but trail was missing |
+| 5 | Specify `_clearSessionPid` runs **unconditionally** on session close; only `_reattachRestoredSessions` is gated by `relaunchOnStartup` | Prevents stale-baseline corruption when user toggles the setting `false → true` |
+| 6 | Drop the explicit immediate `reconcile()` call from the dead-cwd path | `terminal.dispose()` already fires `_handleTerminalClose` → `_removeByKey`. Existing 2s poll catches the rare missed-event case. Belt-and-suspenders adds complexity without value |
+| 7 | Add proactive day-1 collision detection — first-activation consent toast when the official Claude Code extension is installed | Don't bury the only mitigation in CHANGELOG. Surface the choice to the user when it's relevant |
+| 8 | Snapshot `_sessions.values()` at entry to `_reattachRestoredSessions` (don't iterate the live map) | Prevents `onDidOpenTerminal` mid-iteration mutation in the rare case a new session opens during the reattach window |
+| 9 | Test #14 asserts dispatch-before-focus call ordering | v2 only asserted counts — ordering regressions wouldn't be caught |
+| 10 | Inline cleanups: comment precision; assert exact `sendText` arg count; `_clearSessionPid` also has `_disposed` guard; explicit acknowledgement that the constructor signature change requires updating existing-test setup | Tightens the test contract and removes inaccuracies |
+| 11 | New *Known limitations / deferred* cluster | Captures the inquisitor's theoretical concerns we deliberately defer (Memento timeout, mock parameterization, terminal.show race, unbounded queue) so a future maintainer sees the explicit decision trail |
 
 ---
 
@@ -35,14 +43,15 @@ Claude Conductor already detects these tabs (`SessionManager` constructor iterat
 3. Tabs whose `cwd` no longer exists on disk are cleaned up (disposed) with a one-time aggregate toast, rather than left as silently-broken bare prompts.
 4. Tab position, pinning, and editor-group layout are preserved (per AC).
 5. Users who don't want this behavior can disable it via `claudeConductor.relaunchOnStartup: false` (per AC).
+6. Users who also have the **official Claude Code extension** installed get a one-time consent prompt on first activation, so Conductor doesn't silently inject `claude` keystrokes into someone else's session.
 
 ## Non-goals
 
 - **Restoring Claude's in-conversation memory.** That's an Anthropic-side property of Claude Code itself; this design only restores the *session* (a running `claude` process), not its prior context.
 - **Replacing VS Code's terminal model with a custom PTY.** That's [#44](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/44). This design works inside VS Code's terminal API.
-- **Adopting externally-launched `claude · *` sessions.** That's [#33](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/33). This design's PID-record approach is forward-compatible — externally-launched terminals will get tracked and PID-recorded the same way once #33 picks them up. Until then, users with both Conductor and the official Claude Code extension installed should set `claudeConductor.relaunchOnStartup: false` (called out in CHANGELOG).
+- **Adopting externally-launched `claude · *` sessions.** That's [#33](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/33). This design's PID-record approach is forward-compatible — externally-launched terminals will get tracked and PID-recorded the same way once #33 picks them up.
 - **Changing close-detection.** That's [#68](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/68). PID records and close-detection records are decoupled and don't interact.
-- **Moving or rearranging tabs.** Reattach operates strictly in-place on existing terminal references — `terminal.show()`, dispatch into the terminal, no `moveToEditor` calls. Tab position, pinning, and editor-group placement are inherited from VS Code's restoration.
+- **Moving or rearranging tabs.** Reattach operates strictly in-place on existing terminal references — no `moveToEditor` calls. Tab position, pinning, and editor-group placement are inherited from VS Code's restoration.
 
 ## Architecture
 
@@ -50,31 +59,41 @@ A new "reattach pass" runs at the end of `SessionManager`'s constructor, after t
 
 | Current PID vs stored PID | Meaning | Action |
 |---|---|---|
-| Match | Shell process survived across the activation boundary; `claude` is most likely still running | **Skip dispatch** |
-| Differ | Shell was replaced; `claude` is gone | **Dispatch `claude`** (via reattach helper that clears buffered input first) |
+| Match | Shell process survived; `claude` likely still running | **Skip dispatch** |
+| Differ | Shell was replaced; `claude` is gone | **Dispatch `claude`** (delay-fallback path clears buffered input first; see *Buffered-input mitigation*) |
 | No stored PID | First activation post-install, or after `workspaceState` was wiped | **Dispatch `claude`** (Option A — see *Decisions* below) |
-| `processId` resolves to `undefined` or rejects | We can't reason about the shell state | **Skip dispatch** (conservative — better a bare prompt than a stray `"claude"` injected into an active session) |
+| `processId` resolves to `undefined` or rejects | Can't reason about shell state | **Skip dispatch** (better a bare prompt than a stray `"claude"` injected into an active session) |
 
-`workspaceState` is the persistence layer for the PID record. The record is keyed on `path.normalize(folderPath)` with **case preserved** (case folding applies only to in-memory lookup, not to the persisted key — see *Persistence vs in-memory key* below).
+`workspaceState` is the persistence layer for the PID record. Both **read** and **write** paths use the same key-normalization helper:
 
-**Setting gate**: when `claudeConductor.relaunchOnStartup` is `false`, the reattach pass returns immediately without iterating sessions. PID persistence still happens for new launches (so toggling the setting back on later still has accurate baselines).
+```ts
+private _normalizePersistKey(folderPath: string): string {
+  return path.normalize(folderPath);   // case preserved — see Persistence vs in-memory key
+}
+```
+
+`_sessions[…].folderPath` is also stored in the case-preserved `path.normalize(folderPath)` form. The reattach routine, iterating `_sessions.values()` snapshots, has access to the correct case-preserved folder path for the persistence read.
+
+**Setting gate**: when `claudeConductor.relaunchOnStartup` is `false`, the reattach pass returns immediately without iterating sessions. PID persistence still happens for new launches via `launchSession`, AND `_clearSessionPid` runs unconditionally on session close (regardless of setting), so toggling the setting back on later still has accurate baselines.
 
 ## Code surfaces
 
 | File | Change |
 |---|---|
-| `src/sessionManager.ts` | Constructor takes new `workspaceState: vscode.Memento` arg. New private methods `_reattachRestoredSessions()`, `_persistSessionPid(folderPath, pid)`, `_clearSessionPid(folderPath)`, `_dispatchClaudeIntoRestoredTerminal(terminal)`. Existing `_dispatchClaudeCommand` reused. |
-| `src/extension.ts` | Pass `context.workspaceState` to `new SessionManager(...)`. One-line change to constructor call. |
+| `src/sessionManager.ts` | Constructor takes new `workspaceState: vscode.Memento` arg. New private methods `_reattachRestoredSessions()` (async), `_persistSessionPid(folderPath, pid)`, `_clearSessionPid(folderPath)`, `_dispatchClaudeIntoRestoredTerminal(terminal)`, `_normalizePersistKey(folderPath)`. Existing `_dispatchClaudeCommand` reused. |
+| `src/extension.ts` | Pass `context.workspaceState` to `new SessionManager(...)`. Add **first-activation consent flow** (see *Day-1 collision: proactive detection* below) before constructing `SessionManager`. |
 | `src/config.ts` | Add `getRelaunchOnStartup(): boolean` reading `claudeConductor.relaunchOnStartup`. Default `true`. |
 | `package.json` | Register the `claudeConductor.relaunchOnStartup` boolean configuration property under `contributes.configuration.properties` with default `true` and a description. |
 | `test/reattachOnStartup.test.ts` | New file covering the scenarios in *Test coverage* below. |
-| `test/mocks/vscode.ts` | Add `Memento` mock if not already present (for `workspaceState`). |
-| `README.md` | Update *Features* section: document reattach behavior. Update *Configuration* section: document the new setting. Remove/update any "Known Limitations" wording that implies sessions don't survive restart. |
-| `CHANGELOG.md` | Note the new behavior, the new setting, and the day-1 caveat for users running the official Claude Code extension alongside Conductor. |
+| `test/mocks/vscode.ts` | Add `Memento` mock if not already present (for `workspaceState`). The mock must support per-call return-value control (e.g., via vitest's `mockImplementationOnce`) so scenario 11 can express "reject once, then succeed." |
+| `README.md` | Update *Features*, *Configuration*, and remove/update any "Known Limitations" implying sessions don't survive restart. |
+| `CHANGELOG.md` | Note the new feature, the new setting, the day-1 collision behavior. |
+
+> **Test-suite migration note**: the constructor signature change (`new SessionManager()` → `new SessionManager(workspaceState)`) requires updating every existing test that constructs a `SessionManager`. The "additive change" framing from v1 was inaccurate; existing tests need a mock-Memento argument added to their setup. Plan accordingly.
 
 ### Why a method on `SessionManager` and not a top-level activation step
 
-Keeps the lifecycle-management logic colocated with the terminal-tracking logic that already lives in `SessionManager`. The class already owns the `_sessions` map, the `_pidToTerminal` map, and the close-detection state machine. Adding the reattach pass to the same surface keeps the abstraction boundary clean: any future redesign (e.g., #44's PTY wrapper) replaces this entire surface as a unit, rather than scattering startup logic across `extension.ts`.
+Keeps lifecycle-management logic colocated with the terminal-tracking logic that already lives in `SessionManager`. The class already owns `_sessions`, `_pidToTerminal`, and the close-detection state machine. Adding the reattach pass to the same surface keeps the abstraction boundary clean: any future redesign (e.g., #44's PTY wrapper) replaces this entire surface as a unit.
 
 ### Why a single batch pass at the end of the constructor, not inline in `_trackIfClaudeSession`
 
@@ -82,92 +101,111 @@ Keeps the lifecycle-management logic colocated with the terminal-tracking logic 
 
 ## Lifecycle
 
-### Activation order
+### Activation order (in `extension.ts`'s `activate()`)
 
-1. Existing constructor loop iterates `vscode.window.terminals` and calls `_trackIfClaudeSession` on each — same as today. **Note**: tracking-time PID writes are *removed* from `_trackIfClaudeSession`; only the in-memory `_pidToTerminal` index is populated, not `workspaceState`. This is the fix for the read-after-write race that the inquisitor identified.
-2. **NEW**: After that loop, if `getRelaunchOnStartup()` returns `true`, `_reattachRestoredSessions()` is invoked. It iterates `_sessions.values()` and kicks off an async per-session routine for each. All routines run via `Promise.allSettled` (no `await` blocks the constructor).
-3. The constructor returns synchronously. Tree views, status bar, etc. bind to a populated `_sessions` map immediately.
+1. **First-activation consent gate** — if no prior PID record exists in `workspaceState` AND the official Claude Code extension is installed (see *Day-1 collision* below), surface a consent toast and either set `claudeConductor.relaunchOnStartup` true/false based on user response, OR proceed with default `true` if the user dismisses without choosing. Mark the onboarding as shown so this runs at most once.
+2. Construct `new SessionManager(context.workspaceState)`. The constructor:
+   - Iterates `vscode.window.terminals` and calls `_trackIfClaudeSession` on each (existing behavior). **Note**: tracking-time writes to `workspaceState` are NOT performed here. Only `_pidToTerminal` is populated.
+   - Calls `_reattachRestoredSessions()` (fire-and-forget — see step 3) if `getRelaunchOnStartup()` returns `true`.
+3. `_reattachRestoredSessions` is `async` and **owns its own orchestration**:
+   - Captures a synchronous **snapshot** of `_sessions.values()` at entry (defensive against `onDidOpenTerminal` firing mid-iteration).
+   - Kicks off per-session routines and `await Promise.allSettled(...)` on them.
+   - Collects dead-cwd folders during the routines.
+   - After `allSettled`, if `!this._disposed` AND any dead-cwd folders were collected, shows ONE aggregate `showInformationMessage` listing first 3 folders + "and N more" if needed.
+   - Returns. Caller (the constructor) does not await.
 4. The existing `AUTO_LAUNCH_KEY` block in `extension.ts` (lines 94–97) still fires after construction. Because `launchSession` checks `getReuseTerminal()` and finds the just-tracked session, it focuses instead of creating — no double-dispatch.
 
 ### Per-session async reattach routine
 
 ```
 1. await terminal.processId          → currentPid (number | undefined)
-2. read stored PID for folderPath    → storedPid (number | undefined)
-                                       (read from workspaceState — only PREVIOUS
-                                        activation's writes are present, since
-                                        this activation's tracking-time writes
-                                        were removed)
+2. read stored PID                   → storedPid = workspaceState[
+                                         _normalizePersistKey(session.folderPath)]
+                                       (Reads only the PREVIOUS activation's writes,
+                                        since this activation's tracking-time writes
+                                        were removed.)
 3. if currentPid === undefined       → log and skip (can't make a decision)
-4. if storedPid === currentPid       → shell survived, claude likely running, skip
-                                       BUT still call _persistSessionPid(folderPath, currentPid)
-                                       to keep the record fresh for next activation
-5. if !fs.existsSync(folderPath)     → enqueue folderPath into a "dead-cwd" list,
-                                       call terminal.dispose() + reconcile()
-                                       (toast is shown ONCE at end of reattach,
-                                        aggregating all dead cwds)
+4. if storedPid === currentPid       → shell survived, skip dispatch.
+                                       Still call _persistSessionPid(folderPath, currentPid)
+                                       to refresh the record.
+5. if !fs.existsSync(folderPath)     → enqueue folderPath into routine-local deadCwds[]
+                                       array, call terminal.dispose().
+                                       (No explicit reconcile() — _handleTerminalClose
+                                        handles eviction; existing 2s poll catches misses.)
 6. else                              → call _dispatchClaudeIntoRestoredTerminal(terminal),
                                        then _persistSessionPid(folderPath, currentPid)
 ```
 
-After all routines settle, if any dead-cwd folders were collected:
+After `Promise.allSettled` completes (in step 3 of *Activation order*), the orchestrator surfaces the aggregate dead-cwd toast.
 
-```
-7. show ONE showInformationMessage:
-   "Could not restore N session(s) — folder(s) no longer exist: a, b, c"
-   (truncate folder list to first 3, append "and N more" if needed)
-```
+### `_dispatchClaudeIntoRestoredTerminal` — buffered-input mitigation
 
-### `_dispatchClaudeIntoRestoredTerminal` — the buffered-input mitigation
+The existing `_dispatchClaudeCommand` was designed for the launch path where the terminal is *just created* and at a clean prompt. Restored terminals may have buffered prompt input the user typed before closing VS Code (e.g., a partial `ls -`). The shell-integration paths (`executeCommand`) handle command boundaries safely — but the **delay-fallback path** (`terminal.sendText("claude")`) appends to whatever's at the prompt, which would commit `ls -claude\n`.
 
-The existing `_dispatchClaudeCommand` was designed for the launch path where the terminal was *just created* and is at a clean prompt. For restored terminals, the prompt may have buffered input the user typed before closing VS Code (e.g., a partial `ls -`), and the existing helper's delay-fallback path (`terminal.sendText("claude")`) would commit `ls -claude` to the shell.
-
-The reattach call site uses a wrapper that clears any buffered input first:
+The mitigation sends a clear-prefix **only on the delay-fallback path**, not before the entire dispatch:
 
 ```ts
 private async _dispatchClaudeIntoRestoredTerminal(terminal: vscode.Terminal): Promise<void> {
-  // Clear any buffered prompt input. Ctrl-C signals the running shell (no-op if
-  // nothing is running); Ctrl-U clears the current line. On a clean prompt this
-  // is a no-op. On a dirty prompt this is a save.
-  // The `false` arg to sendText suppresses the trailing newline — we don't want
-  // to commit anything yet.
-  terminal.sendText("\u0003\u0015", false);
-  // Small breather so the shell processes the clear before we dispatch.
+  // Variant of _dispatchClaudeCommand for restored terminals: shell-integration
+  // paths are safe (executeCommand handles command boundaries). The clear-prefix
+  // only fires on the delay-fallback path (no shell integration), so it doesn't
+  // race against shell-integration's executeCommand.
+
+  // Fast path — shell integration already active. Safe; no clear needed.
+  if (terminal.shellIntegration) {
+    terminal.shellIntegration.executeCommand(getClaudeCommand());
+    return;
+  }
+
+  // Slow path — wait up to 2 s for shell integration to activate.
+  const integrated = await this._waitForShellIntegration(terminal, 2000);
+  if (integrated) {
+    integrated.executeCommand(getClaudeCommand());
+    return;
+  }
+
+  // Delay fallback — no shell integration. CLEAR-PREFIX REQUIRED HERE.
+  //  (Ctrl-C) signals the running foreground command (no-op on a clean prompt).
+  //  (Ctrl-U) clears the current input line on POSIX shells, bash/zsh/fish,
+  // and PowerShell with PSReadLine (default keybindings).
+  // On legacy cmd.exe and PowerShell-without-PSReadLine these are not interpreted
+  // as line-clear — see "Known limitations" below.
+  terminal.sendText("\u0003\u0015", false);   // false = no trailing newline
   await new Promise<void>((resolve) => setTimeout(resolve, 50));
-  await this._dispatchClaudeCommand(terminal);
+  terminal.sendText(getClaudeCommand());      // newline implicit (default)
 }
 ```
 
-The 50ms delay is imperceptible and applies even when `_dispatchClaudeCommand` takes the shell-integration fast path. This is acceptable cost for preventing the silent corruption case.
+The 50ms breather is sufficient for the PTY to consume the clear bytes before the dispatch text arrives. Because the clear only fires on the delay-fallback (no shell integration), it never races against shell-integration's `executeCommand` — that race surface is removed by construction.
+
+**Known limitation — Windows shell behavior**: on cmd.exe and PowerShell-without-PSReadLine, `\u0003\u0015` is not interpreted as kill-line. If a user on those shells has buffered prompt input AND is on the delay-fallback path AND the bug fires, the dispatched `claude` keystroke may corrupt the line. Mitigation: the user can set `claudeConductor.relaunchOnStartup: false`. Documented in CHANGELOG and README. The setting gate is the recovery mechanism.
 
 ### PID persistence lifecycle
 
-Writes happen at exactly three points — chosen to eliminate the read-after-write race the first draft introduced:
+Writes happen at exactly three points — chosen to eliminate the read-after-write race that v1 introduced:
 
-| Event | Action |
-|---|---|
-| Reattach decision (steps 4 and 6 above) | Call `_persistSessionPid(folderPath, currentPid)` |
-| New session launched (after `launchSession` creates a terminal and its `processId` resolves) | Call `_persistSessionPid(folderPath, pid)` |
-| Session closed (in `_removeByKey`) | Call `_clearSessionPid(folderPath)` — removes the entry |
+| Event | Action | Setting-gated? |
+|---|---|---|
+| Reattach decision (steps 4 and 6 above) | Call `_persistSessionPid(folderPath, currentPid)` | Yes (entire reattach pass is gated) |
+| New session launched (after `launchSession` creates a terminal and its `processId` resolves) | Call `_persistSessionPid(folderPath, pid)` | **No** — runs unconditionally |
+| Session closed (in `_removeByKey`) | Call `_clearSessionPid(folderPath)` | **No** — runs unconditionally |
 
-**No tracking-time writes.** `_trackIfClaudeSession` populates the in-memory `_pidToTerminal` index but does not touch `workspaceState`. This is the structural fix for the race: the reattach read at step 2 sees only the previous activation's writes, never this activation's.
+**Critical**: `_clearSessionPid` is **never** gated by `relaunchOnStartup`. Otherwise, when a user toggles the setting `false → true`, the persisted record contains stale entries for tabs the user closed during the off period — and reattach decisions get made against stale baselines.
 
 ### Persistence vs in-memory key
 
-The persisted record is `Record<string, number>` keyed on **`path.normalize(folderPath)`** (case preserved). The in-memory `_findSessionByFolder` lookup continues to use lowercased keys for Windows-friendly matching.
-
 | Use | Key form | Why |
 |---|---|---|
-| `workspaceState["claudeConductor.sessionPids"][...]` (persistence) | `path.normalize(folderPath)` — case preserved | On case-sensitive filesystems (Linux, macOS, NFS), `D:\Project` and `D:\project` are distinct directories that must not collide in the record |
-| `_findSessionByFolder` (in-memory lookup) | `path.normalize(folderPath).toLowerCase()` | On Windows, the user may pass either case; in-memory matching should be case-insensitive |
+| `workspaceState["claudeConductor.sessionPids"][...]` (persistence read AND write) | `_normalizePersistKey(folderPath)` = `path.normalize(folderPath)` — **case preserved** | On case-sensitive filesystems (Linux, macOS, NFS), `D:\Project` and `D:\project` are distinct directories that must not collide |
+| `_findSessionByFolder` (in-memory lookup only) | `path.normalize(folderPath).toLowerCase()` | On Windows, the user may pass either case; in-memory matching should be case-insensitive |
 
-This is intentional asymmetry, not an oversight. The implementation must keep them separate.
+`_sessions[…].folderPath` itself is the case-preserved form (matches what's stored on the in-memory entry), so the reattach pass iterating `_sessions.values()` already has the right form for the persistence read. **Both `_persistSessionPid` and the reattach-pass read use `_normalizePersistKey` — never lowercase the persisted key.**
 
 ### Write serialization (with rejection handling)
 
 `_persistSessionPid` and `_clearSessionPid` perform read-modify-write on the single shared `claudeConductor.sessionPids` record. Multiple reattach routines and concurrent `launchSession` flows can race on this without serialization.
 
-The implementation serializes writes through an internal promise queue **with explicit rejection handling** so a single `workspaceState.update` failure doesn't permanently halt the queue:
+The implementation serializes writes through an internal promise queue **with explicit rejection handling**:
 
 ```ts
 private _pidWriteQueue: Promise<void> = Promise.resolve();
@@ -183,17 +221,46 @@ private _persistSessionPid(folderPath: string, pid: number): void {
         await this._workspaceState.update(PID_KEY, current);
       } catch (err) {
         log(`[reattach] failed to persist PID for ${folderPath}: ${String(err)}`);
-        // Swallow — the next call will retry the write under fresh conditions.
+        // Swallow — the next call will retry under fresh conditions.
+      }
+    });
+}
+
+private _clearSessionPid(folderPath: string): void {
+  if (this._disposed) return;
+  this._pidWriteQueue = this._pidWriteQueue
+    .catch(() => undefined)
+    .then(async () => {
+      try {
+        const current = this._workspaceState.get<Record<string, number>>(PID_KEY) ?? {};
+        delete current[this._normalizePersistKey(folderPath)];
+        await this._workspaceState.update(PID_KEY, current);
+      } catch (err) {
+        log(`[reattach] failed to clear PID for ${folderPath}: ${String(err)}`);
       }
     });
 }
 ```
 
-Each step has its own try/catch so a transient failure (host I/O error, disk full, schema validation rejection) is logged and the queue continues. The leading `.catch(() => undefined)` ensures even a rejection from the *previous* step doesn't poison the next step.
+The leading `.catch(() => undefined)` ensures even a rejection from the previous step doesn't poison the next step. Both methods have the `_disposed` guard. See *Known limitations / deferred* below for what we explicitly aren't guarding against.
 
-The `_normalizePersistKey` helper is `path.normalize(folderPath)` (no `.toLowerCase()`), per *Persistence vs in-memory key* above.
+## Day-1 collision: proactive detection
 
-The `_disposed` guard prevents a stale `_persistSessionPid` call from a still-resolving async routine from writing to a disposed `Memento` after `SessionManager.dispose()` was invoked.
+Issue [#33](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/33) covers adopting externally-launched `claude · *` terminals (e.g., from the official Claude Code VS Code extension `Anthropic.claude-code`). Until #33 lands, Conductor's reattach can't distinguish its own restored tabs from terminals opened by the official extension. With `relaunchOnStartup: true` as default, a user with both extensions installed could see Conductor inject a stray `claude` keystroke into the official extension's session on first activation.
+
+**Mitigation**: on first activation post-install (detected via a new `claudeConductor.reattachOnboardingShown: boolean` in `globalState`, default `false`):
+
+1. If `vscode.extensions.getExtension('Anthropic.claude-code')` returns a defined value AND `globalState.get('claudeConductor.reattachOnboardingShown')` is falsy:
+2. Show a `vscode.window.showInformationMessage` with two action buttons:
+   > "Claude Conductor reattaches Claude sessions on VS Code restart by typing `claude` into restored terminal tabs. We detected the official Claude Code extension is also installed — Conductor may inject `claude` into its sessions until #33 ships. Enable reattach for Conductor sessions?"
+   - **"Enable" (default)**: leave `claudeConductor.relaunchOnStartup: true` (the default).
+   - **"Disable"**: set `claudeConductor.relaunchOnStartup: false` via `vscode.workspace.getConfiguration().update(...)`.
+3. If the user dismisses the toast without clicking, leave the setting at its default and proceed.
+4. Always set `globalState.update('claudeConductor.reattachOnboardingShown', true)` regardless of choice — the toast appears at most once.
+
+If the official extension is NOT installed, mark onboarding as shown without prompting (no need to bother the user). This means a user who later installs the official extension does NOT get a retroactive toast — they get the CHANGELOG note as a fallback. That's an accepted limitation: proactive detection runs once.
+
+> **Implementer note on extension ID**: `Anthropic.claude-code` is the marketplace publisher.name for the official extension at the time of writing. Verify against the live marketplace listing before shipping; treat as configurable in case Anthropic renames.
 
 ## Error handling
 
@@ -201,30 +268,31 @@ The `_disposed` guard prevents a stale `_persistSessionPid` call from a still-re
 |---|---|
 | `terminal.processId` resolves to `undefined` | Log via `debugLog`, skip dispatch. Conservative — without a PID we can't compare, so we don't risk text injection. |
 | `terminal.processId` rejects | Same as above — skip with a debug log. |
-| `terminal.processId` resolves but the value is the transient bootstrap shell PID rather than the restored shell | Mitigated, not eliminated. If shell integration appears within the slow-path window, the dispatch uses the (safe) shell-integration `executeCommand`; the buffered-input clear-prefix is a no-op when the prompt is clean. The PID-vs-storedPID comparison may be wrong in this narrow window, but the worst case is a stray `claude` keystroke (matched on stale PID) — already documented as the Option-A first-install cost. |
-| `fs.existsSync(folderPath)` returns false | Add to dead-cwd list, call `terminal.dispose()` followed by `reconcile()`. The aggregate toast at the end of reattach surfaces all dead cwds at once. The explicit `reconcile()` call ensures `_sessions` and the PID record are evicted even if `onDidCloseTerminal` does not fire (which the existing close-detection infrastructure already accounts for). |
-| `_dispatchClaudeCommand` falls through to delay-fallback `sendText` | Already handled by the existing implementation — terminal sees `claude` keystrokes after the `claudeConductor.launchDelayMs` delay (default 500 ms). The `_dispatchClaudeIntoRestoredTerminal` wrapper has already cleared buffered input via `Ctrl-C, Ctrl-U`, so the `claude` keystroke commits cleanly. |
+| `terminal.processId` resolves but value is the transient bootstrap shell PID rather than the restored shell | Mitigated, not eliminated. Shell-integration paths use safe `executeCommand` boundaries. The buffered-input clear-prefix (delay-fallback only) limits damage. The PID-vs-storedPID comparison may be wrong in this narrow window; worst case is a stray `claude` keystroke, already documented as the Option-A first-install cost. |
+| `fs.existsSync(folderPath)` returns false | Add to dead-cwd list, call `terminal.dispose()`. Existing close-detection (`_handleTerminalClose` → `_removeByKey`) handles eviction. The aggregate toast at end of reattach surfaces all dead cwds at once. |
+| `_dispatchClaudeCommand` falls through to delay-fallback `sendText` | The reattach variant clears buffered input via `\u0003\u0015` first (POSIX-safe; documented Windows limitations above). |
 | `workspaceState` returns wrong-typed data | Defensive: treat as "no stored PID" → fall through to first-install path → dispatch. |
-| `workspaceState.update` rejection | Caught and logged within the chain step (see *Write serialization* above). The next write retries under fresh conditions. The queue does not stay broken. |
-| `SessionManager.dispose()` called mid-reattach | The per-session routine completes its work but `_persistSessionPid` no-ops because `_disposed` is set. No write to a disposed `Memento`. |
+| `workspaceState.update` rejection | Caught and logged within the chain step. Next write retries under fresh conditions. Queue does not stay broken. |
+| `SessionManager.dispose()` called mid-reattach | Per-session routines complete their work but `_persistSessionPid` and `_clearSessionPid` no-op because `_disposed` is set. Toast also gated by `_disposed`. |
 | Concurrent reattach + new launch race | Won't happen in practice — `launchSession` is only called from user-initiated commands, which can't fire during synchronous constructor execution. |
 
 ### `AUTO_LAUNCH_KEY` coordination (intentional, not a bug)
 
-When VS Code is opened via a `vscode://` URI for a folder that *also* has a restored Claude tab, both reattach (from the constructor) and `AUTO_LAUNCH_KEY` (from `activate()` in `extension.ts`) fire. The reattach pass dispatches `claude` into the restored tab; then `AUTO_LAUNCH_KEY`'s `launchSession` call finds the now-tracked session and `focusSession`s it instead of creating a duplicate. Net effect: one terminal, one dispatch, one focus. **Intentional and correct** — flagged here so it's not "fixed" by mistake later.
+When VS Code is opened via a `vscode://` URI for a folder that *also* has a restored Claude tab, both reattach (from the constructor) and `AUTO_LAUNCH_KEY` (from `activate()` in `extension.ts`) fire. The reattach pass dispatches `claude` into the restored tab; then `AUTO_LAUNCH_KEY`'s `launchSession` call finds the now-tracked session and `focusSession`s it instead of creating a duplicate. **Intentional and correct** — flagged here so it's not "fixed" by mistake later.
 
 ## Decisions
 
-These design decisions were resolved during the 2026-04-27 brainstorm and re-affirmed (or revised) after the inquisitor review:
+1. **PID comparison is the discriminator**. PID identity answers "did the shell process survive?" well in the common cases (VS Code close/open, Reload Window, ptyhost crashes, system restarts). Narrow timing-window failures (transient bootstrap PID) are mitigated by shell-integration safe-paths and the buffered-input clear-prefix.
+2. **Setting gate restored** per AC #4. `claudeConductor.relaunchOnStartup`, default `true`. AC text predates PR #51's rename from `claudeSessions.*` to `claudeConductor.*`; the current convention is the correct one.
+3. **`_clearSessionPid` runs unconditionally on close**. Only the reattach-pass itself is gated by the setting. This prevents stale baselines on `false → true` toggle.
+4. **Dispose + aggregate toast on dead `cwd`** with up to 3 folder names + "and N more". One toast per reattach pass, not one per dead tab.
+5. **No-stored-PID → dispatch** (Option A). On first activation post-install, absence of a record is treated as "fresh shell." Cost of being wrong is bounded (one stray `claude` keystroke, recoverable). Cost of the alternative ("don't dispatch without positive evidence") is much worse — the feature appears broken on first impression.
+6. **Day-1 collision is proactively detected**. First-activation consent toast when `Anthropic.claude-code` extension is detected; CHANGELOG note as the fallback for installed-after-Conductor cases.
+7. **Clear-prefix is delay-fallback only**. Removes the race against shell-integration `executeCommand` and acknowledges the Windows-cmd.exe limitation honestly rather than papering over it.
+8. **Persisted key is `path.normalize` only — not lowercased**. In-memory lookups remain case-folded for Windows ergonomics; persistence preserves case for cross-platform correctness.
+9. **Write queue with rejection handling but without timeout**. The chain pattern self-heals from transient failures via per-step catches. We do NOT add a `Promise.race` timeout for hung `Memento.update` — see *Known limitations / deferred*.
 
-1. **PID comparison is the discriminator** — not "what triggered activation?" The right question is "did the shell process survive?", and PID identity answers it well in the common cases (VS Code close/open, Reload Window, ptyhost crashes, system restarts). The narrow timing-window failure (transient bootstrap PID resolving before the restored shell is wired) is mitigated by the buffered-input clear-prefix and the shell-integration safe-path.
-2. **Setting gate restored** (revised from first draft). `claudeConductor.relaunchOnStartup`, default `true`. Per issue #43's AC. Provides the recovery path for any user-machine-specific reattach regression.
-3. **Dispose + aggregate toast on dead `cwd`** (revised from first draft). When a restored tab's `cwd` no longer exists, `terminal.dispose()` + `reconcile()` removes the tab and clears state. A single aggregate toast is shown at the end of reattach when one or more cwds were dead, listing up to three folders.
-4. **No-stored-PID → dispatch** (Option A). On first activation post-install (or after `workspaceState` reset), absence of a record is treated as "fresh shell, never seen before" and dispatch proceeds. Cost of being wrong is bounded — and reduced further by the buffered-input clear-prefix. Cost of the alternative ("don't dispatch without positive evidence") is much worse — the feature appears broken on first impression. Mitigated by the setting gate: any user who hits the false-positive case can disable.
-5. **Write serialization with rejection handling**. The `_pidWriteQueue` chain pattern, with each step wrapped in its own try/catch and a leading `.catch` swallow, ensures durability under transient failures and avoids the silent-halt failure mode the inquisitor identified.
-6. **Persistence key is `path.normalize` only — not lowercased**. In-memory lookups remain case-folded for Windows ergonomics; persistence preserves case for cross-platform correctness.
-
-The "Conductor completely owns these tabs" framing from the first draft is removed from *Decisions* and demoted to an informative note in *Future direction*. It is descriptive of where the codebase is heading toward #44; it is not load-bearing on this PR's scope.
+The "Conductor completely owns these tabs" framing from v1 is informative future-direction toward #44 only; it is not load-bearing on this PR's scope or any of these decisions.
 
 ## Test coverage
 
@@ -232,61 +300,73 @@ New file: `test/reattachOnStartup.test.ts`.
 
 | # | Scenario | Setup | Assert |
 |---|---|---|---|
-| 1 | Same PID → no dispatch | Mock one `claude · foo` terminal whose `processId` resolves to `42`. Mock `workspaceState.get` to return `{ "/path/to/foo": 42 }`. Setting on. | `createTerminal` not called. No `sendText` / shell-integration `executeCommand` calls on the existing terminal. PID `42` re-persisted (record refreshed). |
-| 2 | Different PID → dispatch via shell-integration fast path | Same setup, stored PID `99`. Mock `terminal.shellIntegration.executeCommand`. | The buffered-input clear-prefix `\u0003\u0015` is sent (via `sendText` with `addNewLine: false`), then after 50ms `terminal.shellIntegration.executeCommand("claude")` is called once. PID `42` written. |
-| 3 | Different PID → dispatch via slow path | Same as 2, but `shellIntegration` is `undefined` initially; fire `onDidChangeTerminalShellIntegration` after a short delay. | Clear-prefix sent. Then slow path resolves and `executeCommand("claude")` is called once. |
-| 4 | Different PID → dispatch via delay fallback | Same as 2, but no shell-integration ever activates. Use vitest fake timers. | Clear-prefix sent (no newline). After `launchDelayMs`, `terminal.sendText("claude")` is called (with the implicit newline from the default `addNewLine: true`). |
-| 5 | No stored PID → dispatch | Stored map is empty. | Same dispatch behavior as scenario 2. PID written after dispatch. |
-| 6 | Cwd missing (single tab) → dispose + aggregate toast (with one entry) | One terminal, mock `fs.existsSync` to return false. | `terminal.dispose()` called. `reconcile()` called. After all routines settle, `vscode.window.showInformationMessage` called once with text containing the folder name. No clear-prefix. No `claude` dispatch. |
-| 7 | Multiple cwds missing → ONE aggregate toast | Three terminals, all with dead cwds. | Three `dispose()` calls. **One** `showInformationMessage` call, listing the three folder names. (If list grows beyond 3, truncated with "and N more".) |
-| 8 | `processId` resolves to `undefined` | Mock `terminal.processId` to resolve undefined. | No dispatch, no dispose. Debug log emitted. State unchanged. |
-| 9 | `processId` rejects | Mock `terminal.processId` to reject. | Same as 8 — no dispatch, no dispose, debug log. |
-| 10 | Multiple restored sessions in parallel — no PID race | Three `claude · *` terminals, all with PID mismatches. | All three dispatch. After all routines settle, `workspaceState.update` final state reflects all three new PIDs. Verifies the write queue serializes correctly. |
-| 11 | `workspaceState.update` rejects mid-chain | Stub `workspaceState.update` to reject once, then succeed on next call. | Subsequent `_persistSessionPid` calls succeed (queue not poisoned). Error logged. |
-| 12 | Setting off → reattach is a no-op | `getRelaunchOnStartup()` returns false. Three restored terminals tracked. | No `_reattachRestoredSessions` work performed. No dispatches, no toast, no PID writes. Tracking still happens (existing constructor loop). |
-| 13 | PID cleanup on close | Track + dispatch a session, then dispose its terminal. | `workspaceState.update` called with the entry removed. |
-| 14 | `AUTO_LAUNCH_KEY` flow + reattach for the same folder | Restored terminal for folder F + `AUTO_LAUNCH_KEY` set to F. | One dispatch (from reattach), one focus (from auto-launch's `launchSession` reuse path). No duplicate `createTerminal`. |
-| 15 | Deactivation racing with reattach | Construct `SessionManager`, immediately call `dispose()` while async routines are mid-await. Mock `terminal.processId` with a 100ms delay. | After routines resolve, `workspaceState.update` is **not** called (the `_disposed` guard prevents writes). No exceptions thrown. |
+| 1 | Same PID → no dispatch | One `claude · foo` terminal, `processId` → `42`, `workspaceState.get` → `{ "/path/to/foo": 42 }`. Setting on. | `createTerminal` not called. No `sendText`/shell-integration calls on the existing terminal. PID re-persisted. |
+| 2 | Different PID → dispatch via shell-integration fast path | Stored PID `99`, current `42`, `shellIntegration.executeCommand` mocked. | **No** clear-prefix `sendText` (clear is only on delay-fallback). `executeCommand("claude")` called once. PID `42` written. |
+| 3 | Different PID → dispatch via slow path | Same as 2, `shellIntegration` undefined initially; fire `onDidChangeTerminalShellIntegration` after a short delay. | No clear-prefix. Slow path resolves and `executeCommand("claude")` called once. |
+| 4 | Different PID → dispatch via delay fallback (POSIX) | Same as 2, no shell-integration ever activates. Vitest fake timers. | Clear-prefix `\u0003\u0015` sent via `sendText("\u0003\u0015", false)` (assert exact 2-arg call). After 50ms, `sendText("claude")` called (1-arg call — implicit newline). |
+| 5 | No stored PID → dispatch | Stored map empty. | Same dispatch behavior as scenario 2. PID written after dispatch. |
+| 6 | Cwd missing (single tab) → dispose + toast (one entry) | One terminal, `fs.existsSync` → false. | `terminal.dispose()` called. After all routines settle, `showInformationMessage` called once with text containing the folder name. No clear-prefix. No `claude` dispatch. **No explicit `reconcile()` call** (verifies v3 simplification). |
+| 7 | Multiple cwds missing → ONE aggregate toast (max 3 names, then "and N more") | Five terminals, all dead cwds. | Five `dispose()` calls. **One** `showInformationMessage` listing first 3 folder names + "and 2 more". |
+| 8 | `processId` resolves to `undefined` | `terminal.processId` → undefined. | No dispatch, no dispose. `debugLog` emitted. State unchanged. |
+| 9 | `processId` rejects | `terminal.processId` rejects. | Same as 8. |
+| 10 | Multiple restored sessions in parallel — write queue serializes correctly | Three terminals, all PID mismatches. | All three dispatch. After settle, `workspaceState.update` final state reflects all three new PIDs. |
+| 11 | `workspaceState.update` rejects mid-chain | Stub `workspaceState.update` via `mockImplementationOnce(() => Promise.reject(...))`, then default `mockImplementation(() => Promise.resolve())`. | Subsequent `_persistSessionPid` calls succeed (queue not poisoned). Error logged. |
+| 12 | Setting off → reattach is a no-op | `getRelaunchOnStartup()` → false. Three restored terminals tracked. | No `_reattachRestoredSessions` work performed. No dispatches, no toast, no PID writes via reattach path. **`_clearSessionPid` still runs** if a session is closed during the off period (verifies Decision #3). |
+| 13 | PID cleanup on close (setting on AND off) | Track + dispatch a session, then dispose. Run twice — once with setting on, once with setting off. | `workspaceState.update` called both times with the entry removed. Verifies `_clearSessionPid` is unconditional. |
+| 14 | `AUTO_LAUNCH_KEY` flow + reattach for the same folder | Restored terminal for folder F + `AUTO_LAUNCH_KEY` set to F. | One dispatch (from reattach), one focus (from auto-launch's `launchSession` reuse path). **Assert call ordering**: dispatch precedes focus. No duplicate `createTerminal`. |
+| 15 | Deactivation racing with reattach | Construct `SessionManager`, immediately `dispose()` while async routines mid-await. `terminal.processId` mocked with 100ms delay. | After routines resolve, `workspaceState.update` is **not** called. **Aggregate toast also not shown** (gated by `_disposed`). No exceptions thrown. |
+| 16 | Day-1 onboarding — official extension installed, first activation | Mock `vscode.extensions.getExtension('Anthropic.claude-code')` → defined. `globalState.get('claudeConductor.reattachOnboardingShown')` → false. | `showInformationMessage` called with two action buttons. After user clicks "Disable", `workspace.getConfiguration().update('claudeConductor.relaunchOnStartup', false, ...)` called. `globalState.update('claudeConductor.reattachOnboardingShown', true, ...)` called. |
+| 17 | Day-1 onboarding — no official extension | Mock `getExtension` → undefined. Onboarding flag false. | No toast shown. `globalState.update(..., true, ...)` called (mark as shown). |
+| 18 | Day-1 onboarding — already shown | Mock `getExtension` → defined. Onboarding flag true. | No toast shown. No `globalState.update`. |
+| 19 | Snapshot iteration — `onDidOpenTerminal` fires mid-reattach | Construct `SessionManager` with one restored terminal. Inside the per-session routine's `await processId`, simulate `onDidOpenTerminal` for a NEW Claude terminal. | Reattach iteration only includes the original terminal (verifies snapshot). New terminal is tracked but not reattached. |
 
 ### Mock strategy
 
-- Reuse the existing `test/mocks/vscode.ts` patterns (already used by `addFolderPrompt.stale.test.ts` from PR #73 and the existing `hookInstaller` tests).
-- Add a `Memento` mock for `workspaceState`: `{ get, update, keys }` with an internal `Map<string, unknown>` backing store. Generic enough to live alongside the existing mocks.
-- `terminal.processId` is mocked as `Promise.resolve(<number>)` per-test. For scenario 15, use a delayed promise.
+- Reuse the existing `test/mocks/vscode.ts` patterns (used by `addFolderPrompt.stale.test.ts` from PR #73 and `hookInstaller` tests).
+- Add a `Memento` mock for `workspaceState`: `{ get, update, keys }`. The `update` method is implemented as a vitest `vi.fn()` so individual tests can override per-call behavior via `mockImplementationOnce`. Internal `Map<string, unknown>` backs the default `get`/`update` semantics.
+- Add a mock for `vscode.extensions.getExtension` — used by scenarios 16/17/18.
+- Add a mock for `globalState` (similar to `workspaceState`) — used by scenarios 16/17/18.
+- `terminal.processId` mocked as `Promise.resolve(<number>)` per-test. Scenarios 15 and 19 use delayed promises.
 - `vi.mock("fs")` for the cwd-existence test (same pattern as the #71 test).
 
-Existing tests stay untouched — the change is additive.
+**Test-suite migration**: every existing test that constructs `SessionManager` needs the new `workspaceState` arg added to its setup. Plan for the mock helper to be extracted to a shared util so the migration is one-import-per-file.
 
 ## Rollout
 
-- **Setting default** is `true` per AC, so the feature is on for everyone after upgrade. Users who don't want it set `claudeConductor.relaunchOnStartup: false` — the gate makes the feature recoverable without a new release.
-- **First activation after upgrade**: any user who currently has restored Claude tabs sitting at bare prompts will see them auto-dispatch. Users with surviving shells (PIDs match → no dispatch) won't see a behavioral change.
-- **Edge — surviving shells, no stored PIDs**: users upgrading from a pre-#43 version have no persisted PIDs in `workspaceState` yet, so the first activation post-upgrade falls into the "no stored PID → dispatch" branch (Option A). For users whose shells *did* survive and where claude *is* still running, this means a one-time stray `"claude"` per terminal — *but* the buffered-input clear-prefix means it won't corrupt buffered shell input, and the setting provides a recovery path. Subsequent activations are race-free.
-- **Day-1 collision warning** (CHANGELOG): if you also use the official Claude Code VS Code extension, set `claudeConductor.relaunchOnStartup: false` until #33 lands — Conductor's reattach can't yet distinguish its own restored sessions from sessions opened by the official extension.
+- **Setting default** is `true` per AC. Users who don't want it set `claudeConductor.relaunchOnStartup: false`.
+- **First activation after upgrade**: any user with restored Claude tabs at bare prompts will see auto-dispatch. Surviving-shell users (PIDs match → no dispatch) see no behavioral change.
+- **Edge — surviving shells, no stored PIDs**: users upgrading from a pre-#43 version have no persisted PIDs yet, so first activation post-upgrade falls into the "no stored PID → dispatch" branch. For surviving-shell + still-running-claude users, this means a one-time stray `claude` per terminal — *but* the buffered-input clear-prefix limits damage on the delay-fallback path, the shell-integration paths handle it cleanly, and the setting provides a recovery path. Subsequent activations are race-free.
+- **Day-1 collision with official Claude Code extension**: handled proactively via the consent toast (see *Day-1 collision* above). For users who install the official extension *after* Conductor, the CHANGELOG note is the fallback.
 - **README updates** (per AC):
   - *Features*: document the reattach behavior.
   - *Configuration*: document `claudeConductor.relaunchOnStartup`.
-  - *Known Limitations*: remove (or rewrite) any wording implying sessions don't survive VS Code restart.
-- **CHANGELOG**: note the new feature, the new setting, the day-1 caveat, and the buffered-input clear-prefix as a defensive behavior.
+  - *Known Limitations*: remove or rewrite any wording implying sessions don't survive VS Code restart. Add a one-liner about the Windows-cmd.exe / PowerShell-without-PSReadLine clear-prefix limitation.
+- **CHANGELOG**: note the new feature, the new setting, the day-1 collision behavior, the buffered-input clear-prefix, and the known Windows shell limitation.
+
+## Known limitations / deferred
+
+These were raised in adversarial review and explicitly deferred. A future maintainer should NOT silently reverse these decisions without revisiting the trade-off.
+
+- **Windows cmd.exe and PowerShell-without-PSReadLine**: the clear-prefix `\u0003\u0015` is not interpreted as kill-line on these shells. If a user on those shells has buffered prompt input AND hits the delay-fallback path (no shell integration), the dispatched `claude` may corrupt the prompt line. Mitigation: setting gate. Acceptable cost; affected user base is small (most modern PowerShell installs ship with PSReadLine and Conductor's primary user-shell is PowerShell with PSReadLine per `CLAUDE.md`).
+- **`workspaceState.update` indefinite hang**: the write queue has no `Promise.race` timeout. If `Memento.update` ever hangs without rejecting, the queue stalls forever. No documented case of this in VS Code; treated as theoretical until observed. The `_disposed` guard prevents new writes from piling up but doesn't cancel an in-flight stalled one.
+- **Promise chain unbounded growth**: `_pidWriteQueue` grows by one promise per call over the session lifetime. Closures held by each chain link mean a slow memory growth proportional to session-lifecycle event count. Not a leak in practice (bounded by user activity); a more elegant single-slot mutex pattern was considered and deferred — promise chains are simpler to reason about.
+- **`terminal.show()` keystroke race on Windows**: a user clicking a tab while reattach is mid-routine triggers `focusSession` → `terminal.show()`, which on Windows can shift keyboard focus and redirect user keystrokes into the terminal during the dispatch. Not unique to this design — same race exists for any extension typing into terminals while users click. Outside scope.
+- **Onboarding toast retroactive trigger**: if a user installs the official Claude Code extension *after* Conductor's first activation has already marked onboarding as shown, no retroactive toast appears. CHANGELOG note is the fallback. Adding retroactive detection would require a periodic check or extension-list change listener — disproportionate complexity for a one-shot UX warning.
 
 ## Future direction (informative — not part of this PR)
 
 ### #44 — custom PTY wrapper
 
-Once #44 is on the table (Conductor owns the PTY directly), this entire reattach pass collapses into "the Conductor process is alive across VS Code restarts; tabs re-bind to live PTYs without dispatching anything." The work in this PR is not wasted — it makes the per-tab lifecycle ownership explicit, which is a precondition for #44. The implementation surface (PID record, dispatch logic) will be replaced wholesale by the PTY-ownership design.
+Once #44 is on the table (Conductor owns the PTY directly), this entire reattach pass collapses into "the Conductor process is alive across VS Code restarts; tabs re-bind to live PTYs without dispatching anything." The work in this PR is a precondition for #44 — it makes per-tab lifecycle ownership explicit, which #44 then takes over wholesale.
 
 ### #33 — externally-launched session adoption
 
-The PID-record approach is forward-compatible. When #33 picks up `claude · *` terminals that were not created by us, they will be tracked the same way and PID-recorded the same way. The reattach survival check works identically for them — no code change needed in this design's surface to support that future work. Until #33 lands, the day-1 collision risk is mitigated by the user-facing setting (per AC).
+The PID-record approach is forward-compatible. When #33 picks up `claude · *` terminals not created by us, they will be tracked and PID-recorded the same way. The reattach survival check works identically. Until #33 lands, the day-1 collision risk is mitigated by the proactive onboarding toast + the user-facing setting.
 
 ### #68 — close-detection spike
 
-This design does not change close-detection paths. The PID record is keyed on folder path and is cleared on close-detection eviction (via `_removeByKey` → `_clearSessionPid`), so the two systems are decoupled.
+Independent of this design. PID record is keyed on folder path, cleared on close-detection eviction (via `_removeByKey` → `_clearSessionPid`). The two systems are decoupled.
 
 ### Activation latency / progress signal
 
-Worst case for a heavy user with many restored tabs and no shell integration: the slow path can fire several routines in parallel, each waiting up to 2s + 500ms delay-fallback. During that window, the tree view shows tracked sessions whose `claude` is not yet dispatched. Adding a `dispatchState: "pending" | "ready"` field on `ActiveSession` and rendering "reattaching..." in the tree view would close this UX gap. Not in scope for this PR — flagged as a follow-up if the latency surfaces in user feedback.
-
-### Tab-ownership framing
-
-The first draft of this spec leaned on a "Conductor completely owns these tabs" principle to discharge AC #4. The inquisitor flagged this as misleading: this design *observes* VS Code's terminal restoration and *types into* whatever shell VS Code chose to spawn — Conductor does not control envelope creation, shell selection, or persistence. True ownership is what #44 proposes. The framing is informative for the trajectory but is not load-bearing on this PR's scope, and AC #4's setting gate is restored regardless.
+Worst case for a heavy user with many restored tabs and no shell integration: slow path can fire several routines in parallel, each waiting up to 2s + 500ms delay-fallback. During that window, the tree view shows tracked sessions whose `claude` is not yet dispatched. Adding a `dispatchState: "pending" | "ready"` field on `ActiveSession` and rendering "reattaching..." in the tree view would close the UX gap. Out of scope for this PR — flagged as a follow-up if user feedback surfaces it.

--- a/docs/superpowers/specs/2026-04-27-43-reattach-on-startup-design.md
+++ b/docs/superpowers/specs/2026-04-27-43-reattach-on-startup-design.md
@@ -1,0 +1,195 @@
+# Design — Reattach Claude sessions on VS Code startup (#43)
+
+**Issue**: [#43](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/43)
+**Date**: 2026-04-27
+**Status**: Approved — ready for implementation planning
+
+---
+
+## Problem
+
+When VS Code restarts (close → reopen, or in some configurations after a ptyhost crash or system restart), terminal **tab envelopes** are restored — name, position, icon, and `creationOptions.cwd` survive — but the inner shell process is sometimes replaced with a fresh one. In that case, a Claude Conductor tab labelled `claude · my-project` reopens with a bare prompt and no `claude` running. The user has to remember which tabs need re-launching and type `claude` manually into each.
+
+Claude Conductor already detects these tabs (`SessionManager` constructor iterates `vscode.window.terminals` and calls `_trackIfClaudeSession`). The missing piece is **dispatching `claude` into the restored tab when its shell is fresh**, without firing into a tab whose shell survived (where `claude` is still running and dispatch would inject the literal text `"claude"` as user input).
+
+## Goals
+
+1. After VS Code restart, Claude tabs whose shells were replaced come back to a working `claude` session automatically — no user action required.
+2. Tabs whose shells *survived* (the common case under default persistent-session settings) are left untouched.
+3. Tabs whose `cwd` no longer exists on disk are cleaned up (disposed) with a one-time toast, rather than left as silently-broken bare prompts.
+
+## Non-goals
+
+- **Restoring Claude's in-conversation memory.** That's an Anthropic-side property of Claude Code itself; this design only restores the *session* (a running `claude` process), not its prior context.
+- **Replacing VS Code's terminal model with a custom PTY.** That's [#44](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/44). This design works inside VS Code's terminal API.
+- **Adopting externally-launched `claude · *` sessions.** That's [#33](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/33). This design's PID-record approach is forward-compatible — externally-launched terminals will get tracked and PID-recorded the same way once #33 picks them up.
+- **Changing close-detection.** That's [#68](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/68). PID records and close-detection records are decoupled and don't interact.
+
+## Architecture
+
+A single new "reattach pass" runs at the end of `SessionManager`'s constructor, after the existing tracking loop. For each tracked Claude terminal, an async per-session routine compares the terminal's *current* shell PID against a previously-stored PID for the same folder path. The comparison decides whether to dispatch `claude`:
+
+| Current PID vs stored PID | Meaning | Action |
+|---|---|---|
+| Match | Shell process survived across the activation boundary; `claude` is most likely still running | **Skip dispatch** |
+| Differ | Shell was replaced; `claude` is gone | **Dispatch `claude`** (existing 3-tier `_dispatchClaudeCommand`) |
+| No stored PID | First activation post-install, or after `workspaceState` was wiped | **Dispatch `claude`** (Option A — see *Decisions* below) |
+| `processId` resolves to `undefined` or rejects | We can't reason about the shell state | **Skip dispatch** (conservative — better a bare prompt than a stray `"claude"` injected into an active session) |
+
+`workspaceState` is the persistence layer for the PID record. The record is keyed on lower-cased normalized folder path, mirroring the existing case-insensitive `_findSessionByFolder` convention.
+
+## Code surfaces
+
+| File | Change |
+|---|---|
+| `src/sessionManager.ts` | Constructor takes a new `workspaceState: vscode.Memento` arg. New private methods `_reattachRestoredSessions()`, `_persistSessionPid(folderPath, pid)`, `_clearSessionPid(folderPath)`. `_dispatchClaudeCommand` is reused as-is — no need to make it public. |
+| `src/extension.ts` | Pass `context.workspaceState` to `new SessionManager(...)`. One-line change to the existing constructor call. |
+| `package.json` | No new settings (unconditional behavior — see *Decisions*). |
+| `test/reattachOnStartup.test.ts` | New file covering the scenarios in *Test coverage* below. |
+| `CHANGELOG.md` | Note the one-time stray-`claude` cost on first activation post-upgrade for users with surviving shells (see *Rollout*). |
+
+### Why a method on `SessionManager` and not a top-level activation step
+
+Keeps the lifecycle-management logic colocated with the terminal-tracking logic that already lives in `SessionManager`. The class already owns the `_sessions` map, the `_pidToTerminal` map, and the close-detection state machine. Adding the reattach pass to the same surface keeps the abstraction boundary clean: any future redesign (e.g., #44's PTY wrapper) replaces this entire surface as a unit, rather than scattering startup logic across `extension.ts`.
+
+### Why a single batch pass at the end of the constructor, not inline in `_trackIfClaudeSession`
+
+`_trackIfClaudeSession` runs synchronously and is also called from `onDidOpenTerminal` during normal use. We don't want every newly-opened terminal to trigger reattach logic — only the snapshot of restored tabs at activation time. A separate explicit pass distinguishes "I just saw a terminal appear during normal use, don't reattach it" from "I'm enumerating restored tabs at activation, decide whether to reattach each one."
+
+## Lifecycle
+
+### Activation order
+
+1. Existing constructor loop iterates `vscode.window.terminals` and calls `_trackIfClaudeSession` on each — same as today.
+2. **NEW**: After that loop, `_reattachRestoredSessions()` is invoked. It iterates `_sessions.values()` and for each entry kicks off an async per-session reattach routine. All routines run in parallel via `Promise.allSettled` (no `await` blocks the constructor — terminal output appears as the async routines complete).
+3. The constructor returns synchronously. Tree views, status bar, etc. bind to a populated `_sessions` map immediately.
+4. The existing `AUTO_LAUNCH_KEY` block in `extension.ts` (lines 94–97) still fires after construction. Because `launchSession` checks `getReuseTerminal()` and finds the just-tracked session, it focuses instead of creating — no double-dispatch.
+
+### Per-session async reattach routine
+
+```
+1. await terminal.processId          → currentPid (number | undefined)
+2. read stored PID for folderPath    → storedPid (number | undefined)
+3. if currentPid === undefined       → log and skip (can't make a decision)
+4. if storedPid === currentPid       → shell survived, claude likely running, skip
+5. if !fs.existsSync(folderPath)     → dispose tab + toast "Could not restore session for <folder> — folder no longer exists"
+6. else                              → call _dispatchClaudeCommand(terminal)
+7. always (steps 4 and 6)            → _persistSessionPid(folderPath, currentPid)
+```
+
+Step 7 also runs on the survival branch (4) so `workspaceState` is refreshed every activation — keeps the record current even when no dispatch was needed.
+
+### PID persistence lifecycle
+
+| Event | Action |
+|---|---|
+| Session tracked (in `_trackIfClaudeSession`, after `terminal.processId` resolves) | Call `_persistSessionPid(folderPath, pid)` — writes the new entry into `workspaceState` |
+| Session closed (in `_removeByKey`) | Call `_clearSessionPid(folderPath)` — removes the entry. Closed sessions shouldn't leave PID ghosts in state |
+| Reattach decision (step 7 above) | Refresh after every dispatch decision |
+
+### State shape
+
+Stored under the key `claudeConductor.sessionPids` in `workspaceState`. Type: `Record<string, number>`. Keys are lower-cased normalized folder paths (matching the existing `_findSessionByFolder` convention: `path.normalize(folderPath).toLowerCase()`).
+
+```ts
+// Example
+{
+  "i:\\projects\\career-ops": 12345,
+  "i:\\projects\\notes": 67890
+}
+```
+
+### Write serialization
+
+`_persistSessionPid` and `_clearSessionPid` perform read-modify-write on the single shared `claudeConductor.sessionPids` record. Multiple reattach routines run in parallel and each session's tracking-time PID resolution can also fire concurrently, so concurrent writes would race and clobber each other.
+
+The implementation **must serialize** these writes through an internal promise queue:
+
+```ts
+private _pidWriteQueue: Promise<void> = Promise.resolve();
+
+private _persistSessionPid(folderPath: string, pid: number): void {
+  this._pidWriteQueue = this._pidWriteQueue.then(async () => {
+    const current = this._workspaceState.get<Record<string, number>>(PID_KEY) ?? {};
+    current[folderPath] = pid;
+    await this._workspaceState.update(PID_KEY, current);
+  });
+}
+```
+
+Writes complete in order; reads inside the chain see the latest persisted record. Acceptable cost — these writes are infrequent and small.
+
+## Error handling
+
+| Failure | Handling |
+|---|---|
+| `terminal.processId` resolves to `undefined` | Log via `debugLog`, skip dispatch. Conservative — without a PID we can't compare, so we don't risk text injection. |
+| `terminal.processId` rejects | Same as above — skip with a debug log. |
+| `fs.existsSync(folderPath)` returns false | `terminal.dispose()` + `vscode.window.showInformationMessage` with the toast text. The dispose triggers existing close-detection cleanup, so `_sessions` and the PID record both clear automatically via `_handleTerminalClose` → `_removeByKey`. |
+| `_dispatchClaudeCommand` falls through to delay-fallback `sendText` (existing 3-tier path) | Already handled by the existing implementation — terminal sees `claude` keystrokes after the `claudeConductor.launchDelayMs` delay (default 500 ms). Worst case: user gets a slightly slower reattach. Same behavior as new launches today. |
+| `workspaceState` returns wrong-typed data (e.g., user manually edited it, or schema changed) | Defensive: treat as "no stored PID" → fall through to first-install path → dispatch. |
+| Concurrent reattach + new launch race | Won't happen in practice — `launchSession` is only called from user-initiated commands, which can't fire during synchronous constructor execution. The async reattach routines complete naturally before any user input is possible. |
+
+### `AUTO_LAUNCH_KEY` coordination (intentional, not a bug)
+
+When VS Code is opened via a `vscode://` URI for a folder that *also* has a restored Claude tab, both reattach (from the constructor) and `AUTO_LAUNCH_KEY` (from `activate()` in `extension.ts`) fire. The reattach pass dispatches `claude` into the restored tab; then `AUTO_LAUNCH_KEY`'s `launchSession` call finds the now-tracked session and `focusSession`s it instead of creating a duplicate. Net effect: one terminal, one dispatch, one focus. **Intentional and correct** — flagged here so it's not "fixed" by mistake later.
+
+## Decisions made during brainstorming
+
+These design decisions were resolved during the 2026-04-27 brainstorm:
+
+1. **PID comparison is the discriminator** — not "what triggered activation?" The right question is "did the shell process survive?", and PID identity answers it uniformly across VS Code close/open, Reload Window, ptyhost crashes, and system restarts.
+2. **Unconditional behavior — no setting gate.** Reattach is a core property of how Conductor manages sessions. Following the strategic intent of "Conductor completely owns these tabs," there's no `claudeConductor.reattachOnStartup` setting; the behavior just happens.
+3. **Dispose + toast on dead `cwd`.** When a restored tab's `cwd` no longer exists, `terminal.dispose()` removes the tab and a one-time toast informs the user. Cleaner than leaving a silently-broken bare prompt with a non-existent working directory.
+4. **No-stored-PID → dispatch** (Option A). On first activation post-install (or after `workspaceState` reset), absence of a record is treated as "fresh shell, never seen before" and dispatch proceeds. Cost of being wrong is bounded: a one-time stray `"claude"` line in an active session, recoverable by the user. Cost of the alternative ("don't dispatch without positive evidence") is much worse — the feature appears broken on first impression.
+
+## Test coverage
+
+New file: `test/reattachOnStartup.test.ts`.
+
+| # | Scenario | Setup | Assert |
+|---|---|---|---|
+| 1 | Same PID → no dispatch | Mock `vscode.window.terminals` with one `claude · foo` terminal whose `processId` resolves to `42`. Mock `workspaceState.get` to return `{ "/path/to/foo": 42 }`. Construct `SessionManager`. | `createTerminal` not called; `executeCommand("workbench.action.terminal.moveToEditor")` not called; the existing terminal is **not** sent any text via `sendText` or shell-integration `executeCommand`. |
+| 2 | Different PID → dispatch via shell-integration fast path | Same setup, but stored PID is `99`. Mock `terminal.shellIntegration.executeCommand`. | `terminal.shellIntegration.executeCommand("claude")` called once. PID `42` written to `workspaceState`. |
+| 3 | Different PID → dispatch via slow path | Same as 2, but `terminal.shellIntegration` is `undefined` initially. Fire `onDidChangeTerminalShellIntegration` after a short delay with `{ terminal, shellIntegration }`. | `shellIntegration.executeCommand("claude")` called once via the slow-path branch. |
+| 4 | Different PID → dispatch via delay fallback | Same as 2, but neither shell-integration path fires (no event). Use vitest's fake timers. | `terminal.sendText("claude")` called after the configured delay. |
+| 5 | No stored PID → dispatch | Stored map is empty. | Same dispatch behavior as scenario 2. PID written after dispatch. |
+| 6 | Cwd missing → dispose + toast | Mock `fs.existsSync(folderPath)` to return false. | `terminal.dispose()` called. `vscode.window.showInformationMessage` called once with text containing the folder name. No `sendText` / `executeCommand("claude")` calls. |
+| 7 | `processId` resolves to `undefined` | Mock `terminal.processId` to resolve undefined. | No dispatch, no dispose. Debug log emitted. State unchanged. |
+| 8 | Multiple restored sessions in parallel | Three `claude · *` terminals, all with PID mismatches. | All three see their dispatch path called. After all routines settle, `workspaceState.update` reflects all three new PIDs (no clobber — verifies the write-queue serialization). |
+| 9 | PID cleanup on close | Track + dispatch a session, then dispose its terminal. | `workspaceState.update` called with the entry removed. |
+| 10 | `AUTO_LAUNCH_KEY` flow + reattach | Restored terminal for folder F + `AUTO_LAUNCH_KEY` set to F. | One dispatch (from reattach), one focus (from auto-launch's `launchSession` reuse path). No duplicate `createTerminal`. |
+
+### Mock strategy
+
+- Reuse the existing `test/mocks/vscode.ts` patterns (already used by `addFolderPrompt.stale.test.ts` from PR #73 and the existing `hookInstaller` tests).
+- Add a `Memento` mock for `workspaceState`: `{ get, update, keys }` with an internal `Map<string, unknown>` backing store. Generic enough to live alongside the existing mocks.
+- `terminal.processId` is mocked as `Promise.resolve(<number>)` per-test.
+- `vi.mock("fs")` for the cwd-existence test (same pattern as the #71 test).
+
+Existing tests stay untouched — the change is additive to `SessionManager`'s constructor, behind a new method that doesn't fire unless a tracked terminal exists at construction time.
+
+## Rollout
+
+- **No setting** → no migration.
+- **First activation after upgrade**: any user who currently has restored Claude tabs sitting at bare prompts will see them auto-dispatch. Users with surviving shells (PIDs match → no dispatch) won't see a behavioral change.
+- **Edge — surviving shells, no stored PIDs**: users upgrading from a pre-#43 version have no persisted PIDs in `workspaceState` yet, so the first activation post-upgrade falls into the "no stored PID → dispatch" branch (Option A above). For users whose shells *did* survive and where claude *is* still running, this means a one-time stray `"claude"` gets sent into the active Claude session per terminal. That's the documented cost of Option A; surfaces once per existing session per upgrade, then never again.
+- **Mention this in the CHANGELOG** so users aren't surprised. Single bullet under the version entry: *"Sessions are now reattached on VS Code startup. On the first launch after upgrade, an existing tab with `claude` already running may receive a stray `claude` keystroke; subsequent launches won't."*
+
+## Future direction (informative — not part of this PR)
+
+### Strategic note on tab ownership
+
+The unconditional-default and dispose-on-dead-cwd choices reflect a strategic intent surfaced during the brainstorm: **Conductor should completely own Claude session tabs**, rather than passively observing whatever VS Code's terminal API does. This PR is a step toward that: it makes Conductor the active manager of session lifecycle. Future design decisions in this area should default to "Conductor decides" rather than "Conductor adapts to VS Code." Capturing the rationale here so it doesn't get diluted later.
+
+### #44 — custom PTY wrapper
+
+Once #44 is on the table (Conductor owns the PTY directly), this entire reattach pass collapses into "the Conductor process is alive across VS Code restarts; tabs re-bind to live PTYs without dispatching anything." The work in this PR is not wasted — it makes the per-tab lifecycle ownership explicit, which is a precondition for #44. But the implementation surface (PID record, dispatch logic) will be replaced wholesale by the PTY-ownership design.
+
+### #33 — externally-launched session adoption
+
+The PID-record approach is forward-compatible. When #33 picks up `claude · *` terminals that were not created by us, they will be tracked the same way and PID-recorded the same way. The reattach survival check works identically for them — no code change needed in this design's surface to support that future work.
+
+### #68 — close-detection spike
+
+This design does not change close-detection paths. The PID record is keyed on folder path and is cleared on close-detection eviction (via `_removeByKey` → `_clearSessionPid`), so the two systems are decoupled.

--- a/package.json
+++ b/package.json
@@ -181,6 +181,11 @@
           "type": "boolean",
           "default": false,
           "description": "Enable verbose diagnostic logging for session lifecycle (Active Sessions panel close-detection diagnostics). Default off."
+        },
+        "claudeConductor.relaunchOnStartup": {
+          "type": "boolean",
+          "default": true,
+          "description": "On VS Code startup, automatically run 'claude' in any Claude Conductor terminal tab whose inner shell was replaced (e.g. after a system restart or ptyhost crash). Set to false to disable, or if Conductor reattaches into terminals owned by another extension."
         }
       }
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,3 +33,7 @@ export function getLaunchDelayMs(): number {
 export function getDebugLogging(): boolean {
   return getConfig().get<boolean>("debugLogging", false);
 }
+
+export function getRelaunchOnStartup(): boolean {
+  return getConfig().get<boolean>("relaunchOnStartup", true);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,9 +80,12 @@ class SessionUriHandler implements vscode.UriHandler {
   }
 }
 
-export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  // First-activation consent gate for reattach feature (#43)
-  await runReattachOnboarding(context.globalState);
+export function activate(context: vscode.ExtensionContext): void {
+  // First-activation onboarding for reattach feature (#43).
+  // Fire-and-forget — do not block extension setup on the user's toast click.
+  // First activation may dispatch into restored tabs before the user can opt
+  // out; this is the documented day-1 caveat (see CHANGELOG notes).
+  void runReattachOnboarding(context.globalState);
 
   sessionManager = new SessionManager(context.workspaceState);
   context.subscriptions.push(sessionManager);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,7 +80,7 @@ class SessionUriHandler implements vscode.UriHandler {
 }
 
 export function activate(context: vscode.ExtensionContext): void {
-  sessionManager = new SessionManager();
+  sessionManager = new SessionManager(context.workspaceState);
   context.subscriptions.push(sessionManager);
 
   // URI handler for cross-window launch

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { ClaudeTerminalLinkProvider } from "./terminalLinks";
 import { StateWatcher } from "./stateWatcher";
 import { ensureHooksInstalled, setupHooksCommand, uninstallHooks } from "./hookInstaller";
 import { isSameWorkspaceFolder } from "./workspaceMatch";
+import { runReattachOnboarding } from "./onboarding";
 
 let sessionManager: SessionManager;
 
@@ -79,7 +80,10 @@ class SessionUriHandler implements vscode.UriHandler {
   }
 }
 
-export function activate(context: vscode.ExtensionContext): void {
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  // First-activation consent gate for reattach feature (#43)
+  await runReattachOnboarding(context.globalState);
+
   sessionManager = new SessionManager(context.workspaceState);
   context.subscriptions.push(sessionManager);
 

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,0 +1,65 @@
+import * as vscode from "vscode";
+import { log } from "./output";
+
+/** globalState key set after the onboarding toast has been considered. */
+export const ONBOARDING_KEY = "claudeConductor.reattachOnboardingShown";
+
+/** Marketplace ID of the official Anthropic Claude Code VS Code extension. */
+const OFFICIAL_CLAUDE_EXT_ID = "Anthropic.claude-code";
+
+/**
+ * First-activation consent flow for the reattach feature (#43).
+ *
+ * If the user has the official Claude Code extension installed AND we have
+ * not yet shown this onboarding toast, surface a one-time prompt asking
+ * them to opt in or out of reattach. Their choice flips
+ * `claudeConductor.relaunchOnStartup` accordingly.
+ *
+ * The flag is set regardless of outcome so the toast appears at most once.
+ * If the user dismisses the toast without clicking, the setting stays at
+ * its default (true).
+ */
+export async function runReattachOnboarding(
+  globalState: vscode.Memento
+): Promise<void> {
+  const alreadyShown = globalState.get<boolean>(ONBOARDING_KEY, false);
+  if (alreadyShown) {
+    return;
+  }
+
+  const officialExt = vscode.extensions.getExtension(OFFICIAL_CLAUDE_EXT_ID);
+  if (!officialExt) {
+    // No collision risk — mark as shown and move on.
+    try {
+      await globalState.update(ONBOARDING_KEY, true);
+    } catch (err) {
+      log(`[onboarding] failed to set ONBOARDING_KEY: ${String(err)}`);
+    }
+    return;
+  }
+
+  // Surface the consent toast.
+  const message =
+    "Claude Conductor reattaches Claude sessions on VS Code restart by typing " +
+    "`claude` into restored terminal tabs. We detected the official Claude " +
+    "Code extension is also installed — Conductor may inject `claude` into " +
+    "its sessions until issue #33 ships. Enable reattach for Conductor sessions?";
+  const choice = await vscode.window.showInformationMessage(
+    message,
+    "Enable",
+    "Disable"
+  );
+
+  if (choice === "Disable") {
+    await vscode.workspace
+      .getConfiguration("claudeConductor")
+      .update("relaunchOnStartup", false, vscode.ConfigurationTarget.Global);
+  }
+  // "Enable" or dismiss → keep default (true), no setting update needed.
+
+  try {
+    await globalState.update(ONBOARDING_KEY, true);
+  } catch (err) {
+    log(`[onboarding] failed to set ONBOARDING_KEY: ${String(err)}`);
+  }
+}

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -421,6 +421,59 @@ export class SessionManager implements vscode.Disposable {
     }
   }
 
+  /**
+   * Normalize a folder path for use as a persistence key.
+   * Case is PRESERVED — see "Persistence vs in-memory key" in the design spec.
+   * Lower-case folding applies only to in-memory `_findSessionByFolder` lookups,
+   * NOT to keys persisted in workspaceState.
+   */
+  private _normalizePersistKey(folderPath: string): string {
+    return path.normalize(folderPath);
+  }
+
+  /**
+   * Write the (folderPath -> pid) entry to workspaceState[PID_KEY].
+   * No-op after dispose().
+   *
+   * Writes are serialized through `_pidWriteQueue` to prevent read-modify-write
+   * races between concurrent reattach routines and `launchSession` flows. The
+   * leading `.catch(() => undefined)` ensures a prior rejection doesn't poison
+   * subsequent writes; the inner try/catch logs and swallows transient failures.
+   */
+  private _persistSessionPid(folderPath: string, pid: number): void {
+    if (this._disposed) return;
+    this._pidWriteQueue = this._pidWriteQueue
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          const current = this._workspaceState.get<Record<string, number>>(PID_KEY) ?? {};
+          current[this._normalizePersistKey(folderPath)] = pid;
+          await this._workspaceState.update(PID_KEY, current);
+        } catch (err) {
+          log(`[reattach] failed to persist PID for ${folderPath}: ${String(err)}`);
+        }
+      });
+  }
+
+  /**
+   * Remove the entry for `folderPath` from workspaceState[PID_KEY].
+   * Same queue + rejection semantics as `_persistSessionPid`. No-op after dispose().
+   */
+  private _clearSessionPid(folderPath: string): void {
+    if (this._disposed) return;
+    this._pidWriteQueue = this._pidWriteQueue
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          const current = this._workspaceState.get<Record<string, number>>(PID_KEY) ?? {};
+          delete current[this._normalizePersistKey(folderPath)];
+          await this._workspaceState.update(PID_KEY, current);
+        } catch (err) {
+          log(`[reattach] failed to clear PID for ${folderPath}: ${String(err)}`);
+        }
+      });
+  }
+
   /** Find session by normalized folder path. */
   private _findSessionByFolder(normalizedPath: string): ActiveSession | undefined {
     const key = normalizedPath.toLowerCase();

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -194,6 +194,70 @@ export class SessionManager implements vscode.Disposable {
     terminal.sendText(cmd);
   }
 
+  /**
+   * Variant of `_dispatchClaudeCommand` for restored terminals.
+   *
+   * Same 3-tier path, but the delay-fallback prepends  (Ctrl-C,
+   * Ctrl-U) before sending `claude`, with a 50ms breather. On POSIX shells
+   * and Windows PowerShell with PSReadLine (default), this clears any
+   * buffered prompt input the user typed before VS Code closed. On legacy
+   * cmd.exe and PowerShell-without-PSReadLine these escape sequences are
+   * not interpreted as kill-line — see "Known limitations" in the design.
+   *
+   * The clear-prefix is NOT sent on the fast or slow paths because
+   * shell-integration's `executeCommand` handles command boundaries
+   * safely; sending raw bytes there could race the integration handshake.
+   */
+  private async _dispatchClaudeIntoRestoredTerminal(terminal: vscode.Terminal): Promise<void> {
+    const cmd = getClaudeCommand();
+
+    // Fast path: shell integration already active
+    if (terminal.shellIntegration) {
+      log(`[reattach:dispatch] fast path — shell integration already active`);
+      terminal.shellIntegration.executeCommand(cmd);
+      return;
+    }
+
+    // Slow path: wait up to 2 s for shell integration to activate
+    const shellIntegrationAvailable = await new Promise<boolean>((resolve) => {
+      let disposed = false;
+
+      const timeoutHandle = setTimeout(() => {
+        if (!disposed) {
+          disposed = true;
+          listener.dispose();
+          log(`[reattach:dispatch] slow path timed out — falling back to delay sendText`);
+          resolve(false);
+        }
+      }, 2000);
+
+      const listener = vscode.window.onDidChangeTerminalShellIntegration((e) => {
+        if (e.terminal === terminal && !disposed) {
+          disposed = true;
+          clearTimeout(timeoutHandle);
+          listener.dispose();
+          log(`[reattach:dispatch] slow path — shell integration activated`);
+          e.shellIntegration.executeCommand(cmd);
+          resolve(true);
+        }
+      });
+    });
+
+    if (shellIntegrationAvailable) {
+      return;
+    }
+
+    // Delay fallback — CLEAR-PREFIX REQUIRED HERE.
+    //  (Ctrl-C) signals the running foreground command; no-op on a clean prompt.
+    //  (Ctrl-U) clears the current input line on POSIX shells and PowerShell+PSReadLine.
+    log(`[reattach:dispatch] delay fallback — sending clear-prefix then claude`);
+    terminal.sendText("", false);
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    const delayMs = getLaunchDelayMs();
+    await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+    terminal.sendText(cmd);
+  }
+
   /** Focus an existing session's editor tab. */
   focusSession(session: ActiveSession): void {
     session.terminal.show(false);

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -10,6 +10,9 @@ export const SESSION_NAME_PREFIX = "claude · ";
 
 const STATE_DIR = path.join(os.homedir(), ".claude", "session-state");
 
+/** workspaceState key for the PID record. */
+const PID_KEY = "claudeConductor.sessionPids";
+
 interface SessionState {
   state: "idle" | "active";
   cwd: string;
@@ -42,7 +45,22 @@ export class SessionManager implements vscode.Disposable {
   /** Fires whenever the active session list changes (open or close). */
   readonly onDidChangeSessions = this._onDidChangeSessions.event;
 
-  constructor() {
+  /** Set when dispose() is called — guards async-resolved writes. */
+  private _disposed = false;
+
+  /**
+   * Serialized write queue for PID persistence. Each call extends the chain
+   * with a leading .catch() so a prior rejection doesn't poison subsequent
+   * writes, and an inner try/catch logs and swallows transient failures.
+   */
+  private _pidWriteQueue: Promise<void> = Promise.resolve();
+
+  /** workspaceState injected by the extension activator. */
+  private readonly _workspaceState: vscode.Memento;
+
+  constructor(workspaceState: vscode.Memento) {
+    this._workspaceState = workspaceState;
+
     // Pick up any Claude terminals that already exist (e.g., extension reloaded)
     for (const terminal of vscode.window.terminals) {
       this._trackIfClaudeSession(terminal);
@@ -415,6 +433,7 @@ export class SessionManager implements vscode.Disposable {
   }
 
   dispose(): void {
+    this._disposed = true;
     for (const d of this._disposables) {
       d.dispose();
     }

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -127,6 +127,17 @@ export class SessionManager implements vscode.Disposable {
 
     // Dispatch the claude command only after the shell prompt is ready
     await this._dispatchClaudeCommand(terminal);
+
+    // Persist the new shell's PID so the next activation's reattach pass
+    // has a baseline. processId is a Thenable; we don't block here.
+    terminal.processId.then(
+      (pid) => {
+        if (pid !== undefined) {
+          this._persistSessionPid(normalized, pid);
+        }
+      },
+      () => { /* ignore — best-effort persistence */ }
+    );
   }
 
   /**
@@ -379,6 +390,12 @@ export class SessionManager implements vscode.Disposable {
       },
       () => { /* ignore */ }
     );
+
+    // Clear the persisted PID for this folder so the next activation's
+    // reattach pass doesn't see a stale baseline. Runs UNCONDITIONALLY
+    // (regardless of relaunchOnStartup setting) to prevent stale baselines
+    // when the user toggles the setting off then back on.
+    this._clearSessionPid(session.folderPath);
 
     this._cleanupStateFile(session.folderPath);
     this._onDidChangeSessions.fire();

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
-import { getClaudeCommand, getReuseTerminal, getLaunchDelayMs } from "./config";
+import { getClaudeCommand, getReuseTerminal, getLaunchDelayMs, getRelaunchOnStartup } from "./config";
 import { log, debugLog } from "./output";
 
 /** Prefix used for all Claude session terminal names */
@@ -55,6 +55,13 @@ export class SessionManager implements vscode.Disposable {
    */
   private _pidWriteQueue: Promise<void> = Promise.resolve();
 
+  /**
+   * Promise from the reattach pass kicked off in the constructor.
+   * Tests await this to verify reattach completed; production callers
+   * fire-and-forget.
+   */
+  private _reattachPromise: Promise<void> = Promise.resolve();
+
   /** workspaceState injected by the extension activator. */
   private readonly _workspaceState: vscode.Memento;
 
@@ -75,6 +82,12 @@ export class SessionManager implements vscode.Disposable {
       }),
       this._onDidChangeSessions
     );
+
+    // Kick off reattach pass for restored Claude tabs (gated by setting).
+    // Fire-and-forget — _reattachPromise is exposed for tests.
+    if (getRelaunchOnStartup()) {
+      this._reattachPromise = this._reattachRestoredSessions();
+    }
   }
 
   /** All currently active Claude sessions. */
@@ -256,6 +269,59 @@ export class SessionManager implements vscode.Disposable {
     const delayMs = getLaunchDelayMs();
     await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
     terminal.sendText(cmd);
+  }
+
+  /**
+   * Reattach pass for restored Claude session tabs (#43).
+   *
+   * Runs once at the end of the constructor when relaunchOnStartup is on.
+   * Iterates a SYNCHRONOUS SNAPSHOT of _sessions.values() taken at entry
+   * (defensive against onDidOpenTerminal mid-iteration mutation), kicks
+   * off per-session async routines, awaits Promise.allSettled, and shows
+   * an aggregate dead-cwd toast when applicable.
+   *
+   * The toast is gated on !this._disposed so a dispose() that lands during
+   * the routines doesn't surface a stale warning.
+   *
+   * Per-session decision logic, dispatch, and cwd-missing handling are
+   * implemented in subsequent tasks of this plan.
+   */
+  private async _reattachRestoredSessions(): Promise<void> {
+    debugLog(`[reattach] starting pass — sessions=${this._sessions.size}`);
+    const snapshot = Array.from(this._sessions.values());
+    const deadCwds: string[] = [];
+
+    await Promise.allSettled(
+      snapshot.map((session) => this._reattachOneSession(session, deadCwds))
+    );
+
+    if (!this._disposed && deadCwds.length > 0) {
+      const shown = deadCwds.slice(0, 3);
+      const overflow = deadCwds.length - shown.length;
+      const folderList = shown.join(", ") + (overflow > 0 ? `, and ${overflow} more` : "");
+      const noun = deadCwds.length === 1 ? "session" : "sessions";
+      vscode.window.showInformationMessage(
+        `Could not restore ${deadCwds.length} ${noun} — folder${deadCwds.length === 1 ? "" : "s"} no longer exist: ${folderList}`
+      );
+    }
+
+    debugLog(`[reattach] pass complete — deadCwds=${deadCwds.length}`);
+  }
+
+  /**
+   * Per-session reattach decision. Mutates `deadCwds` in place when the
+   * session's cwd no longer exists on disk.
+   *
+   * Skeleton implementation in this task — full decision logic lands in
+   * Task 7 (PID compare/dispatch) and Task 8 (cwd-missing handling).
+   */
+  private async _reattachOneSession(
+    session: ActiveSession,
+    deadCwds: string[]
+  ): Promise<void> {
+    // Placeholder — will be filled in by Task 7 and Task 8.
+    void session;
+    void deadCwds;
   }
 
   /** Focus an existing session's editor tab. */

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -309,19 +309,57 @@ export class SessionManager implements vscode.Disposable {
   }
 
   /**
-   * Per-session reattach decision. Mutates `deadCwds` in place when the
+   * Per-session reattach decision (#43). Mutates `deadCwds` in place when the
    * session's cwd no longer exists on disk.
    *
-   * Skeleton implementation in this task — full decision logic lands in
-   * Task 7 (PID compare/dispatch) and Task 8 (cwd-missing handling).
+   * Decision branches:
+   * - currentPid undefined/reject → skip (can't reason about state).
+   * - storedPid === currentPid → shell survived; refresh record, skip dispatch.
+   * - cwd missing → enqueue for aggregate toast, dispose tab.
+   * - else (PID differ or no stored PID) → dispatch via the buffered-input-safe
+   *   helper, then persist the new PID.
    */
   private async _reattachOneSession(
     session: ActiveSession,
     deadCwds: string[]
   ): Promise<void> {
-    // Placeholder — will be filled in by Task 7 and Task 8.
-    void session;
-    void deadCwds;
+    // 1. Resolve current PID (await — Thenable)
+    let currentPid: number | undefined;
+    try {
+      currentPid = await session.terminal.processId;
+    } catch {
+      currentPid = undefined;
+    }
+
+    if (currentPid === undefined) {
+      debugLog(`[reattach:one] folderPath=${session.folderPath} pid=undefined — skip`);
+      return;
+    }
+
+    // 2. Read previously-stored PID from workspaceState
+    const record =
+      this._workspaceState.get<Record<string, number>>(PID_KEY) ?? {};
+    const storedPid = record[this._normalizePersistKey(session.folderPath)];
+
+    // 3. PID match → shell survived, refresh record only, no dispatch
+    if (storedPid === currentPid) {
+      debugLog(`[reattach:one] folderPath=${session.folderPath} pid=${currentPid} match — skip dispatch`);
+      this._persistSessionPid(session.folderPath, currentPid);
+      return;
+    }
+
+    // 4. Cwd missing? Dispose and queue for the aggregate toast.
+    if (!fs.existsSync(session.folderPath)) {
+      debugLog(`[reattach:one] folderPath=${session.folderPath} cwd missing — dispose`);
+      deadCwds.push(session.folderPath);
+      session.terminal.dispose();
+      return;
+    }
+
+    // 5. Fresh shell — dispatch claude, then persist new PID
+    debugLog(`[reattach:one] folderPath=${session.folderPath} stored=${storedPid} current=${currentPid} — dispatch`);
+    await this._dispatchClaudeIntoRestoredTerminal(session.terminal);
+    this._persistSessionPid(session.folderPath, currentPid);
   }
 
   /** Focus an existing session's editor tab. */

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -635,7 +635,7 @@ export class SessionManager implements vscode.Disposable {
           current[this._normalizePersistKey(folderPath)] = pid;
           await this._workspaceState.update(PID_KEY, current);
         } catch (err) {
-          log(`[reattach] failed to persist PID for ${folderPath}: ${String(err)}`);
+          log(`[pid] failed to persist PID for ${folderPath}: ${String(err)}`);
         }
       });
   }
@@ -654,7 +654,7 @@ export class SessionManager implements vscode.Disposable {
           delete current[this._normalizePersistKey(folderPath)];
           await this._workspaceState.update(PID_KEY, current);
         } catch (err) {
-          log(`[reattach] failed to clear PID for ${folderPath}: ${String(err)}`);
+          log(`[pid] failed to clear PID for ${folderPath}: ${String(err)}`);
         }
       });
   }

--- a/test/addFolderPrompt.stale.test.ts
+++ b/test/addFolderPrompt.stale.test.ts
@@ -19,6 +19,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createMemento } from "./mocks/vscode";
 import * as fs from "fs";
 
 // Mock the entire `fs` module so we can control existsSync / statSync / readdirSync
@@ -176,7 +177,7 @@ describe("addFolderPrompt — stale _sessions entry (issue #71)", () => {
     // ARRANGE: construct a fresh SessionManager with no terminals.
     // PATH_A is mocked as non-existent on disk via fs.existsSync above.
     // -------------------------------------------------------------------------
-    const manager = new SessionManager();
+    const manager = new SessionManager(createMemento() as unknown as import("vscode").Memento);
 
     vi.mocked(vscodeMock.window.createTerminal).mockClear();
 

--- a/test/dispatchClaudeIntoRestoredTerminal.test.ts
+++ b/test/dispatchClaudeIntoRestoredTerminal.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for SessionManager._dispatchClaudeIntoRestoredTerminal (#43).
+ *
+ * Verifies the three dispatch tiers and that the buffered-input clear-prefix
+ * () is sent ONLY on the delay-fallback path — not on the
+ * shell-integration fast or slow paths, where executeCommand handles command
+ * boundaries safely.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as vscodeMock from "./mocks/vscode";
+import { createMemento } from "./mocks/vscode";
+import { SessionManager } from "../src/sessionManager";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Private = any;
+
+describe("_dispatchClaudeIntoRestoredTerminal", () => {
+  let sm: SessionManager;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    (vscodeMock.window as Record<string, unknown>).terminals = [];
+    sm = new SessionManager(createMemento() as unknown as import("vscode").Memento);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fast path: shell integration active → executeCommand called once, no clear-prefix", async () => {
+    const executeCommand = vi.fn();
+    const sendText = vi.fn();
+    const terminal = {
+      name: "claude · foo",
+      sendText,
+      shellIntegration: { executeCommand },
+      creationOptions: { cwd: "D:\\foo" },
+    } as unknown as import("vscode").Terminal;
+
+    await (sm as Private)._dispatchClaudeIntoRestoredTerminal(terminal);
+
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    expect(executeCommand).toHaveBeenCalledWith("claude");
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
+  it("slow path: shell integration activates within window → executeCommand called", async () => {
+    const sendText = vi.fn();
+    const terminal = {
+      name: "claude · foo",
+      sendText,
+      shellIntegration: undefined as unknown,
+      creationOptions: { cwd: "D:\\foo" },
+    } as unknown as import("vscode").Terminal;
+
+    // Capture the listener registered by the slow path
+    let registeredListener:
+      | ((e: {
+          terminal: unknown;
+          shellIntegration: { executeCommand: ReturnType<typeof vi.fn> };
+        }) => void)
+      | undefined;
+    vi.spyOn(vscodeMock.window, "onDidChangeTerminalShellIntegration").mockImplementation((cb) => {
+      registeredListener = cb as typeof registeredListener;
+      return new vscodeMock.Disposable(() => {});
+    });
+
+    const dispatchPromise = (sm as Private)._dispatchClaudeIntoRestoredTerminal(terminal);
+
+    // Fire the activation event with a fresh shellIntegration object
+    const activated = { executeCommand: vi.fn() };
+    expect(registeredListener).toBeDefined();
+    registeredListener!({ terminal, shellIntegration: activated });
+
+    await dispatchPromise;
+
+    expect(activated.executeCommand).toHaveBeenCalledWith("claude");
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
+  it("delay fallback: no shell integration → clear-prefix sent, then claude after delay", async () => {
+    vi.useFakeTimers();
+    const sendText = vi.fn();
+    const terminal = {
+      name: "claude · foo",
+      sendText,
+      shellIntegration: undefined as unknown,
+      creationOptions: { cwd: "D:\\foo" },
+    } as unknown as import("vscode").Terminal;
+
+    // The slow-path listener is registered but never fires
+    vi.spyOn(vscodeMock.window, "onDidChangeTerminalShellIntegration").mockReturnValue(
+      new vscodeMock.Disposable(() => {})
+    );
+
+    const dispatchPromise = (sm as Private)._dispatchClaudeIntoRestoredTerminal(terminal);
+
+    // Advance 2000ms → slow-path times out
+    await vi.advanceTimersByTimeAsync(2000);
+    // Advance 50ms breather between clear-prefix and dispatch
+    await vi.advanceTimersByTimeAsync(50);
+    // Advance launchDelayMs (default 500ms) → delay-fallback fires sendText("claude")
+    await vi.advanceTimersByTimeAsync(500);
+    await dispatchPromise;
+
+    // Two sendText calls in order:
+    //   1. clear-prefix  with addNewLine: false (2 args)
+    //   2. "claude" with implicit newline (1 arg)
+    expect(sendText).toHaveBeenCalledTimes(2);
+    expect(sendText).toHaveBeenNthCalledWith(1, "", false);
+    expect(sendText).toHaveBeenNthCalledWith(2, "claude");
+  });
+});

--- a/test/mocks/vscode.ts
+++ b/test/mocks/vscode.ts
@@ -165,6 +165,43 @@ class OutputChannelStub {
 }
 
 // ---------------------------------------------------------------------------
+// Memento (workspaceState / globalState) factory
+//
+// Tests use this to construct mock Mementos with per-call control over
+// `update` (e.g. via vi.mockImplementationOnce). The default `update`
+// resolves to undefined and writes through to the internal Map; tests can
+// override by calling `update.mockImplementationOnce(...)`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Spyable Memento mock — use vi.fn's mockImplementationOnce to inject
+ * failures (e.g. an update() that rejects on the first call only).
+ */
+export interface MementoMock {
+  get: ReturnType<typeof vi.fn> & (<T>(key: string, defaultValue?: T) => T | undefined);
+  update: ReturnType<typeof vi.fn> & ((key: string, value: unknown) => Promise<void>);
+  keys: ReturnType<typeof vi.fn> & (() => string[]);
+  /** Direct access to the backing store for assertions in tests */
+  readonly _store: Map<string, unknown>;
+}
+
+export function createMemento(initial: Record<string, unknown> = {}): MementoMock {
+  const store = new Map<string, unknown>(Object.entries(initial));
+  const get = vi.fn(<T>(key: string, defaultValue?: T): T | undefined => {
+    return (store.has(key) ? store.get(key) : defaultValue) as T | undefined;
+  }) as MementoMock["get"];
+  const update = vi.fn(async (key: string, value: unknown): Promise<void> => {
+    if (value === undefined) {
+      store.delete(key);
+    } else {
+      store.set(key, value);
+    }
+  }) as MementoMock["update"];
+  const keys = vi.fn(() => Array.from(store.keys())) as MementoMock["keys"];
+  return { get, update, keys, _store: store };
+}
+
+// ---------------------------------------------------------------------------
 // FileSystemWatcher stub
 // ---------------------------------------------------------------------------
 
@@ -256,4 +293,17 @@ export const commands = {
 
 export const env = {
   openExternal: vi.fn().mockResolvedValue(true),
+};
+
+// ---------------------------------------------------------------------------
+// extensions namespace
+//
+// Minimal stub: only getExtension is implemented. Tests that touch other
+// vscode.extensions APIs (getExtensionById, all, onDidChange) must add
+// stubs here — relying on `undefined` will throw "X is not a function" at
+// test runtime, which is a clear failure mode (not silent).
+// ---------------------------------------------------------------------------
+
+export const extensions = {
+  getExtension: vi.fn().mockReturnValue(undefined),
 };

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for the day-1 collision proactive-detection flow (#43, scenarios 16–18).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as vscodeMock from "./mocks/vscode";
+import { createMemento, MementoMock } from "./mocks/vscode";
+import { runReattachOnboarding, ONBOARDING_KEY } from "../src/onboarding";
+
+describe("reattach onboarding (#43)", () => {
+  let globalState: MementoMock;
+  let configUpdate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vscodeMock.window.showInformationMessage.mockClear();
+    globalState = createMemento();
+    configUpdate = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(vscodeMock.workspace, "getConfiguration").mockReturnValue({
+      get: vi.fn(),
+      update: configUpdate,
+    } as unknown as import("vscode").WorkspaceConfiguration);
+  });
+
+  // Scenario 16: official extension installed + Disable click
+  it("official extension installed + first activation + user clicks Disable → setting set to false, flag set", async () => {
+    vi.mocked(vscodeMock.extensions.getExtension).mockReturnValue(
+      { id: "Anthropic.claude-code" } as unknown as import("vscode").Extension<unknown>
+    );
+    vi.mocked(vscodeMock.window.showInformationMessage).mockResolvedValue(
+      "Disable" as unknown as import("vscode").MessageItem
+    );
+
+    await runReattachOnboarding(globalState as unknown as import("vscode").Memento);
+
+    expect(vscodeMock.window.showInformationMessage).toHaveBeenCalledTimes(1);
+    expect(configUpdate).toHaveBeenCalledWith(
+      "relaunchOnStartup",
+      false,
+      expect.anything() // ConfigurationTarget.Global
+    );
+    expect(globalState._store.get(ONBOARDING_KEY)).toBe(true);
+  });
+
+  // Scenario 16 — Enable variant
+  it("official extension installed + Enable click → no setting update, flag set", async () => {
+    vi.mocked(vscodeMock.extensions.getExtension).mockReturnValue(
+      { id: "Anthropic.claude-code" } as unknown as import("vscode").Extension<unknown>
+    );
+    vi.mocked(vscodeMock.window.showInformationMessage).mockResolvedValue(
+      "Enable" as unknown as import("vscode").MessageItem
+    );
+
+    await runReattachOnboarding(globalState as unknown as import("vscode").Memento);
+
+    expect(configUpdate).not.toHaveBeenCalled();
+    expect(globalState._store.get(ONBOARDING_KEY)).toBe(true);
+  });
+
+  // Scenario 17: no official extension → no toast, flag still set
+  it("no official extension → no toast, flag still set", async () => {
+    vi.mocked(vscodeMock.extensions.getExtension).mockReturnValue(undefined);
+
+    await runReattachOnboarding(globalState as unknown as import("vscode").Memento);
+
+    expect(vscodeMock.window.showInformationMessage).not.toHaveBeenCalled();
+    expect(configUpdate).not.toHaveBeenCalled();
+    expect(globalState._store.get(ONBOARDING_KEY)).toBe(true);
+  });
+
+  // Scenario 18: already shown → no toast, no flag write
+  it("already shown → no toast, no flag write, no setting change", async () => {
+    globalState._store.set(ONBOARDING_KEY, true);
+    vi.mocked(vscodeMock.extensions.getExtension).mockReturnValue(
+      { id: "Anthropic.claude-code" } as unknown as import("vscode").Extension<unknown>
+    );
+
+    await runReattachOnboarding(globalState as unknown as import("vscode").Memento);
+
+    expect(vscodeMock.window.showInformationMessage).not.toHaveBeenCalled();
+    expect(configUpdate).not.toHaveBeenCalled();
+    // Flag was already true; no NEW write should happen, but value still true
+    expect(globalState._store.get(ONBOARDING_KEY)).toBe(true);
+  });
+});

--- a/test/reattachOnStartup.test.ts
+++ b/test/reattachOnStartup.test.ts
@@ -9,6 +9,9 @@ import * as vscodeMock from "./mocks/vscode";
 import { createMemento } from "./mocks/vscode";
 import { SessionManager } from "../src/sessionManager";
 import * as config from "../src/config";
+import * as fs from "fs";
+
+vi.mock("fs");
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Private = any;
@@ -36,6 +39,8 @@ describe("reattach on startup — orchestration", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     (vscodeMock.window as Record<string, unknown>).terminals = [];
+    // Default: all paths exist on disk (individual tests override as needed)
+    vi.mocked(fs.existsSync).mockReturnValue(true);
   });
 
   // Scenario 12 from the design spec
@@ -50,6 +55,115 @@ describe("reattach on startup — orchestration", () => {
 
     expect((term as { sendText: ReturnType<typeof vi.fn> }).sendText).not.toHaveBeenCalled();
     expect(vscodeMock.window.showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  // Scenario 1: same PID → no dispatch, but PID re-persisted
+  it("same PID → no dispatch, record refreshed", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const term = makeTerminal({ name: "claude · foo", cwd: "D:\\foo", pid: 42 });
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    const mem = createMemento({ [PID_KEY]: { "D:\\foo": 42 } });
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+    await (sm as Private)._pidWriteQueue;
+
+    expect((term as { sendText: ReturnType<typeof vi.fn> }).sendText).not.toHaveBeenCalled();
+    // Record refreshed (re-written even though PID matched)
+    expect(mem.update).toHaveBeenCalled();
+    expect(mem._store.get(PID_KEY)).toEqual({ "D:\\foo": 42 });
+  });
+
+  // Scenario 2: different PID → dispatch via shell-integration fast path
+  it("different PID → fast-path dispatch + PID written", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const executeCommand = vi.fn();
+    const term = makeTerminal({
+      name: "claude · foo",
+      cwd: "D:\\foo",
+      pid: 42,
+      shellIntegration: { executeCommand },
+    });
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    const mem = createMemento({ [PID_KEY]: { "D:\\foo": 99 } });
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+    await (sm as Private)._pidWriteQueue;
+
+    expect(executeCommand).toHaveBeenCalledWith("claude");
+    expect((term as { sendText: ReturnType<typeof vi.fn> }).sendText).not.toHaveBeenCalled();
+    expect(mem._store.get(PID_KEY)).toEqual({ "D:\\foo": 42 });
+  });
+
+  // Scenario 5: no stored PID → dispatch + PID written
+  it("no stored PID → dispatch + PID written", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const executeCommand = vi.fn();
+    const term = makeTerminal({
+      name: "claude · foo",
+      cwd: "D:\\foo",
+      pid: 42,
+      shellIntegration: { executeCommand },
+    });
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    const mem = createMemento(); // empty record
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+    await (sm as Private)._pidWriteQueue;
+
+    expect(executeCommand).toHaveBeenCalledWith("claude");
+    expect(mem._store.get(PID_KEY)).toEqual({ "D:\\foo": 42 });
+  });
+
+  // Scenario 8: processId resolves to undefined → no dispatch
+  it("processId undefined → no dispatch, no dispose, no PID write", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const term = {
+      name: "claude · foo",
+      show: vi.fn(),
+      sendText: vi.fn(),
+      dispose: vi.fn(),
+      processId: Promise.resolve(undefined),
+      shellIntegration: { executeCommand: vi.fn() },
+      creationOptions: { cwd: "D:\\foo" },
+    };
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    const mem = createMemento();
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+
+    expect(term.shellIntegration.executeCommand).not.toHaveBeenCalled();
+    expect(term.sendText).not.toHaveBeenCalled();
+    expect(term.dispose).not.toHaveBeenCalled();
+    expect(mem._store.get(PID_KEY)).toBeUndefined();
+  });
+
+  // Scenario 9: processId rejects → no dispatch
+  it("processId rejects → no dispatch, no dispose", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const term = {
+      name: "claude · foo",
+      show: vi.fn(),
+      sendText: vi.fn(),
+      dispose: vi.fn(),
+      processId: Promise.reject(new Error("rejected")),
+      shellIntegration: { executeCommand: vi.fn() },
+      creationOptions: { cwd: "D:\\foo" },
+    };
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    const mem = createMemento();
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+
+    expect(term.shellIntegration.executeCommand).not.toHaveBeenCalled();
+    expect(term.sendText).not.toHaveBeenCalled();
+    expect(term.dispose).not.toHaveBeenCalled();
   });
 
   // Scenario 19 from the design spec

--- a/test/reattachOnStartup.test.ts
+++ b/test/reattachOnStartup.test.ts
@@ -250,4 +250,133 @@ describe("reattach on startup — orchestration", () => {
     // is tracked in _sessions but no reattach dispatch fires for it.
     expect((newTerm as { sendText: ReturnType<typeof vi.fn> }).sendText).not.toHaveBeenCalled();
   });
+
+  // Scenario 14: AUTO_LAUNCH_KEY interaction
+  // Reattach dispatches first; AUTO_LAUNCH_KEY launchSession finds the
+  // session and focuses it (no duplicate createTerminal).
+  it("AUTO_LAUNCH_KEY + reattach for the same folder → one dispatch + one focus, no duplicate terminal", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    vi.spyOn(config, "getReuseTerminal").mockReturnValue(true);
+    const executeCommand = vi.fn();
+    const term = makeTerminal({
+      name: "claude · foo",
+      cwd: "D:\\foo",
+      pid: 42,
+      shellIntegration: { executeCommand },
+    });
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const mem = createMemento({ [PID_KEY]: { "D:\\foo": 99 } });
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+
+    // Dispatch happened
+    expect(executeCommand).toHaveBeenCalledTimes(1);
+    const dispatchCallOrder = executeCommand.mock.invocationCallOrder[0];
+
+    // Now simulate the AUTO_LAUNCH_KEY block — call launchSession for the same folder.
+    // Because reuseExistingTerminal is true, this should focus the existing
+    // session, not create a new terminal.
+    const showSpy = vi.spyOn(term as { show: ReturnType<typeof vi.fn> }, "show");
+    await sm.launchSession("D:\\foo");
+
+    expect(showSpy).toHaveBeenCalled();
+    const focusCallOrder = showSpy.mock.invocationCallOrder[0];
+    expect(focusCallOrder).toBeGreaterThan(dispatchCallOrder);
+    // No new terminal was created via createTerminal beyond the original
+    expect(vscodeMock.window.createTerminal).not.toHaveBeenCalled();
+  });
+
+  // Scenario 15: dispose racing with reattach
+  it("dispose() mid-reattach → no PID write, no toast, no exception", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    // processId resolves after a delay — gives us time to dispose mid-await
+    let resolveProcessId: (v: number | undefined) => void;
+    const processIdPromise = new Promise<number | undefined>((r) => {
+      resolveProcessId = r;
+    });
+    const term = {
+      name: "claude · foo",
+      show: vi.fn(),
+      sendText: vi.fn(),
+      dispose: vi.fn(),
+      processId: processIdPromise,
+      shellIntegration: { executeCommand: vi.fn() },
+      creationOptions: { cwd: "D:\\foo" },
+    };
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const mem = createMemento();
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+
+    // Dispose immediately — _disposed is now set
+    sm.dispose();
+
+    // Resolve the processId so the routine can complete
+    resolveProcessId!(42);
+
+    // Wait for the routine to settle
+    await (sm as Private)._reattachPromise;
+    await (sm as Private)._pidWriteQueue;
+
+    // No PID write — _persistSessionPid no-ops after dispose()
+    expect(mem.update).not.toHaveBeenCalled();
+    // No toast (gated on !_disposed)
+    expect(vscodeMock.window.showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  // Scenario 11: workspaceState.update rejection mid-chain → queue self-heals
+  it("workspaceState.update rejects once → next persist still succeeds", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const executeCommand = vi.fn();
+    const t1 = makeTerminal({
+      name: "claude · a",
+      cwd: "D:\\a",
+      pid: 1,
+      shellIntegration: { executeCommand },
+    });
+    const t2 = makeTerminal({
+      name: "claude · b",
+      cwd: "D:\\b",
+      pid: 2,
+      shellIntegration: { executeCommand },
+    });
+    (vscodeMock.window as Record<string, unknown>).terminals = [t1, t2];
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const mem = createMemento();
+    // First update rejects — second + onward succeed
+    mem.update.mockImplementationOnce(() => Promise.reject(new Error("disk full")));
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+    await (sm as Private)._pidWriteQueue;
+
+    // Both dispatches happened
+    expect(executeCommand).toHaveBeenCalledTimes(2);
+    // The second update succeeded → store has at least t2's PID
+    const stored = mem._store.get(PID_KEY) as Record<string, number>;
+    expect(stored).toBeDefined();
+    // Order isn't guaranteed (parallel), but at least one PID landed
+    expect(Object.keys(stored).length).toBeGreaterThanOrEqual(1);
+  });
+
+  // Scenario 13: PID cleanup runs whether the setting is on or off
+  it("_clearSessionPid runs unconditionally (setting off does not gate close cleanup)", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(false);
+    const term = makeTerminal({ name: "claude · foo", cwd: "D:\\foo", pid: 42 });
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+    const mem = createMemento({ [PID_KEY]: { "D:\\foo": 42 } });
+
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+
+    // Reattach didn't fire (setting off). Now simulate close.
+    (sm as Private)._removeByKey(term);
+    await (sm as Private)._pidWriteQueue;
+
+    // PID cleared even though setting is off
+    expect(mem._store.get(PID_KEY)).toEqual({});
+  });
 });

--- a/test/reattachOnStartup.test.ts
+++ b/test/reattachOnStartup.test.ts
@@ -39,6 +39,9 @@ describe("reattach on startup — orchestration", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     (vscodeMock.window as Record<string, unknown>).terminals = [];
+    // Clear call history on plain vi.fn() instances (vi.restoreAllMocks only
+    // resets spies, not these module-level fns, so counts bleed otherwise).
+    vscodeMock.window.showInformationMessage.mockClear();
     // Default: all paths exist on disk (individual tests override as needed)
     vi.mocked(fs.existsSync).mockReturnValue(true);
   });
@@ -164,6 +167,60 @@ describe("reattach on startup — orchestration", () => {
     expect(term.shellIntegration.executeCommand).not.toHaveBeenCalled();
     expect(term.sendText).not.toHaveBeenCalled();
     expect(term.dispose).not.toHaveBeenCalled();
+  });
+
+  // Scenario 6: cwd missing for one tab → dispose + single-entry toast
+  it("cwd missing (single tab) → dispose + toast with one folder", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    const term = makeTerminal({ name: "claude · foo", cwd: "D:\\foo", pid: 42 });
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+
+    const sm = new SessionManager(createMemento() as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+
+    expect((term as { dispose: ReturnType<typeof vi.fn> }).dispose).toHaveBeenCalled();
+    expect((term as { sendText: ReturnType<typeof vi.fn> }).sendText).not.toHaveBeenCalled();
+    expect(vscodeMock.window.showInformationMessage).toHaveBeenCalledTimes(1);
+    expect(vscodeMock.window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining("D:\\foo")
+    );
+    // Lock the singular/plural pluralization branch: 1 dead cwd → singular noun
+    const msg = vi.mocked(vscodeMock.window.showInformationMessage).mock.calls[0][0] as string;
+    expect(msg).toMatch(/1 session\b/);  // exactly "1 session" (singular), not "sessions"
+    expect(msg).not.toMatch(/sessions\b/);
+  });
+
+  // Scenario 7: 5 dead cwds → ONE toast with first 3 names + "and 2 more"
+  it("5 cwds missing → ONE aggregate toast with truncation", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    // Map.values() preserves insertion order in modern JS, so the toast
+    // truncation will list folders in the order they were tracked here.
+    const folders = ["D:\\a", "D:\\b", "D:\\c", "D:\\d", "D:\\e"];
+    const terms = folders.map((cwd, i) =>
+      makeTerminal({ name: `claude · ${cwd}`, cwd, pid: 100 + i })
+    );
+    (vscodeMock.window as Record<string, unknown>).terminals = terms;
+
+    const sm = new SessionManager(createMemento() as unknown as import("vscode").Memento);
+    await (sm as Private)._reattachPromise;
+
+    // All 5 disposed
+    for (const t of terms) {
+      expect((t as { dispose: ReturnType<typeof vi.fn> }).dispose).toHaveBeenCalled();
+    }
+
+    // ONE toast with first 3 folder names + "and 2 more"
+    expect(vscodeMock.window.showInformationMessage).toHaveBeenCalledTimes(1);
+    const msg = vi.mocked(vscodeMock.window.showInformationMessage).mock.calls[0][0];
+    expect(msg).toContain("D:\\a");
+    expect(msg).toContain("D:\\b");
+    expect(msg).toContain("D:\\c");
+    expect(msg).toContain("and 2 more");
+    // d and e should NOT appear by name
+    expect(msg).not.toContain("D:\\d");
+    expect(msg).not.toContain("D:\\e");
   });
 
   // Scenario 19 from the design spec

--- a/test/reattachOnStartup.test.ts
+++ b/test/reattachOnStartup.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Integration tests for SessionManager reattach-on-startup (#43).
+ *
+ * Tests are organized by spec scenario number (see design doc test table).
+ * Scenarios are added incrementally as plan tasks 6-9 land.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as vscodeMock from "./mocks/vscode";
+import { createMemento } from "./mocks/vscode";
+import { SessionManager } from "../src/sessionManager";
+import * as config from "../src/config";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Private = any;
+
+const PID_KEY = "claudeConductor.sessionPids";
+
+function makeTerminal(opts: {
+  name: string;
+  cwd: string;
+  pid?: number;
+  shellIntegration?: { executeCommand: ReturnType<typeof vi.fn> };
+}): unknown {
+  return {
+    name: opts.name,
+    show: vi.fn(),
+    sendText: vi.fn(),
+    dispose: vi.fn(),
+    processId: Promise.resolve(opts.pid ?? 1234),
+    shellIntegration: opts.shellIntegration,
+    creationOptions: { cwd: opts.cwd },
+  };
+}
+
+describe("reattach on startup — orchestration", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    (vscodeMock.window as Record<string, unknown>).terminals = [];
+  });
+
+  // Scenario 12 from the design spec
+  it("setting off → reattach is a no-op (no dispatch, no toast)", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(false);
+    const term = makeTerminal({ name: "claude · foo", cwd: "D:\\foo", pid: 42 });
+    (vscodeMock.window as Record<string, unknown>).terminals = [term];
+
+    const sm = new SessionManager(createMemento() as unknown as import("vscode").Memento);
+    // Wait for any reattach work to complete (it shouldn't have started)
+    await (sm as Private)._reattachPromise;
+
+    expect((term as { sendText: ReturnType<typeof vi.fn> }).sendText).not.toHaveBeenCalled();
+    expect(vscodeMock.window.showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  // Scenario 19 from the design spec
+  it("snapshot iteration: onDidOpenTerminal mid-reattach is not included", async () => {
+    vi.spyOn(config, "getRelaunchOnStartup").mockReturnValue(true);
+    const original = makeTerminal({ name: "claude · foo", cwd: "D:\\foo", pid: 42 });
+    (vscodeMock.window as Record<string, unknown>).terminals = [original];
+
+    // Capture onDidOpenTerminal callback so we can fire a synthetic event
+    let openCallback: ((t: unknown) => void) | undefined;
+    vi.spyOn(vscodeMock.window, "onDidOpenTerminal").mockImplementation((cb) => {
+      openCallback = cb as typeof openCallback;
+      return new vscodeMock.Disposable(() => {});
+    });
+
+    const mem = createMemento();
+    const sm = new SessionManager(mem as unknown as import("vscode").Memento);
+
+    // Fire onDidOpenTerminal for a NEW Claude terminal during reattach
+    const newTerm = makeTerminal({ name: "claude · bar", cwd: "D:\\bar", pid: 99 });
+    expect(openCallback).toBeDefined();
+    openCallback!(newTerm);
+
+    await (sm as Private)._reattachPromise;
+
+    // The reattach iteration only saw the original (snapshot). The new terminal
+    // is tracked in _sessions but no reattach dispatch fires for it.
+    expect((newTerm as { sendText: ReturnType<typeof vi.fn> }).sendText).not.toHaveBeenCalled();
+  });
+});

--- a/test/sessionManager.debugLog.test.ts
+++ b/test/sessionManager.debugLog.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as vscodeMock from "./mocks/vscode";
+import { createMemento } from "./mocks/vscode";
 import { getOutputChannel } from "../src/output";
 import { SessionManager } from "../src/sessionManager";
 
@@ -56,7 +57,7 @@ describe("SessionManager close-detection debug logging", () => {
       new vscodeMock.Disposable(() => {})
     );
 
-    const manager = new SessionManager();
+    const manager = new SessionManager(createMemento() as unknown as import("vscode").Memento);
 
     // Manually insert the session so _handleTerminalClose has something to match
     // We do this by triggering onDidOpenTerminal with a claude-prefixed terminal.

--- a/test/sessionManager.focusSession.test.ts
+++ b/test/sessionManager.focusSession.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import { createMemento } from "./mocks/vscode";
 import { SessionManager } from "../src/sessionManager";
 import type { ActiveSession } from "../src/sessionManager";
 
@@ -24,7 +25,7 @@ describe("SessionManager.focusSession", () => {
       isIdle: false,
     };
 
-    const manager = new SessionManager();
+    const manager = new SessionManager(createMemento() as unknown as import("vscode").Memento);
     manager.focusSession(session);
 
     expect(show).toHaveBeenCalledOnce();

--- a/test/sessionManagerPidPersistence.test.ts
+++ b/test/sessionManagerPidPersistence.test.ts
@@ -12,6 +12,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import * as vscodeMock from "./mocks/vscode";
 import { createMemento, MementoMock } from "./mocks/vscode";
 import { SessionManager } from "../src/sessionManager";
+import * as fs from "fs";
+
+// Mock the entire `fs` module so we can control existsSync in launchSession tests.
+vi.mock("fs");
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Private = any;
@@ -82,5 +86,55 @@ describe("SessionManager PID persistence", () => {
     await (sm as Private)._pidWriteQueue;
     const stored = mem._store.get(PID_KEY) as Record<string, number>;
     expect(Object.keys(stored)).toEqual(["D:\\Project\\MyApp"]);
+  });
+
+  it("launchSession persists PID after the new terminal's processId resolves", async () => {
+    // Mock createTerminal to return a fake terminal whose processId resolves to 999
+    const fakeTerminal = {
+      name: "claude · proj",
+      show: vi.fn(),
+      sendText: vi.fn(),
+      dispose: vi.fn(),
+      processId: Promise.resolve(999),
+      shellIntegration: undefined,
+      creationOptions: { cwd: "D:\\proj" },
+    };
+    vi.mocked(vscodeMock.window.createTerminal).mockReturnValue(
+      fakeTerminal as unknown as import("vscode").Terminal
+    );
+    // fs.existsSync must return true for launchSession's cwd guard
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    await sm.launchSession("D:\\proj");
+    // launchSession schedules the persist — drain the queue
+    await (sm as Private)._pidWriteQueue;
+
+    const stored = mem._store.get(PID_KEY) as Record<string, number>;
+    expect(stored).toEqual({ "D:\\proj": 999 });
+  });
+
+  it("_removeByKey clears the PID entry on session close", async () => {
+    // Seed _sessions and PID record
+    const fakeTerminal = {
+      name: "claude · proj",
+      processId: Promise.resolve(123),
+      creationOptions: { cwd: "D:\\proj" },
+    } as unknown as import("vscode").Terminal;
+    (sm as Private)._sessions.set(fakeTerminal, {
+      terminal: fakeTerminal,
+      folderPath: "D:\\proj",
+      folderName: "proj",
+      startedAt: new Date(),
+      isIdle: false,
+    });
+    (sm as Private)._persistSessionPid("D:\\proj", 123);
+    await (sm as Private)._pidWriteQueue;
+    expect(mem._store.get(PID_KEY)).toEqual({ "D:\\proj": 123 });
+
+    // Trigger close cleanup
+    (sm as Private)._removeByKey(fakeTerminal);
+    await (sm as Private)._pidWriteQueue;
+
+    expect(mem._store.get(PID_KEY)).toEqual({});
   });
 });

--- a/test/sessionManagerPidPersistence.test.ts
+++ b/test/sessionManagerPidPersistence.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for SessionManager PID persistence helpers (#43).
+ *
+ * Covers _persistSessionPid, _clearSessionPid, _normalizePersistKey, the
+ * _disposed guard, and the write-queue rejection-recovery path.
+ *
+ * These tests reach into SessionManager via `as any` to call private methods
+ * directly — that's intentional. The public surface for these helpers is
+ * exercised through the reattach-pass integration tests.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as vscodeMock from "./mocks/vscode";
+import { createMemento, MementoMock } from "./mocks/vscode";
+import { SessionManager } from "../src/sessionManager";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Private = any;
+
+const PID_KEY = "claudeConductor.sessionPids";
+
+describe("SessionManager PID persistence", () => {
+  let mem: MementoMock;
+  let sm: SessionManager;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    (vscodeMock.window as Record<string, unknown>).terminals = [];
+    mem = createMemento();
+    sm = new SessionManager(mem as unknown as import("vscode").Memento);
+  });
+
+  it("_normalizePersistKey preserves case", () => {
+    const result = (sm as Private)._normalizePersistKey("D:\\Projects\\MyApp");
+    expect(result.toLowerCase()).not.toBe(result); // sanity: input has uppercase
+    expect(result).toBe("D:\\Projects\\MyApp");
+  });
+
+  it("_persistSessionPid writes through to workspaceState", async () => {
+    (sm as Private)._persistSessionPid("D:\\proj\\foo", 42);
+    // Wait for the queue chain to drain
+    await (sm as Private)._pidWriteQueue;
+    expect(mem.update).toHaveBeenCalledWith(PID_KEY, { "D:\\proj\\foo": 42 });
+  });
+
+  it("_persistSessionPid is no-op after dispose()", async () => {
+    sm.dispose();
+    (sm as Private)._persistSessionPid("D:\\proj\\foo", 42);
+    await (sm as Private)._pidWriteQueue;
+    expect(mem.update).not.toHaveBeenCalled();
+  });
+
+  it("_clearSessionPid removes the entry", async () => {
+    (sm as Private)._persistSessionPid("D:\\proj\\foo", 42);
+    (sm as Private)._persistSessionPid("D:\\proj\\bar", 43);
+    await (sm as Private)._pidWriteQueue;
+    (sm as Private)._clearSessionPid("D:\\proj\\foo");
+    await (sm as Private)._pidWriteQueue;
+    expect(mem._store.get(PID_KEY)).toEqual({ "D:\\proj\\bar": 43 });
+  });
+
+  it("_clearSessionPid is no-op after dispose()", async () => {
+    (sm as Private)._persistSessionPid("D:\\proj\\foo", 42);
+    await (sm as Private)._pidWriteQueue;
+    sm.dispose();
+    (sm as Private)._clearSessionPid("D:\\proj\\foo");
+    await (sm as Private)._pidWriteQueue;
+    expect(mem._store.get(PID_KEY)).toEqual({ "D:\\proj\\foo": 42 });
+  });
+
+  it("queue self-heals after a workspaceState.update rejection", async () => {
+    mem.update.mockImplementationOnce(() => Promise.reject(new Error("disk full")));
+    (sm as Private)._persistSessionPid("D:\\proj\\foo", 42);
+    (sm as Private)._persistSessionPid("D:\\proj\\bar", 43);
+    await (sm as Private)._pidWriteQueue;
+    // First update rejected; second update should still have run.
+    expect(mem.update).toHaveBeenCalledTimes(2);
+    expect(mem._store.get(PID_KEY)).toEqual({ "D:\\proj\\bar": 43 });
+  });
+
+  it("preserves persisted-key case (does not lowercase)", async () => {
+    (sm as Private)._persistSessionPid("D:\\Project\\MyApp", 42);
+    await (sm as Private)._pidWriteQueue;
+    const stored = mem._store.get(PID_KEY) as Record<string, number>;
+    expect(Object.keys(stored)).toEqual(["D:\\Project\\MyApp"]);
+  });
+});


### PR DESCRIPTION
Closes #43.

## Summary

When VS Code restarts and Claude session tab envelopes are restored with fresh shells, Conductor now automatically dispatches `claude` into each tab so sessions come back without manual relaunch. Gated by a new `claudeConductor.relaunchOnStartup` setting (default `true`).

Implements the v3 design at `docs/superpowers/specs/2026-04-27-43-reattach-on-startup-design.md` (commit `216ce95`).

## Architecture

A new `_reattachRestoredSessions` async pass runs at the end of the `SessionManager` constructor (gated by `claudeConductor.relaunchOnStartup`). For each restored Claude terminal:

1. Snapshot iteration of `_sessions.values()` — defensive against `onDidOpenTerminal` mid-pass.
2. Await `terminal.processId` and compare against a previously-persisted PID (workspaceState).
3. **PID match** → shell survived, refresh record, skip dispatch (no stray `claude` keystroke).
4. **PID differ or no record** → fresh shell, dispatch via `_dispatchClaudeIntoRestoredTerminal` (clears any buffered prompt input on the delay-fallback path with `` Ctrl-C/Ctrl-U), then persist new PID.
5. **Cwd missing** → dispose tab, queue for an aggregate end-of-pass toast (`"Could not restore N session(s) — folder(s) no longer exist: a, b, c, and N more"`).
6. **`processId` undefined or rejected** → skip (can't reason about state).

PID persistence writes go through a serialized queue with `.catch(() => undefined).then(...)` rejection handling; `_disposed` guard prevents async-resolved writes after extension teardown.

Day-1 collision with the official Claude Code extension is mitigated by `runReattachOnboarding` in `src/onboarding.ts` — first-activation consent toast with Enable/Disable buttons when `Anthropic.claude-code` is detected.

## Changes

| File | Change |
|---|---|
| `src/sessionManager.ts` | Constructor takes `workspaceState`; new `_disposed`, `_pidWriteQueue`, `_workspaceState` fields; new methods `_normalizePersistKey`, `_persistSessionPid`, `_clearSessionPid`, `_dispatchClaudeIntoRestoredTerminal`, `_reattachRestoredSessions`, `_reattachOneSession`. `launchSession` persists PID after creation; `_removeByKey` clears PID unconditionally. |
| `src/onboarding.ts` | New module — first-activation consent flow. |
| `src/extension.ts` | `activate()` is async; awaits `runReattachOnboarding` first; passes `context.workspaceState` to `SessionManager`. |
| `src/config.ts` | New `getRelaunchOnStartup()` helper (default `true`). |
| `package.json` | New `claudeConductor.relaunchOnStartup` boolean configuration property. |
| `test/mocks/vscode.ts` | New `Memento` factory + `extensions` namespace stub. |
| 4 new test files | `sessionManagerPidPersistence.test.ts` (9 tests), `dispatchClaudeIntoRestoredTerminal.test.ts` (3 tests), `reattachOnStartup.test.ts` (13 tests), `onboarding.test.ts` (4 tests) — 29 new tests covering all 19 design-spec scenarios. |
| 3 existing test files | Migrated to pass mock `Memento` to the new `SessionManager` signature. |
| `README.md`, `CHANGELOG.md` | Document the new feature, the setting, the day-1 caveat, and the Windows-shell limitation per AC. |

## Test plan

- [x] `npm run lint` — clean (`tsc --noEmit`)
- [x] `npm test` — 94/94 tests pass (65 existing + 29 new)
- [x] `npm run compile` — clean (`tsc -p ./`)
- [ ] **Manual smoke (Extension Dev Host / clean profile install — yours to run)**:
  - Launch a Claude session, close VS Code, reopen → session reattaches automatically (PID match → no-op if shell survived; PID differ → auto-dispatch).
  - Set `claudeConductor.relaunchOnStartup: false`, restart VS Code → restored tab stays at bare prompt (no auto-dispatch).
  - Move a folder while VS Code is closed, restart → dead-cwd tab disposes with the aggregate toast.
  - With the official Claude Code extension installed, first activation post-install → consent toast appears once with Enable/Disable buttons.
  - "Reload Window" with active claude → shell PID matches, no stray dispatch.

## Known limitations (documented)

See *Known limitations / deferred* in the design spec. Headlines:

- **Windows cmd.exe / PowerShell-without-PSReadLine**: the buffered-input clear-prefix isn't interpreted as kill-line on those shells. Mitigation: setting gate.
- **Onboarding toast is one-shot**: if the official Claude Code extension is installed *after* Conductor's first activation, no retroactive toast appears. CHANGELOG note as fallback.
- **Promise queue grows unbounded over session lifetime** (theoretical, bounded by user activity).
- **`workspaceState.update` indefinite hang** (theoretical, no documented occurrence in VS Code).

## Process trail

The feature went through three rounds of spec design (v1 → v2 → v3) with two adversarial inquisitor passes between revisions. The design history is committed as three sequential `docs:` commits (`71fa5b9`, `54eccac`, `216ce95`) followed by the implementation plan (`eba432c`) and the 11 implementation commits. Squash-merge will collapse this into one clean commit on `main`.

Implementation was driven by `superpowers:subagent-driven-development` — each task dispatched to a fresh `code-writer` subagent with two-stage review (spec compliance + code quality) between tasks. All review iterations are reflected in the commits as either fix-up content or amends to the originating commit.

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*