### PR TITLE
feat: add Favorites sidebar section (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to the Claude Conductor extension are documented here.
 
 ### Added
 - **`claudeConductor.debugLogging` setting** — when enabled, emits verbose structured `key=value` diagnostic lines to the "Claude Conductor" output channel for every session-lifecycle event: terminal tracking (`[track]`, `[track:pid]`), close-detection tier outcomes (`[close]`, `[close:tier1]`, `[close:tier2]`, `[close:tier3]`, `[close:tier3:no-pid]`), PID index mutations (`[pid:delete]`), and reconcile poll results (`[reconcile]`, `[reconcile:evict]`, `[reconcile:clean]`). Default off; intended for diagnosing missed editor-tab close events (refs #68 phase A).
+- **Favorites sidebar section** ([#75](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/75))
+  - New top-level tree view between Active Sessions and Recent Projects
+  - Star toggle on Recent Projects rows (hover or right-click)
+  - Missing-folder rows dim with `(missing)` and click-to-relocate via `showOpenDialog`
+  - 25-favorite soft cap; over-cap banner; per-machine `globalState` persistence
+
+### Changed
+- `launchSession` now returns a `LaunchResult` (`ok: true | false` with reason) instead of `void`. Internal API; existing extension behavior unchanged.
 
 ### Fixed
 - **Open in New Window no longer silently no-ops on the current window** — when the command is invoked on a session whose folder is already the active workspace, VS Code would receive the `vscode://` URI, route it back to the same window, and the user would perceive no change. The command now detects this case via a case-insensitive folder comparison, shows a dismissible info toast ("You're already in this project's window — focused the session instead."), and focuses the session tab instead of firing the URI. Fixes #66.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,21 @@ Running Claude Code against several projects at once is painful in a plain termi
 
 ### Activity Bar Sidebar
 
-A dedicated "Claude Conductor" panel with two sections:
+A dedicated "Claude Conductor" panel with three sections:
 
 - **Active Sessions** — currently running Claude terminals. Sessions are grouped by project root; click a project row to expand it and see its sessions. Click a session leaf to focus it. A green terminal icon means the session is working; an orange bell means it's waiting for your input.
+- **Favorites** — a curated list of project roots you've pinned for quick access. Sits between Active Sessions and Recent Projects.
 - **Recent Projects** — your VS Code recently opened folders plus any configured extras, grouped by project root. Click a project row to expand it and see its worktrees. Click a folder leaf to launch a new session.
+
+### Favorites
+
+A curated list of project roots you've pinned for quick access. Sits between Active Sessions and Recent Projects.
+
+- **Add a favorite:** hover a project row in Recent Projects or right-click and choose **Add to Favorites**. The row shows a filled star icon when favorited.
+- **Remove a favorite:** hover a favorited row and click the filled star, or right-click → **Remove from Favorites**.
+- **Relocate a favorite:** if a favorited folder is missing on disk, the row dims and shows `(missing)`. Click the row, press Enter, or right-click → **Locate Folder...** to point the favorite at the folder's new location.
+- **Capacity:** soft cap of 25 favorites. Adding a 26th is rejected with a toast. If storage drift produces more than 25 entries, the panel shows a banner above the tree and renders all entries (no silent truncation).
+- **Persistence:** per-machine via VS Code's `globalState`. Favorites do not sync between machines (intentional — see Known Limits).
 
 Both panels render as a **two-level tree**: project roots are collapsed by default (showing a child count), with their `.worktrees/<branch>` subdirectories nested underneath. When a worktree's parent project root is not present in Recent Projects, the group row is shown with a dimmed folder icon and a "(not in recents)" label so you can tell at a glance that the root itself isn't tracked.
 
@@ -120,6 +131,12 @@ To remove the hooks at any time: run `Claude Conductor: Remove Notification Hook
 - Session tracking only works within a single VS Code window (sessions in other windows aren't visible in the sidebar)
 - The idle notification fires after Claude Code's built-in ~60-second idle threshold — not tunable from the extension
 - VS Code terminal tabs cannot change color or flash after creation, so "attention" is communicated via sidebar bell icons and notifications rather than tab-level indicators
+
+### Known Limits — Favorites
+
+- **Favorites paths are tracked as you typed them.** Two distinct path strings that resolve to the same folder via symlinks or junctions produce duplicate entries.
+- **UNC shares (`\\server\share`):** these render as present in the panel until you actually launch a session. If the share is offline, the launch will fail and the row will dim afterward. The next successful launch flips it back to present.
+- **Multi-window writes:** if you mutate Favorites in two VS Code windows simultaneously, the last write wins. The list is bounded (25 entries) and mutation rate is low, so collisions are unlikely in practice. Settings Sync is intentionally not enabled.
 
 ## Contributing / Development
 

--- a/docs/superpowers/plans/2026-04-28-75-favorites.md
+++ b/docs/superpowers/plans/2026-04-28-75-favorites.md
@@ -1,0 +1,2107 @@
+# Favorites Sidebar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a manual "Favorites" sidebar section between Active Sessions and Recent Projects, with persistent globalState storage, inline star toggling, missing-folder relocation, and a 25-entry soft cap.
+
+**Architecture:** A standalone `FavoritesStore` service owns canonical state (lowercase index + serialized persist queue with snapshot rollback). A `PathExistenceCache` provides synchronous existence reads via async stat with TTL, UNC-skip, and `markMissing`/`markPresent` flips driven by `launchSession` results. Both `FavoritesProvider` (new) and `RecentProjectsProvider` (modified) consult the store synchronously inside `getTreeItem` to flip a star icon and `viewItem` contextValue. A bidirectional drift-detector test parses `package.json` against an exported `VIEW_ITEM` constant set.
+
+**Tech Stack:** TypeScript, VS Code Extension API (engines `^1.93.0`), vitest for tests, `vsce` for packaging.
+
+**Spec:** `docs/superpowers/specs/2026-04-28-75-favorites-design.md` (v4 — locked after 3 inquisitor passes).
+
+**CI Jobs (must pass):**
+- `npm run lint` (tsc noEmit on `tsconfig.json`)
+- `npx tsc --noEmit -p tsconfig.test.json` (typecheck)
+- `npm test` (vitest run)
+- `npm run compile` (tsc -p ./)
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `src/projectGrouping.ts` | Modify | Add exported `isWorktreePath()` predicate. |
+| `src/pathExistenceCache.ts` | Create | Async-stat-backed cache with `peek`/`markMissing`/`markPresent`/`evict`/`refresh`. UNC-skip. |
+| `src/favoritesStore.ts` | Create | Service owning entries, canonical-key index, serialized persist queue, typed change events, deferred v1→v2 migration. |
+| `src/sessionManager.ts` | Modify | `launchSession` returns `LaunchResult` instead of `void`. UNC pre-flight skipped. |
+| `src/treeView.ts` | Modify | Export `VIEW_ITEM` constants. Migrate `RecentProjectsProvider` contextValue. New `FavoritesProvider`. |
+| `src/extension.ts` | Modify | Construct store + cache. Register `FavoritesProvider`. Register favorites commands. Wire `markMissing`/`markPresent` into the favorite-launch click handler. |
+| `package.json` | Modify | Add 3rd view contribution, 3 commands, 6 menu clauses. Migrate existing `viewItem == recentProject` clause. |
+| `test/projectGrouping.test.ts` | Modify | Add tests for `isWorktreePath`. |
+| `test/pathExistenceCache.test.ts` | Create | Unit tests per spec test plan. |
+| `test/favoritesStore.test.ts` | Create | Unit tests per spec test plan. |
+| `test/favoritesProvider.test.ts` | Create | Provider rendering tests. |
+| `test/treeView.test.ts` | Modify | Cross-panel star coupling, race regression, contextValue migration verification. |
+| `test/sessionManager.launchResult.test.ts` | Create | `LaunchResult` cases. |
+| `test/packageJsonContextKeys.test.ts` | Create | Bidirectional drift detector with negative-fixture list. |
+| `README.md` | Modify | Favorites section, 25-cap, click-to-relocate, UNC behavior, multi-window last-writer-wins limit. |
+| `CHANGELOG.md` | Modify | New entry under next version. |
+
+---
+
+## Phase 1: Foundation (no UI dependencies)
+
+### Task 1: Add `isWorktreePath` predicate to `projectGrouping.ts`
+
+**Files:**
+- Modify: `src/projectGrouping.ts`
+- Modify: `test/projectGrouping.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/projectGrouping.test.ts`:
+
+```typescript
+import { isWorktreePath } from "../src/projectGrouping";
+
+describe("isWorktreePath", () => {
+  it("matches a basic .worktrees branch path with forward slashes", () => {
+    expect(isWorktreePath("C:/proj/.worktrees/fix-bug")).toBe(true);
+  });
+
+  it("matches a path with backslashes (Windows native)", () => {
+    expect(isWorktreePath("C:\\proj\\.worktrees\\fix-bug")).toBe(true);
+  });
+
+  it("matches a path with a trailing separator (regression for v3 raw-input gap)", () => {
+    expect(isWorktreePath("C:\\proj\\.worktrees\\fix-bug\\")).toBe(true);
+    expect(isWorktreePath("C:/proj/.worktrees/fix-bug/")).toBe(true);
+  });
+
+  it("rejects a project root (no .worktrees segment)", () => {
+    expect(isWorktreePath("C:\\proj")).toBe(false);
+    expect(isWorktreePath("/home/user/proj")).toBe(false);
+  });
+
+  it("rejects a .worktrees directory itself with no branch segment", () => {
+    expect(isWorktreePath("C:/proj/.worktrees")).toBe(false);
+    expect(isWorktreePath("C:/proj/.worktrees/")).toBe(false);
+  });
+
+  it("rejects a nested path beneath a worktree (more than one segment under .worktrees)", () => {
+    expect(isWorktreePath("C:/proj/.worktrees/fix-bug/src")).toBe(false);
+  });
+
+  it("is case-insensitive on the .worktrees segment", () => {
+    expect(isWorktreePath("C:/proj/.WorkTrees/branch")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run from the worktree:
+
+```
+npm test -- --run test/projectGrouping.test.ts
+```
+
+Expected: tests fail with `isWorktreePath is not a function` or `is not exported`.
+
+- [ ] **Step 3: Implement the predicate**
+
+Add to the bottom of `src/projectGrouping.ts` (below the existing `groupByProjectRoot` export):
+
+```typescript
+/**
+ * True when `p` is a worktree path of the shape `<root>/.worktrees/<branch>`.
+ * Trailing separators are tolerated. Case-insensitive on the `.worktrees`
+ * segment to match the existing `parseWorktreePath` behavior.
+ */
+export function isWorktreePath(p: string): boolean {
+  const normalized = p.replace(/\\/g, "/").replace(/\/+$/, "");
+  return /\/\.worktrees\/[^/]+$/i.test(normalized);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+npm test -- --run test/projectGrouping.test.ts
+```
+
+Expected: all `isWorktreePath` tests pass; existing `groupByProjectRoot` tests still pass.
+
+- [ ] **Step 5: Run full suite + lint + typecheck**
+
+```
+npm run lint
+npx tsc --noEmit -p tsconfig.test.json
+npm test -- --run
+npm run compile
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```
+git -C <worktree> add src/projectGrouping.ts test/projectGrouping.test.ts
+git -C <worktree> commit -m "feat: add isWorktreePath predicate to projectGrouping (#75)"
+```
+
+---
+
+### Task 2: Create `PathExistenceCache`
+
+**Files:**
+- Create: `src/pathExistenceCache.ts`
+- Create: `test/pathExistenceCache.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/pathExistenceCache.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PathExistenceCache } from "../src/pathExistenceCache";
+
+describe("PathExistenceCache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("peek returns unknown for an unseen path", () => {
+    const cache = new PathExistenceCache();
+    expect(cache.peek("C:/x")).toEqual({ kind: "unknown" });
+  });
+
+  it("markPresent flips state and fires single-path event", () => {
+    const cache = new PathExistenceCache();
+    const events: unknown[] = [];
+    cache.onDidChange(e => events.push(e));
+
+    cache.markPresent("C:/x");
+
+    expect(cache.peek("C:/x")).toEqual({ kind: "exists" });
+    expect(events).toEqual([{ kind: "single", path: "C:/x" }]);
+  });
+
+  it("markMissing flips state and fires single-path event", () => {
+    const cache = new PathExistenceCache();
+    cache.markMissing("C:/x");
+    expect(cache.peek("C:/x")).toEqual({ kind: "missing", stale: false });
+  });
+
+  it("missing entries report stale=true after TTL but never collapse to unknown (v2 flicker regression)", () => {
+    const cache = new PathExistenceCache();
+    cache.markMissing("C:/x");
+    vi.advanceTimersByTime(31_000);  // > 30s TTL
+    expect(cache.peek("C:/x")).toEqual({ kind: "missing", stale: true });
+  });
+
+  it("exists entries collapse to unknown after TTL", () => {
+    const cache = new PathExistenceCache();
+    cache.markPresent("C:/x");
+    vi.advanceTimersByTime(31_000);
+    expect(cache.peek("C:/x")).toEqual({ kind: "unknown" });
+  });
+
+  it("markPresent after markMissing unsticks the entry (v3 stuck-missing regression)", () => {
+    const cache = new PathExistenceCache();
+    cache.markMissing("C:/x");
+    expect(cache.peek("C:/x")).toEqual({ kind: "missing", stale: false });
+    cache.markPresent("C:/x");
+    expect(cache.peek("C:/x")).toEqual({ kind: "exists" });
+  });
+
+  it("evict removes the entry", () => {
+    const cache = new PathExistenceCache();
+    cache.markPresent("C:/x");
+    cache.evict("C:/x");
+    expect(cache.peek("C:/x")).toEqual({ kind: "unknown" });
+  });
+
+  it("canonical-key matching: case and separator insensitive", () => {
+    const cache = new PathExistenceCache();
+    cache.markPresent("C:\\Foo");
+    expect(cache.peek("c:/foo")).toEqual({ kind: "exists" });
+    expect(cache.peek("C:\\Foo\\")).toEqual({ kind: "exists" });
+  });
+
+  it("refresh skips UNC paths (\\\\server\\share style)", async () => {
+    const cache = new PathExistenceCache();
+    const statSpy = vi.fn();
+    // Inject stat for testability:
+    (cache as unknown as { _statForTest: typeof statSpy })._statForTest = statSpy;
+
+    await cache.refresh(["\\\\server\\share\\foo", "//server/share/bar"]);
+
+    expect(statSpy).not.toHaveBeenCalled();
+    expect(cache.peek("\\\\server\\share\\foo")).toEqual({ kind: "unknown" });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+npm test -- --run test/pathExistenceCache.test.ts
+```
+
+Expected: cannot find module `pathExistenceCache`.
+
+- [ ] **Step 3: Implement the cache**
+
+Create `src/pathExistenceCache.ts`:
+
+```typescript
+import * as vscode from "vscode";
+import * as fs from "fs";
+
+export type ExistenceState =
+  | { kind: "exists"; checkedAt: number }
+  | { kind: "missing"; checkedAt: number }
+  | { kind: "unknown" };
+
+export type PeekResult =
+  | { kind: "exists" }
+  | { kind: "missing"; stale: boolean }
+  | { kind: "unknown" };
+
+export type CacheChangeEvent =
+  | { kind: "single"; path: string }
+  | { kind: "broad" };
+
+const TTL_MS = 30_000;
+const STAT_TIMEOUT_MS = 500;
+
+function canonicalKey(p: string): string {
+  return p.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+}
+
+function isLikelyNetworkPath(p: string): boolean {
+  return p.startsWith("\\\\") || p.startsWith("//");
+}
+
+/** Stat with a hard timeout. Resolves to true=exists, false=missing, null=timeout. */
+function statWithTimeout(p: string): Promise<boolean | null> {
+  return new Promise(resolve => {
+    let settled = false;
+    const t = setTimeout(() => {
+      if (!settled) { settled = true; resolve(null); }
+    }, STAT_TIMEOUT_MS);
+
+    fs.stat(p, err => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(t);
+      resolve(err === null);
+    });
+  });
+}
+
+export class PathExistenceCache {
+  private cache = new Map<string, ExistenceState>();
+  private readonly _onDidChange = new vscode.EventEmitter<CacheChangeEvent>();
+  readonly onDidChange = this._onDidChange.event;
+
+  // Test seam: replaced in tests to avoid real fs calls in refresh().
+  private _statForTest?: (p: string) => Promise<boolean | null>;
+
+  peek(p: string): PeekResult {
+    const e = this.cache.get(canonicalKey(p));
+    if (!e || e.kind === "unknown") return { kind: "unknown" };
+    const stale = Date.now() - e.checkedAt > TTL_MS;
+    if (e.kind === "missing") return { kind: "missing", stale };
+    if (stale) return { kind: "unknown" };
+    return { kind: "exists" };
+  }
+
+  markPresent(p: string): void {
+    this.cache.set(canonicalKey(p), { kind: "exists", checkedAt: Date.now() });
+    this._onDidChange.fire({ kind: "single", path: p });
+  }
+
+  markMissing(p: string): void {
+    this.cache.set(canonicalKey(p), { kind: "missing", checkedAt: Date.now() });
+    this._onDidChange.fire({ kind: "single", path: p });
+  }
+
+  evict(p: string): void {
+    if (this.cache.delete(canonicalKey(p))) {
+      this._onDidChange.fire({ kind: "single", path: p });
+    }
+  }
+
+  async refresh(paths: string[]): Promise<void> {
+    const stat = this._statForTest ?? statWithTimeout;
+    const toCheck = paths.filter(p => !isLikelyNetworkPath(p));
+    let anyChange = false;
+
+    for (const p of toCheck) {
+      const result = await stat(p);
+      if (result === null) continue;  // timeout, leave cache alone
+      const key = canonicalKey(p);
+      const prev = this.cache.get(key);
+      const next: ExistenceState = result
+        ? { kind: "exists", checkedAt: Date.now() }
+        : { kind: "missing", checkedAt: Date.now() };
+      this.cache.set(key, next);
+      if (!prev || prev.kind !== next.kind) anyChange = true;
+    }
+
+    if (anyChange) this._onDidChange.fire({ kind: "broad" });
+  }
+
+  dispose(): void {
+    this._onDidChange.dispose();
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+npm test -- --run test/pathExistenceCache.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run full suite + lint + typecheck**
+
+```
+npm run lint
+npx tsc --noEmit -p tsconfig.test.json
+npm test -- --run
+npm run compile
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```
+git -C <worktree> add src/pathExistenceCache.ts test/pathExistenceCache.test.ts
+git -C <worktree> commit -m "feat: add PathExistenceCache with markMissing/markPresent (#75)"
+```
+
+---
+
+### Task 3: Create `FavoritesStore`
+
+**Files:**
+- Create: `src/favoritesStore.ts`
+- Create: `test/favoritesStore.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/favoritesStore.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Memento } from "vscode";
+import { FavoritesStore, MAX_FAVORITES } from "../src/favoritesStore";
+
+function makeMemento(initial?: unknown): Memento & { _data: Record<string, unknown>; updateCalls: unknown[] } {
+  const data: Record<string, unknown> = {};
+  if (initial !== undefined) data["claudeConductor.favorites"] = initial;
+  const calls: unknown[] = [];
+  const m = {
+    _data: data,
+    updateCalls: calls,
+    keys: () => Object.keys(data),
+    get: <T>(key: string) => data[key] as T | undefined,
+    update: vi.fn(async (key: string, value: unknown) => {
+      calls.push({ key, value });
+      data[key] = value;
+    }),
+  };
+  return m as unknown as Memento & { _data: Record<string, unknown>; updateCalls: unknown[] };
+}
+
+describe("FavoritesStore", () => {
+  it("isFavorited returns false for empty store", () => {
+    const s = new FavoritesStore(makeMemento());
+    expect(s.isFavorited("C:/x")).toBe(false);
+  });
+
+  it("add, then isFavorited returns true (synchronous read after async add)", async () => {
+    const s = new FavoritesStore(makeMemento());
+    await s.add("C:/proj");
+    expect(s.isFavorited("C:/proj")).toBe(true);
+  });
+
+  it("canonical-key dedup: two case-different paths collapse to one entry", async () => {
+    const s = new FavoritesStore(makeMemento());
+    await s.add("C:\\Foo");
+    await s.add("c:/foo/");
+    expect(s.list()).toEqual([{ path: "C:\\Foo" }]);
+  });
+
+  it("rejects worktree paths", async () => {
+    const s = new FavoritesStore(makeMemento());
+    const r = await s.add("C:/proj/.worktrees/fix");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/worktree/i);
+    expect(s.list()).toEqual([]);
+  });
+
+  it("rejects past 25-entry cap", async () => {
+    const s = new FavoritesStore(makeMemento());
+    for (let i = 0; i < MAX_FAVORITES; i++) await s.add(`C:/p${i}`);
+    const r = await s.add(`C:/over`);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/cap/i);
+    expect(s.list()).toHaveLength(MAX_FAVORITES);
+  });
+
+  it("relocate to canonical-equal path is a no-op with reason 'same-path'", async () => {
+    const s = new FavoritesStore(makeMemento());
+    await s.add("C:/Foo");
+    const r = await s.relocate("C:/Foo", "c:\\foo\\");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/same/i);
+    expect(s.list()).toEqual([{ path: "C:/Foo" }]);
+  });
+
+  it("relocate to a different existing entry drops the old, fires broad event", async () => {
+    const s = new FavoritesStore(makeMemento());
+    await s.add("C:/A");
+    await s.add("C:/B");
+
+    const events: unknown[] = [];
+    s.onDidChange(e => events.push(e));
+
+    const r = await s.relocate("C:/A", "C:/B");
+    expect(r.ok).toBe(true);
+    expect(s.list()).toEqual([{ path: "C:/B" }]);
+    expect(events).toContainEqual({ kind: "broad" });
+  });
+
+  it("relocate to a brand-new path replaces entry path; fires single-path event", async () => {
+    const s = new FavoritesStore(makeMemento());
+    await s.add("C:/Old");
+
+    const events: unknown[] = [];
+    s.onDidChange(e => events.push(e));
+
+    const r = await s.relocate("C:/Old", "C:/New");
+    expect(r.ok).toBe(true);
+    expect(s.list()).toEqual([{ path: "C:/New" }]);
+    expect(events.some(e => (e as { kind: string }).kind === "single")).toBe(true);
+  });
+
+  it("v1 string[] storage is read but not written until first mutation (deferred migration)", async () => {
+    const m = makeMemento(["C:/legacy1", "C:/legacy2"]);
+    const s = new FavoritesStore(m);
+    expect(s.list()).toEqual([{ path: "C:/legacy1" }, { path: "C:/legacy2" }]);
+    expect(m.updateCalls).toEqual([]);  // no write on read
+
+    await s.add("C:/new");
+    // First mutation triggers the migration write in v2 envelope shape.
+    expect(m.updateCalls).toHaveLength(1);
+    const written = (m.updateCalls[0] as { value: unknown }).value as { version: number; entries: unknown[] };
+    expect(written.version).toBe(2);
+    expect(written.entries).toHaveLength(3);
+  });
+
+  it("future-version envelope renders best-effort, blocks writes", async () => {
+    const m = makeMemento({ version: 99, entries: [{ path: "C:/futureA" }] });
+    const s = new FavoritesStore(m);
+    expect(s.list()).toEqual([{ path: "C:/futureA" }]);
+
+    const r = await s.add("C:/blocked");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/version/i);
+    expect(s.list()).toEqual([{ path: "C:/futureA" }]);
+  });
+
+  it("persist failure rolls back exactly one mutation (await-prior contract)", async () => {
+    const m = makeMemento();
+    let callCount = 0;
+    m.update = vi.fn(async () => {
+      callCount++;
+      if (callCount === 1) throw new Error("simulated persist failure");
+      // success otherwise
+    });
+
+    const s = new FavoritesStore(m);
+
+    // First add will fail to persist → roll back.
+    await s.add("C:/A").catch(() => undefined);
+    // Wait for rollback to complete via the persistChain.
+    await s.waitForIdle();
+    expect(s.list()).toEqual([]);
+
+    // Second add proceeds against the post-rollback (empty) state and persists successfully.
+    await s.add("C:/B");
+    expect(s.list()).toEqual([{ path: "C:/B" }]);
+  });
+
+  it("apply throw is contained: state unchanged, no event fired", async () => {
+    const s = new FavoritesStore(makeMemento());
+    await s.add("C:/seed");
+    const eventsBefore: unknown[] = [];
+    s.onDidChange(e => eventsBefore.push(e));
+
+    await expect(
+      s._enqueueMutationForTest(() => { throw new Error("boom"); }, { kind: "broad" })
+    ).rejects.toThrow("boom");
+
+    expect(s.list()).toEqual([{ path: "C:/seed" }]);
+    expect(eventsBefore).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+npm test -- --run test/favoritesStore.test.ts
+```
+
+Expected: cannot find module `favoritesStore`.
+
+- [ ] **Step 3: Implement the store**
+
+Create `src/favoritesStore.ts`:
+
+```typescript
+import * as vscode from "vscode";
+import { isWorktreePath } from "./projectGrouping";
+
+export interface FavoritesEntry {
+  path: string;
+}
+
+export type FavoritesChangeEvent =
+  | { kind: "single"; path: string }
+  | { kind: "broad" };
+
+interface FavoritesStorageEnvelope {
+  version: 2;
+  entries: FavoritesEntry[];
+}
+
+export const STORAGE_KEY = "claudeConductor.favorites";
+export const MAX_FAVORITES = 25;
+
+export interface MutationResult {
+  ok: boolean;
+  reason?: string;
+}
+
+function canonicalKey(p: string): string {
+  return p.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+}
+
+/** Pure read; no write side effects. v1 string[] is converted in-memory only. */
+function readWithoutMigrating(memento: vscode.Memento): {
+  entries: FavoritesEntry[];
+  unknownVersion: boolean;
+} {
+  const raw = memento.get<unknown>(STORAGE_KEY);
+  if (raw === undefined || raw === null) return { entries: [], unknownVersion: false };
+  if (Array.isArray(raw)) {
+    if (raw.length === 0) return { entries: [], unknownVersion: false };
+    if (typeof raw[0] === "string") {
+      // v1 legacy
+      return {
+        entries: (raw as string[]).map(p => ({ path: p })),
+        unknownVersion: false,
+      };
+    }
+    // Defensive: array of objects without envelope (shouldn't happen but tolerate)
+    return { entries: raw as FavoritesEntry[], unknownVersion: false };
+  }
+  if (typeof raw === "object" && raw !== null && "version" in raw) {
+    const env = raw as FavoritesStorageEnvelope;
+    if (env.version === 2) {
+      return { entries: Array.isArray(env.entries) ? env.entries : [], unknownVersion: false };
+    }
+    return { entries: Array.isArray((env as { entries?: unknown }).entries) ? (env as { entries: FavoritesEntry[] }).entries : [], unknownVersion: true };
+  }
+  return { entries: [], unknownVersion: false };
+}
+
+export class FavoritesStore {
+  private entries: FavoritesEntry[] = [];
+  private keyIndex: Set<string> = new Set();
+  private readonly _onDidChange = new vscode.EventEmitter<FavoritesChangeEvent>();
+  readonly onDidChange = this._onDidChange.event;
+
+  /** Tracks the latest persist (success or rollback). Mutations await this. */
+  private persistChain: Promise<void> = Promise.resolve();
+
+  /** True when the storage envelope has an unknown future version — block writes. */
+  private readonly unknownVersion: boolean;
+
+  constructor(private readonly memento: vscode.Memento) {
+    const r = readWithoutMigrating(memento);
+    this.entries = r.entries;
+    this.unknownVersion = r.unknownVersion;
+    this.rebuildIndex();
+  }
+
+  // ---- Synchronous reads ----
+  isFavorited(p: string): boolean {
+    return this.keyIndex.has(canonicalKey(p));
+  }
+  list(): readonly FavoritesEntry[] { return this.entries; }
+  isOverCap(): boolean { return this.entries.length > MAX_FAVORITES; }
+
+  /** Test helper: wait for in-flight persists (and any rollback) to complete. */
+  async waitForIdle(): Promise<void> {
+    await this.persistChain.catch(() => undefined);
+  }
+
+  // ---- Mutations ----
+  async add(p: string): Promise<MutationResult> {
+    if (this.unknownVersion) {
+      return { ok: false, reason: "Storage version is newer than this build supports." };
+    }
+    if (isWorktreePath(p)) {
+      return { ok: false, reason: "Favorite the project root, not a worktree." };
+    }
+    if (this.isFavorited(p)) {
+      return { ok: true };  // idempotent
+    }
+    if (this.entries.length >= MAX_FAVORITES) {
+      return { ok: false, reason: `Favorites cap reached (${MAX_FAVORITES}). Remove an entry first.` };
+    }
+
+    await this.enqueueMutation(
+      snapshot => [...snapshot, { path: p }],
+      { kind: "single", path: p }
+    );
+    return { ok: true };
+  }
+
+  async remove(p: string): Promise<void> {
+    if (this.unknownVersion) return;  // silent no-op; can't write
+    if (!this.isFavorited(p)) return;
+
+    const key = canonicalKey(p);
+    await this.enqueueMutation(
+      snapshot => snapshot.filter(e => canonicalKey(e.path) !== key),
+      { kind: "single", path: p }
+    );
+  }
+
+  async relocate(oldPath: string, newPath: string): Promise<MutationResult> {
+    if (this.unknownVersion) {
+      return { ok: false, reason: "Storage version is newer than this build supports." };
+    }
+    if (isWorktreePath(newPath)) {
+      return { ok: false, reason: "Favorite the project root, not a worktree." };
+    }
+
+    const oldKey = canonicalKey(oldPath);
+    const newKey = canonicalKey(newPath);
+
+    if (oldKey === newKey) {
+      return { ok: false, reason: "That's the same path. Choose a different folder." };
+    }
+
+    if (!this.keyIndex.has(oldKey)) {
+      return { ok: false, reason: "Original entry not found." };
+    }
+
+    if (this.keyIndex.has(newKey)) {
+      // Drop the old entry — newPath is already favorited.
+      await this.enqueueMutation(
+        snapshot => snapshot.filter(e => canonicalKey(e.path) !== oldKey),
+        { kind: "broad" }
+      );
+      return { ok: true, reason: "That folder is already in your Favorites — removed the missing entry." };
+    }
+
+    // Replace path on the matched entry; preserve order.
+    await this.enqueueMutation(
+      snapshot => snapshot.map(e =>
+        canonicalKey(e.path) === oldKey ? { path: newPath } : e
+      ),
+      { kind: "single", path: newPath }
+    );
+    return { ok: true };
+  }
+
+  /** Test seam: expose enqueueMutation for the apply-throw test. */
+  _enqueueMutationForTest(
+    apply: (snapshot: FavoritesEntry[]) => FavoritesEntry[],
+    payload: FavoritesChangeEvent
+  ): Promise<void> {
+    return this.enqueueMutation(apply, payload);
+  }
+
+  private async enqueueMutation(
+    apply: (snapshot: FavoritesEntry[]) => FavoritesEntry[],
+    payload: FavoritesChangeEvent
+  ): Promise<void> {
+    // Wait for any prior persist (success or rollback) to fully resolve.
+    await this.persistChain.catch(() => undefined);
+
+    const snapshot = [...this.entries];
+
+    let next: FavoritesEntry[];
+    try {
+      next = apply(snapshot);
+    } catch (err) {
+      throw err;
+    }
+
+    this.entries = next;
+    this.rebuildIndex();
+    this._onDidChange.fire(payload);
+
+    this.persistChain = this.memento
+      .update(STORAGE_KEY, { version: 2, entries: this.entries } as FavoritesStorageEnvelope)
+      .then(() => undefined)
+      .catch((err: unknown) => {
+        this.entries = snapshot;
+        this.rebuildIndex();
+        this._onDidChange.fire({ kind: "broad" });
+        void vscode.window.showErrorMessage(
+          `Couldn't save Favorites — please try again. (${(err as Error)?.message ?? err})`
+        );
+      });
+
+    return this.persistChain;
+  }
+
+  private rebuildIndex(): void {
+    this.keyIndex = new Set(this.entries.map(e => canonicalKey(e.path)));
+  }
+
+  dispose(): void {
+    this._onDidChange.dispose();
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+npm test -- --run test/favoritesStore.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run full suite + lint + typecheck**
+
+```
+npm run lint
+npx tsc --noEmit -p tsconfig.test.json
+npm test -- --run
+npm run compile
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```
+git -C <worktree> add src/favoritesStore.ts test/favoritesStore.test.ts
+git -C <worktree> commit -m "feat: add FavoritesStore with serialized persist queue (#75)"
+```
+
+---
+
+## Phase 2: SessionManager refactor
+
+### Task 4: `launchSession` returns `LaunchResult`
+
+**Files:**
+- Modify: `src/sessionManager.ts`
+- Create: `test/sessionManager.launchResult.test.ts`
+- May modify: any caller of `launchSession` flagged by tsc
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/sessionManager.launchResult.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fs from "fs";
+
+vi.mock("vscode", async () => {
+  const m = await import("./mocks/vscode");
+  return m;
+});
+
+import { SessionManager } from "../src/sessionManager";
+
+describe("launchSession LaunchResult", () => {
+  it("returns {ok:false, reason:'missing'} for a non-UNC path that doesn't exist", async () => {
+    const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    const sm = new SessionManager();
+    const r = await sm.launchSession("C:/no/such/path");
+    expect(r).toEqual(expect.objectContaining({ ok: false, reason: "missing" }));
+    existsSpy.mockRestore();
+  });
+
+  it("returns {ok:true} for a path that exists", async () => {
+    const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    const sm = new SessionManager();
+    const r = await sm.launchSession("C:/exists");
+    expect(r.ok).toBe(true);
+    existsSpy.mockRestore();
+  });
+
+  it("skips fs.existsSync pre-flight for UNC paths", async () => {
+    const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    const sm = new SessionManager();
+    const r = await sm.launchSession("\\\\server\\share\\foo");
+    // existsSync should not have been called for the UNC path
+    expect(existsSpy).not.toHaveBeenCalledWith(expect.stringMatching(/^\\\\server/));
+    // launch proceeds optimistically; result.ok is true (createTerminal mock returns)
+    expect(r.ok).toBe(true);
+    existsSpy.mockRestore();
+  });
+});
+```
+
+> **Note for the implementer:** the `SessionManager` constructor and `createTerminal` mock surface differ across this codebase. If the existing `sessionManager.*.test.ts` files use a different setup pattern, mirror theirs. The behaviors under test are: (a) early-return-with-result on non-UNC missing, (b) UNC pre-flight skip, (c) success returns `{ok:true}`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+npm test -- --run test/sessionManager.launchResult.test.ts
+```
+
+Expected: type errors or "launchSession returns void."
+
+- [ ] **Step 3: Refactor `launchSession`**
+
+In `src/sessionManager.ts`, modify `launchSession` (currently around lines 76–112). Replace the early-return-on-missing branch and the trailing return:
+
+```typescript
+export type LaunchResult =
+  | { ok: true; reused: boolean }
+  | { ok: false; reason: "missing" | "other"; message: string };
+
+function isLikelyNetworkPath(p: string): boolean {
+  return p.startsWith("\\\\") || p.startsWith("//");
+}
+
+// inside the class:
+async launchSession(folderPath: string): Promise<LaunchResult> {
+  const normalized = path.normalize(folderPath);
+
+  // Skip pre-flight for UNC — sync fs.existsSync there can hang on SMB timeouts.
+  if (!isLikelyNetworkPath(normalized)) {
+    if (!fs.existsSync(normalized)) {
+      log(`[launch] missing cwd: ${normalized}`);
+      return {
+        ok: false,
+        reason: "missing",
+        message: `Folder does not exist: ${normalized}`,
+      };
+    }
+  }
+
+  if (getReuseTerminal()) {
+    const existing = this._findSessionByFolder(normalized);
+    if (existing) {
+      this.focusSession(existing);
+      return { ok: true, reused: true };
+    }
+  }
+
+  const folderName = path.basename(normalized);
+  const terminal = vscode.window.createTerminal({
+    name: `${SESSION_NAME_PREFIX}${folderName}`,
+    cwd: normalized,
+    iconPath: new vscode.ThemeIcon("sparkle"),
+    color: new vscode.ThemeColor("terminal.ansiGreen"),
+  });
+
+  terminal.show(true);
+  await vscode.commands.executeCommand("workbench.action.terminal.moveToEditor");
+  await this._dispatchClaudeCommand(terminal);
+
+  return { ok: true, reused: false };
+}
+```
+
+Export the type at the top of the file (alongside other exported types):
+
+```typescript
+export type { LaunchResult };
+```
+
+(If `LaunchResult` was declared with `export type` already, skip the re-export.)
+
+- [ ] **Step 4: Update callers**
+
+Run `npm run lint` to find every caller of `launchSession` whose `void` consumption is now incorrect. Most callers in `extension.ts` either fire-and-forget or `await` for sequencing — change `await sm.launchSession(p);` to:
+
+```typescript
+const result = await sm.launchSession(p);
+if (!result.ok && result.reason === "missing") {
+  void vscode.window.showErrorMessage(result.message);
+}
+```
+
+(The favorites-specific `markMissing`/`markPresent` wiring is added in Task 8; for now, just keep existing behavior plus the error-message surfacing.)
+
+- [ ] **Step 5: Run tests + lint + typecheck**
+
+```
+npm run lint
+npx tsc --noEmit -p tsconfig.test.json
+npm test -- --run
+npm run compile
+```
+
+Expected: all green. Existing `sessionManager.*.test.ts` may need touch-ups if they assert on `launchSession` return value.
+
+- [ ] **Step 6: Commit**
+
+```
+git -C <worktree> add src/sessionManager.ts src/extension.ts test/sessionManager.launchResult.test.ts
+git -C <worktree> commit -m "refactor: launchSession returns LaunchResult instead of void (#75)"
+```
+
+---
+
+## Phase 3: Tree view layer
+
+### Task 5: Add `VIEW_ITEM` constants and migrate `RecentProjectsProvider` contextValue
+
+**Files:**
+- Modify: `src/treeView.ts`
+- Modify: `test/treeView.test.ts`
+
+- [ ] **Step 1: Write the failing test additions**
+
+Add to `test/treeView.test.ts`:
+
+```typescript
+import { VIEW_ITEM } from "../src/treeView";
+
+describe("VIEW_ITEM constants", () => {
+  it("has all required tokens", () => {
+    expect(VIEW_ITEM.PROJECT_ROOT_FAVORITED).toBe("projectRoot.favorited");
+    expect(VIEW_ITEM.PROJECT_ROOT_UNFAVORITED).toBe("projectRoot.unfavorited");
+    expect(VIEW_ITEM.PROJECT_ROOT_MISSING).toBe("projectRoot.missing");
+    expect(VIEW_ITEM.WORKTREE_CHILD).toBe("worktreeChild");
+    expect(VIEW_ITEM.ACTIVE_SESSION).toBe("activeSession");
+  });
+});
+
+describe("RecentProjectsProvider contextValue migration", () => {
+  it("renders favorited rows with projectRoot.favorited contextValue", async () => {
+    // Setup: store says C:/proj is favorited.
+    // Provider renders a row for C:/proj. Assert contextValue is projectRoot.favorited.
+    // (Implementation detail: this test depends on the provider being constructed
+    // with a FavoritesStore — see Task 6 for the full coupling. For now, verify
+    // the contextValue values are emitted correctly given a mock store.)
+    // Skip until Task 6 lands the FavoritesStore wiring.
+  });
+});
+```
+
+(The full cross-panel coupling test arrives in Task 6 once `FavoritesProvider` exists.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+npm test -- --run test/treeView.test.ts
+```
+
+Expected: `VIEW_ITEM` not exported.
+
+- [ ] **Step 3: Add `VIEW_ITEM` constants and update `RecentProjectItem`**
+
+In `src/treeView.ts`, near the top imports add:
+
+```typescript
+import { FavoritesStore } from "./favoritesStore";
+import { PathExistenceCache } from "./pathExistenceCache";
+```
+
+Then add the `VIEW_ITEM` export (place it near the top of the file, after imports but before the first class):
+
+```typescript
+export const VIEW_ITEM = {
+  PROJECT_ROOT_FAVORITED:   "projectRoot.favorited",
+  PROJECT_ROOT_UNFAVORITED: "projectRoot.unfavorited",
+  PROJECT_ROOT_MISSING:     "projectRoot.missing",
+  WORKTREE_CHILD:           "worktreeChild",
+  ACTIVE_SESSION:           "activeSession",
+} as const;
+```
+
+Update `RecentProjectItem` (currently around line 148–165). Replace its constructor signature and body:
+
+```typescript
+class RecentProjectItem extends vscode.TreeItem {
+  readonly folderPath: string;
+
+  constructor(
+    entry: FolderEntry,
+    isWorktreeChild: boolean,
+    state: { favorited: boolean; missing: boolean }
+  ) {
+    super(entry.name, vscode.TreeItemCollapsibleState.None);
+    this.folderPath = entry.folderPath;
+    this.description = isWorktreeChild
+      ? path.basename(entry.folderPath)
+      : entry.parentDir;
+    this.tooltip = `${entry.folderPath} (${entry.source})`;
+    this.iconPath = new vscode.ThemeIcon("folder");
+
+    if (isWorktreeChild) {
+      this.contextValue = VIEW_ITEM.WORKTREE_CHILD;
+    } else if (state.missing) {
+      this.contextValue = VIEW_ITEM.PROJECT_ROOT_MISSING;
+      this.description = "(missing)";
+      this.iconPath = new vscode.ThemeIcon(
+        "folder",
+        new vscode.ThemeColor("disabledForeground")
+      );
+    } else if (state.favorited) {
+      this.contextValue = VIEW_ITEM.PROJECT_ROOT_FAVORITED;
+    } else {
+      this.contextValue = VIEW_ITEM.PROJECT_ROOT_UNFAVORITED;
+    }
+
+    this.command = {
+      command: "claudeConductor.openSession",
+      title: "Launch Session",
+      arguments: [entry.folderPath],
+    };
+  }
+}
+```
+
+Update `RecentProjectsProvider` to take a `FavoritesStore` and `PathExistenceCache` and consult them in `getChildren` when constructing leaf items. Modify the constructor and the `getChildren` branch that creates `RecentProjectItem` instances:
+
+```typescript
+export class RecentProjectsProvider
+  implements vscode.TreeDataProvider<RecentTreeNode>
+{
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<RecentTreeNode | undefined | void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  constructor(
+    private readonly sessionManager: SessionManager,
+    private readonly favoritesStore: FavoritesStore,
+    private readonly existenceCache: PathExistenceCache
+  ) {
+    sessionManager.onDidChangeSessions(() => this._onDidChangeTreeData.fire(undefined));
+    favoritesStore.onDidChange(() => this._onDidChangeTreeData.fire(undefined));
+    existenceCache.onDidChange(() => this._onDidChangeTreeData.fire(undefined));
+  }
+
+  getTreeItem(element: RecentTreeNode): vscode.TreeItem {
+    return element;
+  }
+
+  async getChildren(element?: RecentTreeNode): Promise<RecentTreeNode[]> {
+    if (element instanceof RecentGroupItem) {
+      const { group } = element;
+      const leaves: RecentProjectItem[] = [];
+      if (group.top !== null) {
+        const fav = this.favoritesStore.isFavorited(group.top.folderPath);
+        const peek = this.existenceCache.peek(group.top.folderPath);
+        const missing = fav && peek.kind === "missing";  // only flag favorited rows as missing
+        leaves.push(new RecentProjectItem(group.top, false, { favorited: fav, missing }));
+      }
+      for (const child of group.children) {
+        leaves.push(new RecentProjectItem(child, true, { favorited: false, missing: false }));
+      }
+      return leaves;
+    }
+
+    const folders = await getAllFolders();
+    const groups = groupByProjectRoot(folders, (f) => f.folderPath);
+    return groups.map((g) => new RecentGroupItem(g));
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire(undefined);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+npm test -- --run test/treeView.test.ts
+```
+
+Expected: `VIEW_ITEM` test passes. Existing tests may need to update calls to `new RecentProjectsProvider(...)` to pass mock store + cache.
+
+> **Note for the implementer:** existing tests construct `RecentProjectsProvider` without store/cache. Update them to pass minimal stubs:
+> ```typescript
+> const fakeStore = { isFavorited: () => false, onDidChange: () => ({ dispose: () => {} }) } as unknown as FavoritesStore;
+> const fakeCache = { peek: () => ({ kind: "unknown" }), onDidChange: () => ({ dispose: () => {} }) } as unknown as PathExistenceCache;
+> ```
+> Tests that currently expect `contextValue === "recentProject"` must be updated to expect one of the new values per state.
+
+- [ ] **Step 5: Run full suite + lint + typecheck**
+
+```
+npm run lint
+npx tsc --noEmit -p tsconfig.test.json
+npm test -- --run
+npm run compile
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```
+git -C <worktree> add src/treeView.ts test/treeView.test.ts
+git -C <worktree> commit -m "feat: VIEW_ITEM constants + migrate RecentProjectsProvider contextValue (#75)"
+```
+
+---
+
+### Task 6: Create `FavoritesProvider`
+
+**Files:**
+- Modify: `src/treeView.ts`
+- Create: `test/favoritesProvider.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/favoritesProvider.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { TreeItemCollapsibleState } from "./mocks/vscode";
+import type { Memento } from "vscode";
+
+import { FavoritesStore } from "../src/favoritesStore";
+import { PathExistenceCache } from "../src/pathExistenceCache";
+import { FavoritesProvider, VIEW_ITEM } from "../src/treeView";
+
+function makeMemento(): Memento {
+  const data: Record<string, unknown> = {};
+  return {
+    keys: () => Object.keys(data),
+    get: <T>(k: string) => data[k] as T | undefined,
+    update: async (k, v) => { data[k] = v; },
+  } as unknown as Memento;
+}
+
+describe("FavoritesProvider", () => {
+  it("returns empty children when store has no entries", async () => {
+    const store = new FavoritesStore(makeMemento());
+    const cache = new PathExistenceCache();
+    const provider = new FavoritesProvider(store, cache);
+    expect(await provider.getChildren()).toEqual([]);
+  });
+
+  it("renders a single favorite as a top-level row with projectRoot.favorited contextValue", async () => {
+    const store = new FavoritesStore(makeMemento());
+    await store.add("C:/proj");
+    const cache = new PathExistenceCache();
+    cache.markPresent("C:/proj");
+
+    const provider = new FavoritesProvider(store, cache);
+    const top = await provider.getChildren();
+    expect(top).toHaveLength(1);
+    expect(top[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_FAVORITED);
+  });
+
+  it("renders alphabetically (basename, full-path tiebreak)", async () => {
+    const store = new FavoritesStore(makeMemento());
+    await store.add("C:/zzz");
+    await store.add("C:/aaa");
+    await store.add("C:/mmm");
+    const cache = new PathExistenceCache();
+    const provider = new FavoritesProvider(store, cache);
+
+    const top = await provider.getChildren();
+    expect(top.map(n => n.label)).toEqual(["aaa", "mmm", "zzz"]);
+  });
+
+  it("renders missing folder with (missing) description, dimmed icon, and locate command", async () => {
+    const store = new FavoritesStore(makeMemento());
+    await store.add("C:/missing");
+    const cache = new PathExistenceCache();
+    cache.markMissing("C:/missing");
+
+    const provider = new FavoritesProvider(store, cache);
+    const [row] = await provider.getChildren();
+
+    expect(row.description).toBe("(missing)");
+    expect(row.contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_MISSING);
+    expect(row.command).toEqual({
+      command: "claudeConductor.locateFavorite",
+      title: "Relocate Folder",
+      arguments: ["C:/missing"],
+    });
+  });
+
+  it("stale-missing renders identical to fresh-missing (no flicker regression)", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = new FavoritesStore(makeMemento());
+      await store.add("C:/missing");
+      const cache = new PathExistenceCache();
+      cache.markMissing("C:/missing");
+      vi.advanceTimersByTime(31_000);  // → stale
+
+      const provider = new FavoritesProvider(store, cache);
+      const [row] = await provider.getChildren();
+      expect(row.description).toBe("(missing)");
+      expect(row.contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_MISSING);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("optimistic-present on UNC paths (cache returns unknown)", async () => {
+    const store = new FavoritesStore(makeMemento());
+    await store.add("\\\\server\\share\\foo");
+    const cache = new PathExistenceCache();  // never marked → unknown for the UNC path
+
+    const provider = new FavoritesProvider(store, cache);
+    const [row] = await provider.getChildren();
+    expect(row.description).not.toBe("(missing)");
+    expect(row.contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_FAVORITED);
+  });
+
+  it("renders all entries when storage drifts >25; sets TreeView.message banner when over cap", async () => {
+    // Seed 30 entries directly (bypassing add cap).
+    const m = makeMemento();
+    const seed = Array.from({ length: 30 }, (_, i) => ({ path: `C:/p${String(i).padStart(2, "0")}` }));
+    await m.update("claudeConductor.favorites", { version: 2, entries: seed });
+
+    const store = new FavoritesStore(m);
+    const cache = new PathExistenceCache();
+    const provider = new FavoritesProvider(store, cache);
+
+    const top = await provider.getChildren();
+    expect(top).toHaveLength(30);
+
+    // The provider exposes the over-cap banner string as a property; the actual
+    // TreeView.message wiring happens in extension.ts. Test only the data.
+    expect(provider.getOverCapBanner()).toMatch(/over the 25 cap/i);
+  });
+
+  it("addFavorite past cap: store rejects, provider state unchanged", async () => {
+    const store = new FavoritesStore(makeMemento());
+    for (let i = 0; i < 25; i++) await store.add(`C:/p${i}`);
+    const cache = new PathExistenceCache();
+    const provider = new FavoritesProvider(store, cache);
+
+    const r = await store.add("C:/over");
+    expect(r.ok).toBe(false);
+
+    const top = await provider.getChildren();
+    expect(top).toHaveLength(25);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+npm test -- --run test/favoritesProvider.test.ts
+```
+
+Expected: cannot find `FavoritesProvider` export.
+
+- [ ] **Step 3: Implement `FavoritesProvider`**
+
+Append to `src/treeView.ts` (or insert after `RecentProjectsProvider`):
+
+```typescript
+import type { FavoritesEntry } from "./favoritesStore";
+
+class FavoriteGroupItem extends vscode.TreeItem {
+  constructor(public readonly group: import("./projectGrouping").ProjectGroup<{ folderPath: string; name: string }>) {
+    super(path.basename(group.root) || group.root, vscode.TreeItemCollapsibleState.Collapsed);
+    this.tooltip = group.root;
+    this.iconPath = new vscode.ThemeIcon("folder");
+  }
+}
+
+class FavoriteLeafItem extends vscode.TreeItem {
+  readonly folderPath: string;
+
+  constructor(
+    folderPath: string,
+    isWorktreeChild: boolean,
+    state: { missing: boolean }
+  ) {
+    super(path.basename(folderPath) || folderPath, vscode.TreeItemCollapsibleState.None);
+    this.folderPath = folderPath;
+    this.tooltip = state.missing
+      ? "This folder is missing on disk. Click or press Enter to relocate; right-click for more options."
+      : folderPath;
+
+    if (isWorktreeChild) {
+      this.contextValue = VIEW_ITEM.WORKTREE_CHILD;
+      this.iconPath = new vscode.ThemeIcon("folder");
+      this.command = {
+        command: "claudeConductor.openSession",
+        title: "Launch Session",
+        arguments: [folderPath],
+      };
+    } else if (state.missing) {
+      this.contextValue = VIEW_ITEM.PROJECT_ROOT_MISSING;
+      this.description = "(missing)";
+      this.iconPath = new vscode.ThemeIcon(
+        "folder",
+        new vscode.ThemeColor("disabledForeground")
+      );
+      this.command = {
+        command: "claudeConductor.locateFavorite",
+        title: "Relocate Folder",
+        arguments: [folderPath],
+      };
+    } else {
+      this.contextValue = VIEW_ITEM.PROJECT_ROOT_FAVORITED;
+      this.iconPath = new vscode.ThemeIcon("folder");
+      this.command = {
+        command: "claudeConductor.openSession",
+        title: "Launch Session",
+        arguments: [folderPath],
+      };
+    }
+  }
+}
+
+type FavoriteTreeNode = FavoriteGroupItem | FavoriteLeafItem;
+
+export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteTreeNode> {
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<FavoriteTreeNode | undefined | void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  constructor(
+    private readonly store: FavoritesStore,
+    private readonly cache: PathExistenceCache
+  ) {
+    store.onDidChange(() => this._onDidChangeTreeData.fire(undefined));
+    cache.onDidChange(() => this._onDidChangeTreeData.fire(undefined));
+  }
+
+  getTreeItem(el: FavoriteTreeNode): vscode.TreeItem { return el; }
+
+  async getChildren(element?: FavoriteTreeNode): Promise<FavoriteTreeNode[]> {
+    if (element instanceof FavoriteGroupItem) {
+      const leaves: FavoriteLeafItem[] = [];
+      const top = element.group.top;
+      if (top) {
+        const peek = this.cache.peek(top.folderPath);
+        const missing = peek.kind === "missing";
+        leaves.push(new FavoriteLeafItem(top.folderPath, false, { missing }));
+      }
+      for (const child of element.group.children) {
+        leaves.push(new FavoriteLeafItem(child.folderPath, true, { missing: false }));
+      }
+      return leaves;
+    }
+
+    const entries = [...this.store.list()];
+    // Alphabetical by basename; full-path tiebreak
+    entries.sort((a, b) => {
+      const aName = path.basename(a.path).toLowerCase();
+      const bName = path.basename(b.path).toLowerCase();
+      if (aName !== bName) return aName.localeCompare(bName);
+      return a.path.toLowerCase().localeCompare(b.path.toLowerCase());
+    });
+
+    // Render every entry as a flat top-level row. The current product spec
+    // does not nest worktree children under favorited project roots in the
+    // Favorites tree (worktrees aren't stored in favorites; nesting would
+    // require pulling from getAllFolders). Treating each favorite as a
+    // single-row group with no children keeps the UI predictable.
+    return entries.map(e => {
+      const peek = this.cache.peek(e.path);
+      const missing = peek.kind === "missing";
+      return new FavoriteLeafItem(e.path, false, { missing });
+    });
+  }
+
+  /** Returns the over-cap banner string when storage drift exists; null otherwise. */
+  getOverCapBanner(): string | null {
+    if (!this.store.isOverCap()) return null;
+    return `Favorites: ${this.store.list().length} entries (over the 25 cap — consider removing some).`;
+  }
+}
+```
+
+> **Implementation note:** the spec describes Favorites rows nesting worktree children "for free via grouping." The plan ships the simpler flat rendering — favorites are project roots; worktrees show up under their parent in Recent Projects. If product later wants nested worktree children in Favorites, that's a follow-up that adds a `getAllFolders()` cross-reference and `groupByProjectRoot` — see the file's existing pattern in `RecentProjectsProvider`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+npm test -- --run test/favoritesProvider.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run full suite + lint + typecheck**
+
+```
+npm run lint
+npx tsc --noEmit -p tsconfig.test.json
+npm test -- --run
+npm run compile
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```
+git -C <worktree> add src/treeView.ts test/favoritesProvider.test.ts
+git -C <worktree> commit -m "feat: FavoritesProvider with star icon + missing-row click-to-relocate (#75)"
+```
+
+---
+
+## Phase 4: package.json wiring
+
+### Task 7: Add view contribution, commands, and menus
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Read current package.json structure**
+
+Run:
+
+```
+node -e "const p=require('./package.json'); console.log(JSON.stringify(p.contributes.views,null,2))"
+node -e "const p=require('./package.json'); console.log(JSON.stringify(p.contributes.commands.filter(c=>c.command.includes('claudeConductor')),null,2))"
+node -e "const p=require('./package.json'); console.log(JSON.stringify(p.contributes.menus,null,2))" | head -120
+```
+
+This grounds the edits in actual structure.
+
+- [ ] **Step 2: Add the third view between activeSessions and recentProjects**
+
+In `package.json`, locate `"contributes" → "views" → "claudeConductor"`. Add the favorites entry between the existing two:
+
+```json
+"claudeConductor": [
+  { "id": "claudeConductor.activeSessions", "name": "Active Sessions" },
+  { "id": "claudeConductor.favorites",      "name": "Favorites" },
+  { "id": "claudeConductor.recentProjects", "name": "Recent Projects" }
+]
+```
+
+- [ ] **Step 3: Add the three commands**
+
+In `"contributes" → "commands"`, append:
+
+```json
+{
+  "command": "claudeConductor.addFavorite",
+  "title": "Add to Favorites",
+  "category": "Claude Conductor",
+  "icon": "$(star-empty)"
+},
+{
+  "command": "claudeConductor.removeFavorite",
+  "title": "Remove from Favorites",
+  "category": "Claude Conductor",
+  "icon": "$(star-full)"
+},
+{
+  "command": "claudeConductor.locateFavorite",
+  "title": "Locate Folder...",
+  "category": "Claude Conductor"
+}
+```
+
+- [ ] **Step 4: Add the menu clauses; migrate the existing recentProject clause**
+
+In `"contributes" → "menus" → "view/item/context"`, **change** the existing `"viewItem == recentProject"` clause to `"viewItem =~ /^projectRoot\\./"`. (This is the migration of `package.json:143` — the existing inline action ("Launch Session" or whatever it currently triggers) now matches all three project-root states.)
+
+Append the new clauses:
+
+```json
+{
+  "command": "claudeConductor.addFavorite",
+  "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.unfavorited",
+  "group": "inline@1"
+},
+{
+  "command": "claudeConductor.removeFavorite",
+  "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.favorited",
+  "group": "inline@1"
+},
+{
+  "command": "claudeConductor.locateFavorite",
+  "when": "view == claudeConductor.favorites && viewItem == projectRoot.missing",
+  "group": "inline@1"
+},
+{
+  "command": "claudeConductor.removeFavorite",
+  "when": "view == claudeConductor.favorites && viewItem == projectRoot.missing",
+  "group": "missing@2"
+},
+{
+  "command": "claudeConductor.addFavorite",
+  "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.unfavorited",
+  "group": "favorites@1"
+},
+{
+  "command": "claudeConductor.removeFavorite",
+  "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.favorited",
+  "group": "favorites@1"
+}
+```
+
+- [ ] **Step 5: Verify package.json parses and CI checks pass**
+
+```
+node -e "JSON.parse(require('fs').readFileSync('./package.json','utf8'))"
+npm run lint
+npx tsc --noEmit -p tsconfig.test.json
+npm test -- --run
+npm run compile
+```
+
+Expected: all green. Note: existing tests will not yet exercise the new commands (Task 8 does the wiring); they should still pass.
+
+- [ ] **Step 6: Commit**
+
+```
+git -C <worktree> add package.json
+git -C <worktree> commit -m "feat: package.json — Favorites view, commands, menus (#75)"
+```
+
+---
+
+## Phase 5: Extension wiring
+
+### Task 8: Construct services + register provider + register commands + wire markMissing/markPresent
+
+**Files:**
+- Modify: `src/extension.ts`
+
+- [ ] **Step 1: Add construction at activate()**
+
+In `src/extension.ts`, near the top of `activate(context)` after `sessionManager` is created, add:
+
+```typescript
+import { FavoritesStore } from "./favoritesStore";
+import { PathExistenceCache } from "./pathExistenceCache";
+import { FavoritesProvider, VIEW_ITEM } from "./treeView";  // VIEW_ITEM may already be re-exported
+```
+
+Inside `activate`:
+
+```typescript
+const favoritesStore = new FavoritesStore(context.globalState);
+const existenceCache = new PathExistenceCache();
+context.subscriptions.push(favoritesStore, existenceCache);
+```
+
+- [ ] **Step 2: Update RecentProjectsProvider construction**
+
+The existing call site (likely `new RecentProjectsProvider(sessionManager)`) becomes:
+
+```typescript
+const recentProvider = new RecentProjectsProvider(sessionManager, favoritesStore, existenceCache);
+```
+
+- [ ] **Step 3: Register the FavoritesProvider as a TreeView**
+
+```typescript
+const favoritesProvider = new FavoritesProvider(favoritesStore, existenceCache);
+const favoritesView = vscode.window.createTreeView("claudeConductor.favorites", {
+  treeDataProvider: favoritesProvider,
+  showCollapseAll: false,
+});
+context.subscriptions.push(favoritesView);
+
+// Wire over-cap banner — refresh whenever favorites change.
+function refreshOverCapBanner() {
+  favoritesView.message = favoritesProvider.getOverCapBanner() ?? undefined;
+}
+favoritesStore.onDidChange(() => refreshOverCapBanner());
+refreshOverCapBanner();
+```
+
+- [ ] **Step 4: Register the three commands**
+
+```typescript
+context.subscriptions.push(
+  vscode.commands.registerCommand("claudeConductor.addFavorite", async (arg: unknown) => {
+    const path = resolvePathArg(arg);
+    if (!path) return;
+    const r = await favoritesStore.add(path);
+    if (!r.ok && r.reason) {
+      void vscode.window.showWarningMessage(r.reason);
+    }
+  }),
+
+  vscode.commands.registerCommand("claudeConductor.removeFavorite", async (arg: unknown) => {
+    const path = resolvePathArg(arg);
+    if (!path) return;
+    await favoritesStore.remove(path);
+    existenceCache.evict(path);
+  }),
+
+  vscode.commands.registerCommand("claudeConductor.locateFavorite", async (oldPathArg: unknown) => {
+    const oldPath = resolvePathArg(oldPathArg);
+    if (!oldPath) return;
+
+    const picked = await vscode.window.showOpenDialog({
+      canSelectFolders: true,
+      canSelectFiles: false,
+      canSelectMany: false,
+      openLabel: "Select new location",
+    });
+    if (!picked || picked.length === 0) return;
+    const newPath = picked[0].fsPath;
+
+    const r = await favoritesStore.relocate(oldPath, newPath);
+    if (r.ok) {
+      existenceCache.evict(oldPath);
+      if (r.reason) {
+        // dedup case carries a reason on success
+        void vscode.window.showInformationMessage(r.reason);
+      }
+    } else if (r.reason) {
+      void vscode.window.showWarningMessage(r.reason);
+    }
+  })
+);
+```
+
+Add the helper `resolvePathArg` near the existing `resolveSession`:
+
+```typescript
+function resolvePathArg(arg: unknown): string | undefined {
+  if (typeof arg === "string") return arg;
+  if (arg && typeof arg === "object") {
+    const obj = arg as Record<string, unknown>;
+    if (typeof obj.folderPath === "string") return obj.folderPath;
+    if (typeof obj.path === "string") return obj.path;
+  }
+  return undefined;
+}
+```
+
+- [ ] **Step 5: Wire markMissing/markPresent into the favorite-launch click handler**
+
+Find the existing command `claudeConductor.openSession` (or whichever command fires from `RecentProjectItem.command` and `FavoriteLeafItem.command`). Wrap its `launchSession` call:
+
+```typescript
+vscode.commands.registerCommand("claudeConductor.openSession", async (folderPathArg: unknown) => {
+  const folderPath = resolvePathArg(folderPathArg);
+  if (!folderPath) return;
+
+  const result = await sessionManager.launchSession(folderPath);
+  if (result.ok) {
+    existenceCache.markPresent(folderPath);
+  } else if (result.reason === "missing") {
+    existenceCache.markMissing(folderPath);
+    void vscode.window.showErrorMessage(result.message);
+  }
+})
+```
+
+(If `claudeConductor.openSession` is registered elsewhere, modify it in place. The contract is: cache.markPresent on success, cache.markMissing on `reason === "missing"`.)
+
+- [ ] **Step 6: Run all CI checks**
+
+```
+npm run lint
+npx tsc --noEmit -p tsconfig.test.json
+npm test -- --run
+npm run compile
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Manual smoke test (in a dev host)**
+
+Press F5 in VS Code with the worktree open. In the Extension Development Host:
+1. Verify Favorites view appears between Active Sessions and Recent Projects (empty).
+2. In Recent Projects, hover a row — verify a star button appears.
+3. Click the star — verify the project appears in Favorites and the star fills.
+4. Click the star again — verify removal.
+5. Right-click a row in Favorites — verify "Remove from Favorites" appears.
+6. Add a folder, delete it from disk externally, then click it from Favorites — verify it dims with `(missing)` and clicking opens the relocate dialog.
+
+Smoke-test failures should be fixed in this task before committing.
+
+- [ ] **Step 8: Commit**
+
+```
+git -C <worktree> add src/extension.ts
+git -C <worktree> commit -m "feat: wire Favorites store/cache/provider/commands in activate (#75)"
+```
+
+---
+
+## Phase 6: Drift detector + cross-panel race regression test
+
+### Task 9: `packageJsonContextKeys.test.ts`
+
+**Files:**
+- Create: `test/packageJsonContextKeys.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Create `test/packageJsonContextKeys.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { VIEW_ITEM } from "../src/treeView";
+
+interface Menu {
+  command?: string;
+  when?: string;
+  group?: string;
+}
+
+const PKG_PATH = path.join(__dirname, "..", "package.json");
+const pkg = JSON.parse(fs.readFileSync(PKG_PATH, "utf8")) as {
+  contributes?: { menus?: { "view/item/context"?: Menu[] } };
+};
+
+const clauses = pkg.contributes?.menus?.["view/item/context"] ?? [];
+const allWhen = clauses.map(c => c.when ?? "").filter(Boolean);
+
+const VIEW_ITEM_VALUES = Object.values(VIEW_ITEM) as string[];
+
+/** Extract every `viewItem == "X"` literal from a when string. */
+function extractEqLiterals(when: string): string[] {
+  const re = /viewItem\s*==\s*([A-Za-z][A-Za-z0-9._-]*)/g;
+  const out: string[] = [];
+  let m;
+  while ((m = re.exec(when)) !== null) out.push(m[1]);
+  return out;
+}
+
+/** Extract every `viewItem =~ /pattern/` regex (compiled as RegExp) from a when string. */
+function extractRegexes(when: string): RegExp[] {
+  // Match: viewItem =~ /escaped/flags?
+  const re = /viewItem\s*=~\s*\/((?:\\\/|[^/])+)\/([gimsuy]*)/g;
+  const out: RegExp[] = [];
+  let m;
+  while ((m = re.exec(when)) !== null) {
+    // package.json escapes \\ for backslash; un-escape so the pattern matches at runtime.
+    const pattern = m[1].replace(/\\\\/g, "\\");
+    out.push(new RegExp(pattern, m[2]));
+  }
+  return out;
+}
+
+const NEGATIVE_FIXTURES = [
+  "projectRootSomething",
+  "projectRoot",
+  "myprojectRoot.favorited",
+  "projectRoot.favoritedExtra",
+  "recentProject",  // legacy un-migrated value — should NOT match the migrated regex
+  "xyzactiveSession",
+  "activeSessionFoo",
+];
+
+describe("package.json viewItem ↔ VIEW_ITEM bidirectional bijection", () => {
+  it("every `viewItem == X` literal references a VIEW_ITEM value", () => {
+    const literals = allWhen.flatMap(extractEqLiterals);
+    for (const lit of literals) {
+      expect(VIEW_ITEM_VALUES).toContain(lit);
+    }
+  });
+
+  it("every `viewItem =~ /pattern/` matches at least one VIEW_ITEM value", () => {
+    const regexes = allWhen.flatMap(extractRegexes);
+    for (const re of regexes) {
+      const matched = VIEW_ITEM_VALUES.some(v => re.test(v));
+      expect(matched, `regex ${re.source} matched no VIEW_ITEM value`).toBe(true);
+    }
+  });
+
+  it("every VIEW_ITEM value is referenced by at least one menu clause", () => {
+    for (const value of VIEW_ITEM_VALUES) {
+      const literals = allWhen.flatMap(extractEqLiterals);
+      const regexes = allWhen.flatMap(extractRegexes);
+      const referenced =
+        literals.includes(value) ||
+        regexes.some(re => re.test(value));
+      expect(referenced, `VIEW_ITEM value ${value} is orphaned (no menu clause references it)`).toBe(true);
+    }
+  });
+
+  it("regexes do not match negative-fixture sibling tokens", () => {
+    const regexes = allWhen.flatMap(extractRegexes);
+    for (const re of regexes) {
+      for (const neg of NEGATIVE_FIXTURES) {
+        expect(re.test(neg), `regex ${re.source} unexpectedly matched negative fixture ${neg}`).toBe(false);
+      }
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+```
+npm test -- --run test/packageJsonContextKeys.test.ts
+```
+
+Expected: all four assertions pass against the package.json from Task 7.
+
+- [ ] **Step 3: Run full CI suite**
+
+```
+npm run lint
+npx tsc --noEmit -p tsconfig.test.json
+npm test -- --run
+npm run compile
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```
+git -C <worktree> add test/packageJsonContextKeys.test.ts
+git -C <worktree> commit -m "test: bidirectional drift detector for VIEW_ITEM ↔ package.json (#75)"
+```
+
+---
+
+### Task 10: Cross-panel race regression guard
+
+**Files:**
+- Modify: `test/treeView.test.ts`
+
+- [ ] **Step 1: Add the cross-panel race test**
+
+Append to `test/treeView.test.ts`:
+
+```typescript
+import { FavoritesStore } from "../src/favoritesStore";
+import { PathExistenceCache } from "../src/pathExistenceCache";
+import { RecentProjectsProvider } from "../src/treeView";
+
+describe("Cross-panel star coupling", () => {
+  it("Recent Projects row reflects favorited state immediately after store.add", async () => {
+    const data: Record<string, unknown> = {};
+    const memento = {
+      keys: () => Object.keys(data),
+      get: <T>(k: string) => data[k] as T | undefined,
+      update: async (k: string, v: unknown) => { data[k] = v; },
+    } as unknown as import("vscode").Memento;
+
+    const store = new FavoritesStore(memento);
+    const cache = new PathExistenceCache();
+    const sm = makeSessionManager([]);
+
+    vi.mocked(getAllFolders).mockResolvedValue([
+      { folderPath: "C:/proj", name: "proj", parentDir: "C:", source: "recent" as const },
+    ]);
+
+    const provider = new RecentProjectsProvider(sm as any, store, cache);
+
+    // Before add: contextValue should be unfavorited
+    const groupsBefore = await provider.getChildren();
+    const leavesBefore = await provider.getChildren(groupsBefore[0]);
+    expect(leavesBefore[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_UNFAVORITED);
+
+    await store.add("C:/proj");
+
+    // After add: contextValue is favorited
+    const groupsAfter = await provider.getChildren();
+    const leavesAfter = await provider.getChildren(groupsAfter[0]);
+    expect(leavesAfter[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_FAVORITED);
+  });
+
+  it("regression: getTreeItem reads live store, not a stale snapshot (race guard)", async () => {
+    // Simulates the v1 race: provider's getChildren is in flight when store mutates.
+    // The synchronous isFavorited read inside the leaf-item construction must see
+    // the latest state.
+    const data: Record<string, unknown> = {};
+    const memento = {
+      keys: () => Object.keys(data),
+      get: <T>(k: string) => data[k] as T | undefined,
+      update: async (k: string, v: unknown) => { data[k] = v; },
+    } as unknown as import("vscode").Memento;
+
+    const store = new FavoritesStore(memento);
+    const cache = new PathExistenceCache();
+    const sm = makeSessionManager([]);
+
+    vi.mocked(getAllFolders).mockResolvedValue([
+      { folderPath: "C:/proj", name: "proj", parentDir: "C:", source: "recent" as const },
+    ]);
+
+    const provider = new RecentProjectsProvider(sm as any, store, cache);
+
+    // Start a getChildren call.
+    const inflight = provider.getChildren();
+
+    // While "in flight," mutate the store.
+    await store.add("C:/proj");
+
+    // Resolve the in-flight call — it had time to await getAllFolders, then
+    // builds leaves synchronously (in getChildren(group)), where the live
+    // store state is what counts.
+    const groups = await inflight;
+    const leaves = await provider.getChildren(groups[0]);
+    expect(leaves[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_FAVORITED);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+```
+npm test -- --run test/treeView.test.ts
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 3: Run full CI suite**
+
+```
+npm run lint
+npx tsc --noEmit -p tsconfig.test.json
+npm test -- --run
+npm run compile
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```
+git -C <worktree> add test/treeView.test.ts
+git -C <worktree> commit -m "test: cross-panel star coupling + race regression guard (#75)"
+```
+
+---
+
+## Phase 7: Documentation
+
+### Task 11: README + CHANGELOG
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Locate the "Activity Bar Sidebar" section in README.md**
+
+Open `README.md`. Find the section documenting the existing Active Sessions / Recent Projects panels.
+
+- [ ] **Step 2: Add the Favorites subsection**
+
+Insert (between the existing two panel descriptions):
+
+```markdown
+### Favorites
+
+A curated list of project roots you've pinned for quick access. Sits between Active Sessions and Recent Projects.
+
+- **Add a favorite:** hover a project row in Recent Projects or right-click and choose **Add to Favorites**. The row shows a star icon when favorited.
+- **Remove a favorite:** hover a favorited row and click the filled star, or right-click → **Remove from Favorites**.
+- **Relocate a favorite:** if a favorited folder is missing on disk, the row dims and shows `(missing)`. Click or press Enter on a missing row (or right-click → **Locate Folder...**) to point the favorite at the folder's new location.
+- **Capacity:** soft cap of 25 favorites. Beyond that, add new ones is rejected with a toast.
+- **Persistence:** per-machine via VS Code's `globalState`. Favorites do not sync between machines (this is intentional — see Known Limits).
+
+### Known Limits
+
+- **Favorites paths are tracked as you typed them.** Two distinct path strings that resolve to the same folder via symlinks or junctions produce duplicate entries.
+- **UNC shares (`\\server\share`):** these render as present until you actually launch the session. If the share is offline, the launch will fail and the row will dim. The next successful launch flips it back.
+- **Multi-window writes:** if you mutate Favorites in two VS Code windows simultaneously, the last write wins. The list is bounded (25 entries) and mutation rate is low, so collisions are unlikely in practice. Settings Sync is intentionally not enabled for v1.
+```
+
+- [ ] **Step 3: Add CHANGELOG entry**
+
+In `CHANGELOG.md`, under the next unreleased version (or create one):
+
+```markdown
+## [Unreleased]
+
+### Added
+- **Favorites sidebar section** ([#75](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/75))
+  - New top-level tree view between Active Sessions and Recent Projects
+  - Star toggle on Recent Projects rows (hover or right-click)
+  - Missing-folder rows dim with `(missing)` and click-to-relocate
+  - 25-favorite soft cap; per-machine `globalState` persistence
+
+### Changed
+- `launchSession` now returns a `LaunchResult` (`ok: true | false` with reason) instead of `void`. Internal API; existing extension behavior unchanged.
+```
+
+- [ ] **Step 4: Run all CI checks**
+
+```
+npm run lint
+npx tsc --noEmit -p tsconfig.test.json
+npm test -- --run
+npm run compile
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```
+git -C <worktree> add README.md CHANGELOG.md
+git -C <worktree> commit -m "docs: README + CHANGELOG for Favorites (#75)"
+```
+
+---
+
+## Phase 8: PR
+
+### Task 12: Push and open the PR
+
+**Files:** none
+
+- [ ] **Step 1: Push the branch**
+
+```
+git -C <worktree> push -u origin 75-favorites
+```
+
+- [ ] **Step 2: Create the PR**
+
+Use `mcp__plugin_github_github__create_pull_request` with:
+- Title: `feat: add Favorites sidebar section (#75)`
+- Body: summary of phases 1–7, link to spec + plan, mark "closes #75" in plain text (no backticks — see `feedback_gh_closing_keywords_need_plain_text.md`)
+- End the body with the Claude attribution line per CLAUDE.md GitHub Comments rule.
+
+- [ ] **Step 3: Verify all CI jobs green**
+
+After CI runs (lint, typecheck, test, compile), confirm all 4 jobs pass before requesting review.
+
+- [ ] **Step 4: Request review (if applicable) or merge**
+
+---
+
+## Self-Review (against the spec)
+
+| Spec section | Plan task |
+|---|---|
+| `FavoritesStore` service | Task 3 |
+| `PathExistenceCache` (incl. `markPresent`) | Task 2 |
+| `isWorktreePath` predicate | Task 1 |
+| `launchSession` returns `LaunchResult` | Task 4 |
+| `VIEW_ITEM` constants | Task 5 |
+| `RecentProjectsProvider` contextValue migration | Task 5 |
+| `FavoritesProvider` | Task 6 |
+| Storage envelope + deferred migration | Task 3 (in store) |
+| Serialized persist queue | Task 3 |
+| Multi-window last-writer-wins (no merge) | Task 3 (documented in store comments + Task 11 README) |
+| Missing-row click-to-relocate | Task 6 (FavoriteLeafItem) |
+| 25-cap render-path banner | Task 6 (`getOverCapBanner`) + Task 8 (TreeView.message wiring) |
+| `package.json` view + commands + menus | Task 7 |
+| `package.json:143` `recentProject` clause migration | Task 7 (Step 4) |
+| Extension wiring (activate, register, command handlers) | Task 8 |
+| `markMissing`/`markPresent` callsite in launch handler | Task 8 (Step 5) |
+| Drift detector test | Task 9 |
+| Cross-panel race regression test | Task 10 |
+| README + CHANGELOG | Task 11 |
+| PR | Task 12 |
+
+All spec sections are covered. Type names (`FavoritesEntry`, `FavoritesChangeEvent`, `LaunchResult`, `VIEW_ITEM`, `MAX_FAVORITES`) are consistent across tasks.

--- a/docs/superpowers/specs/2026-04-28-75-favorites-design.md
+++ b/docs/superpowers/specs/2026-04-28-75-favorites-design.md
@@ -1,6 +1,6 @@
 # Design Spec — Favorites Sidebar Section (Issue #75)
 
-**Status:** Draft v2 (post inquisitor review)
+**Status:** Draft v3 (post second inquisitor review)
 **Date:** 2026-04-28
 **Issue:** [#75](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/75)
 **Branch:** `75-favorites`
@@ -8,13 +8,11 @@
 ## Revision History
 
 - **v1 (2026-04-28)** — initial brainstorm output.
-- **v2 (2026-04-28)** — addressed inquisitor charges:
-  - Cross-panel race fixed by extracting a `FavoritesStore` service (charge 1).
-  - Synchronous `existsSync` replaced with async stat + TTL cache + UNC skip (charge 2).
-  - `viewItem` migration explicitly acknowledged with package.json menu-clause updates (charge 3).
-  - Storage shape changed to `Array<{path: string}>` with a one-shot read-side migration (charge 4).
-  - Missing-row click no longer hijacks `TreeItem.command` — relies on context menu + tooltip (charge 5).
-  - Risks/Non-Goals expanded for charges 6–11 (dedup canonical key, Settings Sync rationale, max favorites cap, refresh-storm split, test plan rewritten to behavior-based, cross-workspace acknowledgement).
+- **v2 (2026-04-28)** — addressed inquisitor pass 1 (cross-panel race, UNC hangs, viewItem migration first attempt, storage shape, click-hijack).
+- **v3 (2026-04-28)** — addressed inquisitor pass 2:
+  - **Blocker fixes:** composite single-token contextValues (no multi-token regex matching); serialized persist queue with snapshot rollback; `version` envelope on storage with deferred-on-mutation migration; click-on-missing opens relocate dialog directly.
+  - **Smaller fixes:** `peek()` keeps last-known on TTL expiry with `stale` flag; regex anchoring; bidirectional drift test; render-path 25-cap enforcement; relocate same-path toast restored; targeted `onDidChangeTreeData` invalidation; UNC launch failure feeds existence cache; cache eviction on remove/relocate; explicit `isWorktreePath` predicate sourced from `projectGrouping.ts`.
+  - **YAGNI cut:** removed the `id: string` UUID field. Storage shape stays object-based (extensible) without a speculative identifier no v1 feature reads.
 
 ## Summary
 
@@ -28,16 +26,17 @@ Favorites is a **manual curation overlay**, not a usage tracker. Pinning a proje
 - Reuse `projectGrouping.ts` and `RecentProjectsProvider` patterns — minimal new architecture.
 - Tolerate transient absence (unmounted drives) and intentional moves (folder relocated on disk) without silent data loss.
 - Keep the design scoped — no drag-to-reorder, no per-worktree pinning, no auto-tracking.
-- Future-proof storage so deferred features (drag-reorder, sync, frequency) don't force a schema migration later.
+- Extensible storage shape so deferred features land non-breakingly.
 
 ## Non-Goals (with rationale)
 
-- **Drag-to-reorder.** Deferred. Soft cap of 25 favorites enforced at `addFavorite` (toast on overflow); past that, alphabetical-only ordering is unusable and we revisit the deferred feature.
-- **Per-worktree favorites.** Excluded. Favorites are project-rooted; worktrees come along via grouping. Both `addFavorite` and `locateFavorite` reject worktree paths.
+- **Drag-to-reorder.** Deferred. Soft cap of 25 favorites enforced both at `addFavorite` (toast on overflow) AND at the render path (truncate display + log warning if storage drifts past). Past 25 alphabetical-only ordering is unusable; that's the trigger to revisit.
+- **Per-worktree favorites.** Excluded. Favorites are project-rooted; worktrees come along via grouping. Both `addFavorite` and `locateFavorite` reject worktree paths via the shared `isWorktreePath()` predicate.
 - **Auto-frequency tracking.** Out of scope per the issue.
-- **Settings Sync (`setKeysForSync`).** Explicitly NOT registered in v1 because path portability across machines is unsolved (drive letters, project locations differ across desktop/laptop). Revisit when a user requests it AND proposes a path-resolution strategy. The forward-compatible storage shape (see Storage) means adding sync later is non-breaking — the `id` field can serve as a sync-portable identifier independent of the `path`.
-- **Cross-workspace filtering.** Favorites are user-global. Opening a workspace where most favorited paths live elsewhere produces `(missing)` rows for those paths. v1 accepts this; the dimmed visual treatment is intentionally unobtrusive so the panel doesn't read as "everything is broken."
-- **Promoting Favorites into a workspace-level setting.** Stays user-global.
+- **Settings Sync (`setKeysForSync`).** Explicitly NOT registered in v1 because path portability across machines is unsolved (drive letters, project locations differ). The object-shape storage means adding sync later is non-breaking. A sync-portable identifier (UUID, content hash, or symbolic name) would be added at that time — *not* speculatively now.
+- **Stable per-entry identifier.** Removed from v3. v2 added `id: string` to "future-proof" sync; the inquisitor pass correctly flagged this as YAGNI — no v1 feature reads it, multi-window cold-start migrates the same v1 data twice and races UUIDs, and any future identifier scheme has constraints we don't know yet (deterministic vs random, content vs path). Storage stays `[{path: string}]`; the object envelope is the actual extensibility hedge.
+- **Cross-workspace filtering.** Favorites are user-global. Opening a workspace where most favorited paths live elsewhere produces `(missing)` rows for those paths. v1 accepts this; the dimmed visual treatment is intentionally unobtrusive.
+- **Symlink/junction canonicalization.** Canonical key skips `realpathSync` (which throws on missing paths the relocate flow needs to handle uniformly). Documented tradeoff: two distinct path strings resolving to the same directory produce duplicate entries.
 
 ## Architecture
 
@@ -57,24 +56,26 @@ Add a third `TreeView` contribution in `package.json`:
 
 ### `FavoritesStore` service (new file: `src/favoritesStore.ts`)
 
-A standalone service that owns all favorites state. **Both providers consult it; neither owns it.** This is the architectural crux that fixes the cross-panel race.
+A standalone service that owns all favorites state. Both providers consult it; neither owns it. The persist path is **serialized**: at most one `memento.update` is in flight at a time, ensuring rollback semantics are deterministic.
 
 ```typescript
-export interface FavoritesEntry {
-  /** Canonical user-facing path, original case preserved. */
-  path: string;
-  /** Stable id (UUID v4) — survives path relocation, future-proofs sync. */
-  id: string;
+export interface FavoritesEntry { path: string; }
+export interface FavoritesStorageEnvelope {
+  version: 2;
+  entries: FavoritesEntry[];
 }
 
 export class FavoritesStore {
   private entries: FavoritesEntry[] = [];
-  private keyIndex: Set<string> = new Set();   // lowercased canonical keys
+  private keyIndex: Set<string> = new Set();
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   readonly onDidChange = this._onDidChange.event;
 
+  // Serialized persist queue
+  private persistChain: Promise<void> = Promise.resolve();
+
   constructor(private readonly memento: vscode.Memento) {
-    this.entries = readAndMigrate(memento);
+    this.entries = readWithoutMigrating(memento);  // pure read; no write side effects
     this.rebuildIndex();
   }
 
@@ -84,66 +85,115 @@ export class FavoritesStore {
   }
   list(): readonly FavoritesEntry[] { return this.entries; }
 
-  // ---- Async mutations (called from commands) ----
-  async add(path: string): Promise<{ ok: boolean; reason?: string }> { /* ... */ }
-  async remove(path: string): Promise<void> { /* ... */ }
-  async relocate(oldPath: string, newPath: string): Promise<{ ok: boolean; reason?: string }> { /* ... */ }
+  // ---- Async mutations — all routed through enqueueMutation ----
+  async add(path: string): Promise<{ ok: boolean; reason?: string }> { ... }
+  async remove(path: string): Promise<void> { ... }
+  async relocate(oldPath: string, newPath: string): Promise<{ ok: boolean; reason?: string }> { ... }
 
-  private rebuildIndex(): void { /* ... */ }
+  /**
+   * Serialized mutation: snapshot, apply in memory, fire change, then chain
+   * the persist behind any in-flight persist. Rollback to snapshot on reject.
+   */
+  private enqueueMutation(apply: (entries: FavoritesEntry[]) => FavoritesEntry[]): Promise<void> {
+    const snapshot = [...this.entries];
+    this.entries = apply(snapshot);
+    this.rebuildIndex();
+    this._onDidChange.fire();
+
+    this.persistChain = this.persistChain
+      .catch(() => { /* swallow prior errors; each link handles its own rollback */ })
+      .then(() => this.memento.update(STORAGE_KEY, { version: 2, entries: this.entries }))
+      .catch(err => {
+        // Roll back to the snapshot taken when *this* mutation was enqueued.
+        // If subsequent mutations succeeded on top of this one, they're now
+        // also rolled back — that's the contract of serialized persists:
+        // failure of an earlier persist invalidates all later in-memory
+        // mutations chained on it.
+        this.entries = snapshot;
+        this.rebuildIndex();
+        this._onDidChange.fire();
+        showPersistErrorToast(err);
+      });
+
+    return this.persistChain;
+  }
+
+  private rebuildIndex(): void {
+    this.keyIndex = new Set(this.entries.map(e => canonicalKey(e.path)));
+  }
 }
 ```
 
-**Why this fixes the race:** providers do not cache the favorites set across an `await`. Inside `getTreeItem(element)` — which VS Code calls synchronously per visible row — they call `store.isFavorited(element.path)` and read the live index. When the store mutates, it updates `entries` and `keyIndex` *first* (synchronous), then fires `onDidChange`, then persists to `globalState` asynchronously in the background. Stale paint is impossible because there is no stale snapshot to paint against — the index is the only source of truth and it's read fresh every render.
+**Why the persist queue is serialized:** the inquisitor's pass-2 charge correctly identified that `memento.update` rejecting after multiple mutations have stacked produces undefined rollback behavior. Serializing means there's only ever one in-flight persist whose rejection has unambiguous semantics: roll the in-memory state back to the snapshot taken when *that mutation* was enqueued. Any subsequent mutations chained behind it are also rolled back — they were predicated on the failed persist's success.
 
-**Persistence sequencing:** mutations apply to in-memory state synchronously; the async `memento.update()` is fire-and-forget but errors surface through a `.catch(handlePersistError)` that toasts the user and rolls back the in-memory change.
+This costs latency on rapid-fire toggles (each waits behind the previous's persist) but is correct. For a curated list capped at 25 entries, latency is irrelevant.
 
 ### Canonical Key
 
 ```typescript
 /**
- * Canonical lookup key for dedup, isFavorited(), and store lookups.
- * Pipeline: separator normalize → trim trailing separator → case-fold (lower).
- *
- * Notably does NOT call fs.realpathSync — symlink/junction resolution is
- * deferred to v2 because realpathSync on missing paths throws, and the
- * caller cannot distinguish "missing path that's also a symlink" from
- * "missing path." Acknowledged tradeoff: two distinct symlink-resolved-same
- * paths produce duplicate favorite entries. Document this in user-facing
- * docs ("Favorites tracks paths as you typed them").
+ * Canonical lookup key. Pipeline: separator normalize → trim trailing
+ * separator → case-fold (lower). Does NOT consult realpathSync — see
+ * Non-Goals for the symlink tradeoff rationale.
  */
 function canonicalKey(p: string): string {
   return p
-    .replace(/\\/g, "/")           // separator normalize
-    .replace(/\/+$/, "")           // trim trailing separators
-    .toLowerCase();                // case-fold (Windows-correct, harmless on POSIX)
+    .replace(/\\/g, "/")
+    .replace(/\/+$/, "")
+    .toLowerCase();
 }
 ```
 
-This canonical key is used in **every** dedup check: `add`, `relocate`, `isFavorited`, and the menu `when`-clause `viewItem` derivation. Tests assert the same key derivation in both `package.json` menu-clause logic and the store.
+Used identically in: `add` dedup, `relocate` dedup, `isFavorited`, and the existence cache key. No alternate normalizations anywhere.
 
-### Existence Check (async, cached, UNC-aware)
+### Worktree Path Predicate
 
-Replace the v1 sync `fs.existsSync` design with an async cache:
+`isWorktreePath(p: string): boolean` is exported from `src/projectGrouping.ts` (the same module that already has the worktree-detection regex internally). The predicate matches the existing detection rule: path ends with `/.worktrees/<single-segment>` after separator normalization, case-insensitive.
 
 ```typescript
+// Exported from src/projectGrouping.ts
+export function isWorktreePath(p: string): boolean {
+  return /\/\.worktrees\/[^/]+$/i.test(p.replace(/\\/g, "/"));
+}
+```
+
+This is the *only* predicate used to reject worktree paths in `addFavorite` and `locateFavorite`. No other heuristics, no shell-out to git.
+
+### Existence Cache (async, stale-aware, UNC-skipping)
+
+```typescript
+type ExistenceState =
+  | { kind: "exists"; checkedAt: number }
+  | { kind: "missing"; checkedAt: number }
+  | { kind: "unknown" };  // never checked
+
 class PathExistenceCache {
-  private cache = new Map<string, { exists: boolean; checkedAt: number }>();
+  private cache = new Map<string, ExistenceState>();
   private readonly TTL_MS = 30_000;
   private readonly STAT_TIMEOUT_MS = 500;
 
-  /** Synchronous read for getTreeItem. Returns last-known value or 'unknown'. */
-  peek(path: string): "exists" | "missing" | "unknown" {
+  /**
+   * Synchronous read for getTreeItem.
+   * Returns: 'exists' | 'missing' | { kind: 'missing', stale: true } | 'unknown'.
+   * Stale-missing keeps the dimmed render until the next stat lands.
+   */
+  peek(path: string): { kind: "exists" } | { kind: "missing"; stale: boolean } | { kind: "unknown" } {
     const e = this.cache.get(canonicalKey(path));
-    if (!e) return "unknown";
-    if (Date.now() - e.checkedAt > this.TTL_MS) return "unknown";
-    return e.exists ? "exists" : "missing";
+    if (!e || e.kind === "unknown") return { kind: "unknown" };
+    const stale = Date.now() - e.checkedAt > this.TTL_MS;
+    if (e.kind === "missing") return { kind: "missing", stale };
+    if (stale) return { kind: "unknown" };  // exists+stale → re-confirm; safe to show present optimistically meanwhile
+    return { kind: "exists" };
   }
 
-  /** Async refresh — non-blocking, with timeout. UNC paths skipped. */
-  async refresh(paths: string[]): Promise<void> {
-    const toCheck = paths.filter(p => !isLikelyNetworkPath(p));  // skip \\server\share
-    // ...stat each with Promise.race against STAT_TIMEOUT_MS, populate cache, fire event...
-  }
+  /** Mark a path missing immediately (e.g., after a launch failure). */
+  markMissing(path: string): void { ... }
+
+  /** Evict cache entry — called on remove/relocate. */
+  evict(path: string): void { ... }
+
+  /** Background refresh; non-blocking, with timeout. UNC paths skipped. */
+  async refresh(paths: string[]): Promise<void> { ... }
 }
 
 function isLikelyNetworkPath(p: string): boolean {
@@ -152,257 +202,327 @@ function isLikelyNetworkPath(p: string): boolean {
 ```
 
 **Behavior:**
-- Render time: `peek()` returns `"unknown"` initially; treat as optimistic-present (no `(missing)` decoration). Tree renders instantly.
-- Refresh: a background pass calls `cache.refresh(allFavoritedPaths)` on store load and on `onDidChange`. When stat results land, fire `_onDidChangeDecorations` so providers re-render rows with updated missing flags.
-- UNC paths: skipped by the refresh loop; always rendered as optimistic-present. User who favorites `\\server\share\proj` won't see `(missing)` if the share is offline — they'll get a launch error if they click. This is the correct tradeoff vs hanging the extension host.
-- TTL: 30s — re-stat happens at most twice per minute even with rapid refresh churn.
-
-**Why this addresses the inquisitor's charge:** sync stat on disconnected UNC paths can block the extension host for the SMB timeout (tens of seconds). The async + timeout + UNC-skip design caps the worst case at 500ms per non-UNC path, run on a background async pass that doesn't block any tree render.
+- `peek`'s asymmetric staleness (return `unknown` for stale-exists but stale-missing for stale-missing) avoids the v2 flicker: a confirmed-missing entry stays dimmed across TTL expiry until a fresh stat result lands. No 30s on/off oscillation.
+- `markMissing(path)` is called from `launchSession` failure handlers when launching a UNC favorite fails — the cache learns from launch attempts so repeated clicks don't keep optimistic-rendering an unreachable path.
+- `evict(path)` is called by `FavoritesStore` from `remove` and `relocate` so stat results landing for stale paths never fire `onDidChange` for non-existent entries.
+- UNC paths skipped by `refresh()` are still rendered as optimistic-present until a launch failure flips them to missing via `markMissing()` — feedback loop closes the v2 gap.
 
 ### Provider Refresh Decoupling
 
-Two distinct refresh axes, two distinct events:
-
-| Event | What changed | Provider response |
+| Event | Trigger | Provider response |
 |---|---|---|
-| `onDidChangeSessions` (existing) | Active session set | RecentProjectsProvider re-fetches `getAllFolders()`, re-groups, fires `onDidChangeTreeData(undefined)` |
-| `FavoritesStore.onDidChange` (new) | Favorites set | Both providers fire `onDidChangeTreeData(undefined)` *without* re-fetching folders. VS Code re-calls `getTreeItem` per row, which reads the live `isFavorited()` and renders the new icon. No re-grouping, no I/O. |
-| `existenceCache.onDidChange` (new) | A previously-unknown path now has a known existence state | Both providers fire `onDidChangeTreeData(undefined)`. Same pattern — re-render only, no re-fetch. |
+| `onDidChangeSessions` (existing) | Active session set changes | RecentProjectsProvider re-fetches `getAllFolders()`, re-groups, fires `onDidChangeTreeData(undefined)` |
+| `FavoritesStore.onDidChange` | Favorites set changes | Both providers fire `onDidChangeTreeData(toggledElement)` (targeted) when a single path was toggled. For multi-path mutations (e.g., relocate-with-dedup which removes one and updates another), fire `onDidChangeTreeData(undefined)`. |
+| `existenceCache.onDidChange` | A row's existence state transitioned (e.g., stat result landed, `markMissing` called) | Both providers fire `onDidChangeTreeData(specificElement)` if the change is single-path; broad invalidation only when refresh batch returns >1 transition. |
 
-**Why this fixes the refresh storm:** the v1 design had `RecentProjectsProvider` re-running `getAllFolders()` on every favorites change. That's three full data refreshes per logical action (open session → favorite → idle bell). v2 splits "data changed" from "decoration changed"; favorites toggles trigger only icon/contextValue re-render, not folder re-fetch.
+**Targeted invalidation:** `FavoritesStore` exposes `onDidChange` as `Event<{ kind: "single"; path: string } | { kind: "broad" }>` (instead of `Event<void>`) so consumers can choose targeted vs full invalidation. Star-toggles emit `{ kind: "single", path }`; relocate-with-dedup and bulk operations emit `{ kind: "broad" }`.
 
-### `viewItem` Context Values & Migration
+### `viewItem` Context Values — Composite Single Tokens
 
-**Existing state:** `RecentProjectsProvider` rows currently have `contextValue = "recentProject"` (`treeView.ts:159`), and `package.json:143` has a menu clause `viewItem == recentProject`. The v1 spec silently changed `contextValue` to `projectRoot.unfavorited`, which would have broken the existing menu clause.
+**Crux of the v3 fix:** VS Code's `viewItem` matching with `==` is literal string equality. v2's "space-separated multi-token" claim was wrong. v3 uses *single composite tokens*.
 
-**v2 migration plan:**
+| Provider | Row state | `contextValue` |
+|---|---|---|
+| RecentProjectsProvider (top-level) | not favorited | `recentProject.unfavorited` |
+| RecentProjectsProvider (top-level) | favorited | `recentProject.favorited` |
+| RecentProjectsProvider (top-level) | favorited + missing | `recentProject.missing` |
+| FavoritesProvider (top-level) | present | `favoriteProject.favorited` |
+| FavoritesProvider (top-level) | missing | `favoriteProject.missing` |
+| Either provider (worktree child) | any | `worktreeChild` |
+| ActiveSessionsProvider | unchanged | `activeSession` |
 
-1. Define exported constants in `src/treeView.ts`:
-   ```typescript
-   export const VIEW_ITEM = {
-     PROJECT_ROOT_FAVORITED:   "projectRoot.favorited",
-     PROJECT_ROOT_UNFAVORITED: "projectRoot.unfavorited",
-     PROJECT_ROOT_MISSING:     "projectRoot.missing",
-     WORKTREE_CHILD:           "worktreeChild",
-     // existing values preserved for back-compat
-     RECENT_PROJECT:           "recentProject",
-     ACTIVE_SESSION:           "activeSession",
-   } as const;
-   ```
-2. **RecentProjectsProvider rows** — `contextValue` becomes a *space-separated multi-value*: `"recentProject projectRoot.favorited"` or `"recentProject projectRoot.unfavorited"`. VS Code's `viewItem` matching handles space-separated tokens via the `=~` regex operator. This preserves the existing `viewItem == recentProject` clause AND enables new `viewItem =~ /projectRoot\\.favorited/` clauses without breaking anything.
-3. **FavoritesProvider rows** — `contextValue` is `"favoritedProject projectRoot.favorited"` (or `projectRoot.missing` when missing). The first token is a Favorites-specific marker; the second is the shared favorited-state token.
-4. **Test:** add a `package-json-context-keys.test.ts` that parses `package.json` menu `when` clauses, extracts every `viewItem` literal, and asserts it appears in the `VIEW_ITEM` constants. This is the drift detector the inquisitor demanded.
+**`package.json` migration of the existing `recentProject` clause:**
 
-### Storage
-
-| Key | Type | Scope | Notes |
-|---|---|---|---|
-| `claudeConductor.favorites` | `FavoritesEntry[]` | `globalState` (per-machine) | Each entry has `path` and stable `id`. Order is **not** UX-visible — alphabetical sort happens at render time. |
-
-**Read-side migration** (handles users coming from v1 string-array storage if any preview exists; also defensive):
-
-```typescript
-function readAndMigrate(memento: vscode.Memento): FavoritesEntry[] {
-  const raw = memento.get("claudeConductor.favorites");
-  if (!Array.isArray(raw)) return [];
-  if (raw.length === 0) return [];
-
-  // v1 shape: string[]
-  if (typeof raw[0] === "string") {
-    const migrated = (raw as string[]).map(path => ({ path, id: randomUUID() }));
-    memento.update("claudeConductor.favorites", migrated);  // fire-and-forget upgrade
-    return migrated;
-  }
-
-  // v2 shape: FavoritesEntry[]
-  return raw as FavoritesEntry[];
+```jsonc
+{
+  "command": "claudeConductor.openRecentProject",  // existing command
+  "when": "view == claudeConductor.recentProjects && viewItem =~ /^recentProject\\b/",
+  "group": "inline"
 }
 ```
 
-**Why this matters:** four deferred features (drag-reorder, frequency tracking, sync, custom labels) all want per-entry metadata. `Array<{path, id}>` future-proofs all of them at zero current cost. The `id` field is the load-bearing piece — it survives path relocation, so a relocate operation preserves identity (sort position, future timestamps).
+The `\b` word-boundary anchor ensures `recentProject.favorited` matches but a hypothetical future `recentProjectFoo` does not. The `^` ensures we don't match `xyzrecentProject.favorited`.
+
+**Existing three `activeSession` clauses are unchanged** — `activeSession` is still a single literal token.
+
+```typescript
+// Exported from src/treeView.ts
+export const VIEW_ITEM = {
+  RECENT_PROJECT_FAVORITED:    "recentProject.favorited",
+  RECENT_PROJECT_UNFAVORITED:  "recentProject.unfavorited",
+  RECENT_PROJECT_MISSING:      "recentProject.missing",
+  FAVORITE_PROJECT_FAVORITED:  "favoriteProject.favorited",
+  FAVORITE_PROJECT_MISSING:    "favoriteProject.missing",
+  WORKTREE_CHILD:              "worktreeChild",
+  ACTIVE_SESSION:              "activeSession",
+} as const;
+```
+
+### Storage Envelope
+
+```typescript
+const STORAGE_KEY = "claudeConductor.favorites";
+
+interface FavoritesStorageEnvelope {
+  version: 2;
+  entries: { path: string }[];
+}
+```
+
+| Stored value | Interpretation |
+|---|---|
+| `undefined` or `null` | No favorites; treat as `[]`. |
+| `[]` | No favorites. |
+| `string[]` (no version field) | v1 legacy. Read-time: convert to envelope shape and replace storage atomically on first **mutation** (not on first read). Multiple windows reading concurrently see the same legacy data; the migration write happens once, when the user actually changes something. |
+| `{ version: 2, entries: [...] }` | v2 native; use as-is. |
+| `{ version: <other>, ... }` | Future shape unknown to this build. Toast: `"Favorites storage was written by a newer version of the extension; v1 read-only mode."` Treat as `[]` for writes (no destructive overwrite), render entries best-effort if `entries` is an array. |
+
+**Multi-window race resolution:** because migration is deferred to first mutation, two windows opening v1 data both display it correctly without writing. The first window to actually mutate triggers the migration write. The second window's `globalState` change listener (if VS Code provides one) or its next read picks up the new shape. Even if both windows mutate simultaneously, *no UUIDs are at stake* — `entries` is just `{path}` objects, dedup is canonical-key-based, and the worst case is a last-writer-wins on the entries array which is the same semantics as any concurrent storage update.
+
+**v1-build compatibility:** the envelope shape is an object, not an array. A v1 build reading the envelope would see `Array.isArray(raw) === false` and fall through to its empty-state branch — no crash, no misinterpretation, just "no favorites" until the user upgrades again or downgrades v2. This is acceptable for a manual-curation feature where loss of pinned-state on downgrade is recoverable (re-pin a few projects).
 
 ## Commands
 
 | Command ID | Args | Behavior |
 |---|---|---|
-| `claudeConductor.addFavorite` | `path: string` | Reject worktree paths. Reject if `entries.length >= 25` (toast: `"Favorites cap reached (25). Remove an entry first."`). Normalize. Append entry with new UUID. Fire `onDidChange`. Idempotent: if already favorited (canonical-key match), no-op silently. |
-| `claudeConductor.removeFavorite` | `path: string` | Remove entries whose canonical key matches. Fire `onDidChange`. No-op if absent. |
-| `claudeConductor.locateFavorite` | `oldPath: string` | Show `vscode.window.showOpenDialog({ canSelectFolders: true, canSelectFiles: false, canSelectMany: false, openLabel: "Select new location" })`. **Reject worktree paths from the dialog result** with toast `"Favorite the project root, not a worktree."` (the same guard `addFavorite` uses). On valid selection: if the new canonical key matches a *different* existing entry, drop the old entry and toast `"That folder is already in your Favorites — removed the missing entry."`. If the new key matches the OLD entry's key (case/separator tweaks), update path string in place. Otherwise: replace `path` on the matched entry, preserving `id`. Fire `onDidChange`. |
+| `claudeConductor.addFavorite` | `path: string` | Reject worktree paths via `isWorktreePath()` (toast). Reject when `entries.length >= 25` (toast: `"Favorites cap reached (25). Remove an entry first."`). Normalize. Append entry if not already present (canonical-key match). Idempotent. |
+| `claudeConductor.removeFavorite` | `path: string` | Remove entries whose canonical key matches. Evict from existence cache. No-op if absent. |
+| `claudeConductor.locateFavorite` | `oldPath: string` | Show `vscode.window.showOpenDialog({ canSelectFolders: true, canSelectFiles: false, canSelectMany: false, openLabel: "Select new location" })`. Reject if user cancels (no-op). Reject worktree paths via `isWorktreePath()` (toast). If `canonicalKey(newPath) === canonicalKey(oldPath)`: toast `"That's the same path. Choose a different folder."` and no-op. If `canonicalKey(newPath)` matches a different existing entry: drop the old entry, evict its cache key, toast `"That folder is already in your Favorites — removed the missing entry."`. Otherwise: replace `path` on the matched entry, evict the old cache key. |
+| `claudeConductor.openMissingFavoriteRelocator` | `path: string` | **New** — invoked from `TreeItem.command` on a missing favorite row (click handler). Internally just calls `claudeConductor.locateFavorite(path)`. Exists separately so the on-click and right-click-menu paths can be tested and potentially diverge later. Registered but hidden from the command palette via `commandPalette` menu `when` clause set to `false`. |
 
 ## Menus
 
 ```jsonc
 "menus": {
   "view/item/context": [
+    // Star toggle (inline) — Recent + Favorites, unfavorited row → add
     {
       "command": "claudeConductor.addFavorite",
-      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem =~ /projectRoot\\.unfavorited/",
+      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == recentProject.unfavorited",
       "group": "inline@1"
     },
+    // Star toggle (inline) — Recent, favorited row → remove (Recent shows the favorited state too)
     {
       "command": "claudeConductor.removeFavorite",
-      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem =~ /projectRoot\\.favorited/",
+      "when": "view == claudeConductor.recentProjects && viewItem == recentProject.favorited",
       "group": "inline@1"
     },
+    // Star toggle (inline) — Favorites row → remove
+    {
+      "command": "claudeConductor.removeFavorite",
+      "when": "view == claudeConductor.favorites && viewItem == favoriteProject.favorited",
+      "group": "inline@1"
+    },
+    // Missing favorite — Locate Folder (inline + context)
     {
       "command": "claudeConductor.locateFavorite",
-      "when": "view == claudeConductor.favorites && viewItem =~ /projectRoot\\.missing/",
-      "group": "missing@1"
+      "when": "view == claudeConductor.favorites && viewItem =~ /^(favoriteProject|recentProject)\\.missing$/",
+      "group": "inline@1"
     },
+    // Missing favorite — Remove (context only, secondary)
     {
       "command": "claudeConductor.removeFavorite",
-      "when": "view == claudeConductor.favorites && viewItem =~ /projectRoot\\.missing/",
+      "when": "view == claudeConductor.favorites && viewItem =~ /^(favoriteProject|recentProject)\\.missing$/",
       "group": "missing@2"
     },
-    // Non-inline duplicates for context-menu discoverability
+    // Non-inline duplicates for right-click discoverability
     {
       "command": "claudeConductor.addFavorite",
-      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem =~ /projectRoot\\.unfavorited/",
+      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == recentProject.unfavorited",
       "group": "favorites@1"
     },
     {
       "command": "claudeConductor.removeFavorite",
-      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem =~ /projectRoot\\.favorited/",
+      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && (viewItem == recentProject.favorited || viewItem == favoriteProject.favorited)",
       "group": "favorites@1"
     }
+  ],
+  "commandPalette": [
+    { "command": "claudeConductor.openMissingFavoriteRelocator", "when": "false" }
   ]
 }
 ```
 
-The `=~` operator matches against the multi-token contextValue string. Existing `viewItem == recentProject` clauses (package.json:143) continue to match unchanged.
+**Migration to existing `recentProject` clause** (`package.json:143`): change `"viewItem == recentProject"` → `"viewItem =~ /^recentProject\\b/"`. The regex matches any `recentProject.<state>` composite. `\b` prevents partial matches against future tokens.
 
-## Missing-Folder Behavior (revised — no command hijack)
+## Missing-Folder Behavior (revised — click opens relocate)
 
-When the existence cache reports `"missing"` for a row's path:
+When the existence cache reports `missing` (fresh or stale) for a row's path:
 
-1. **Render** — `TreeItem.description = "(missing)"`, `TreeItem.iconPath = new ThemeIcon("folder", new ThemeColor("disabledForeground"))`. The contextValue token `projectRoot.missing` is set.
-2. **Tooltip** — `"This folder is missing on disk. Right-click to relocate or remove."`
-3. **`TreeItem.command`** — *not set*. Clicking the row does nothing. (No toast hijack. The right-click context menu is the affordance.)
-4. **Right-click menu** — offers `Locate Folder...` (group `missing@1`) and `Remove from Favorites` (group `missing@2`).
+1. **Render** — `TreeItem.description = "(missing)"`, `TreeItem.iconPath = new ThemeIcon("folder", new ThemeColor("disabledForeground"))`, `contextValue = "favoriteProject.missing"` (or `recentProject.missing` for a favorited+missing Recent row).
+2. **Tooltip** — `"This folder is missing on disk. Click or press Enter to relocate; right-click for more options."`
+3. **`TreeItem.command`** — `{ command: "claudeConductor.openMissingFavoriteRelocator", arguments: [path], title: "Relocate Folder" }`. **Click and Enter both open the relocate dialog.** This is the keyboard-only path the inquisitor demanded.
+4. **Right-click menu** — offers `Locate Folder...` (group `inline@1` — shows on hover too as a button) and `Remove from Favorites` (group `missing@2`).
+5. **Worktree children** — a missing favorite's grouping yields zero worktree children (worktrees aren't in storage). Missing rows render as leaves.
 
-**Worktree children of a missing favorite:** the parent's missing render does not change expansion behavior; users can still expand the group, but children come from `groupByProjectRoot` over the favorited-paths list, which means missing parents have zero worktree children (since worktrees aren't in `globalState["claudeConductor.favorites"]`). Net effect: missing rows are leaf-rendered.
+**Keyboard-only journey from "I see missing" to "relocated":**
+- Tab/arrow to the Favorites view → arrow-down to the missing row → press Enter → relocate dialog opens → arrow-keys + Enter through dialog → relocated.
 
 ## Data Flow
 
 ```
 User clicks star (Recent Projects, unfavorited row)
   └─> command: claudeConductor.addFavorite(path)
-        └─> store.add(path)                       // sync: mutate entries[] + keyIndex
-              ├─> emit onDidChange                 // sync, immediate
-              │   ├─> RecentProjectsProvider fires onDidChangeTreeData → re-render icons
-              │   └─> FavoritesProvider fires onDidChangeTreeData → re-render list
-              └─> memento.update(...)              // async, background
-                  └─> .catch(handlePersistError)   // rollback + toast on failure
+        └─> store.add(path)
+              └─> enqueueMutation(snapshot, applyAdd)
+                    ├─> entries.push(...); rebuildIndex(); _onDidChange.fire({kind: "single", path})
+                    │     ├─> RecentProjectsProvider fires onDidChangeTreeData(theElement)
+                    │     └─> FavoritesProvider fires onDidChangeTreeData(undefined) (new row appears)
+                    └─> persistChain.then(() => memento.update(...))
+                          └─> .catch(err) → entries = snapshot; rebuild; fire; toast
 ```
 
 ```
-User right-clicks a missing favorite → "Locate Folder..."
+User right-clicks a missing favorite → "Locate Folder..." (or clicks the row, or presses Enter)
   └─> command: claudeConductor.locateFavorite(oldPath)
-        └─> showOpenDialog → newPath
+        └─> showOpenDialog → newPath?
               ├─ undefined → no-op
-              ├─ worktree path → reject with toast
-              ├─ canonical(newPath) === canonical(oldPath) → update entry.path in place
-              ├─ canonical(newPath) matches another entry → drop old entry, toast
-              └─ otherwise → entry.path = newPath, preserve id
-        └─> store.relocate(...) → onDidChange → re-render
+              ├─ isWorktreePath(newPath) → reject + toast
+              ├─ canonicalKey(newPath) === canonicalKey(oldPath) → toast "same path" + no-op
+              ├─ canonicalKey(newPath) matches another entry → drop old, evict cache, toast "already favorited"
+              └─ otherwise → entry.path = newPath; evict oldPath from cache
+        └─> store.relocate(...) → enqueueMutation → persist
+```
+
+```
+launchSession on a UNC favorite fails
+  └─> caller catches error
+        └─> existenceCache.markMissing(path)
+              └─> _onDidChange.fire({kind: "single", path})
+                    └─> Both providers re-render that one row as (missing)
 ```
 
 ## Error Handling
 
 | Failure | Treatment |
 |---|---|
-| `globalState.update` rejection | Log to `console.error`. Toast `"Couldn't save Favorites — please try again."` Roll back the in-memory mutation. |
+| `globalState.update` rejection | Roll back in-memory state to the mutation's pre-snapshot. Toast `"Couldn't save Favorites — please try again."` Subsequent in-flight mutations chained behind this one are also rolled back (serialized-persist contract). |
 | `showOpenDialog` returns `undefined` | No-op. Missing entry stays. |
-| `addFavorite` called with a path already favorited (canonical match) | Silent no-op. |
-| `addFavorite` called with a `.worktrees/<branch>` path | Reject with toast `"Favorite the project root, not a worktree."` Storage unchanged. |
-| `addFavorite` called when at cap (25) | Reject with toast `"Favorites cap reached (25). Remove an entry first."` |
-| `removeFavorite` called with a path not in storage | Silent no-op. |
-| `locateFavorite` chosen path equals the original missing path (canonical match) | Update path in place — covers case/separator tweaks where user "fixes" the casing. No toast. |
-| `locateFavorite` chosen path is a worktree | Reject as `addFavorite` does. |
-| Background stat throws (EACCES, etc.) | Cache as `missing`; the render falls through to the missing-row treatment. Logged once per path per session at console.warn. |
-| Stat times out (>500ms) | Cache as `unknown`; rendered as optimistic-present. Re-checked on next refresh cycle. |
+| `addFavorite` called with a path already favorited | Silent no-op. |
+| `addFavorite` called with a worktree path | Reject with toast `"Favorite the project root, not a worktree."` |
+| `addFavorite` called when `entries.length >= 25` | Reject with toast `"Favorites cap reached (25). Remove an entry first."` |
+| Render path encounters `entries.length > 25` (storage drift) | Truncate display to first 25 entries (sorted alphabetically). `console.warn` once per session. Subsequent `addFavorite` calls continue to reject at the cap. |
+| `removeFavorite` called with absent path | Silent no-op. |
+| `locateFavorite` chosen path equals the old path (canonical) | Toast `"That's the same path. Choose a different folder."` No mutation. |
+| `locateFavorite` chosen path is a worktree | Reject with toast (same as `addFavorite`). |
+| Background stat throws (EACCES, etc.) | Cache as `missing`. Logged once per path per session. |
+| Stat times out (>500ms) | No cache entry written; `peek` returns `unknown` next time; render as optimistic-present; re-checked on next refresh cycle. |
+| `launchSession` fails on a favorite | `existenceCache.markMissing(path)`. Row dims on next render. |
+| Read encounters unknown storage version (`version > 2`) | Toast warning. Render entries best-effort if `entries` is an array. Block writes until reset (skipping mutations with a different toast). |
 
-## Testing (behavior-first, not implementation-first)
+## Testing (behavior-first)
 
-New file: `test/favoritesStore.test.ts` — store unit tests.
-New file: `test/favoritesProvider.test.ts` — provider rendering tests.
-New file: `test/packageJsonContextKeys.test.ts` — package.json drift detector.
-Additions to `test/treeView.test.ts` — cross-panel star coupling, multi-token contextValue.
+New files:
+- `test/favoritesStore.test.ts`
+- `test/favoritesProvider.test.ts`
+- `test/packageJsonContextKeys.test.ts`
+- `test/pathExistenceCache.test.ts`
+
+Additions to:
+- `test/treeView.test.ts`
 
 ### `favoritesStore.test.ts`
 
 - `isFavorited` returns true/false synchronously after add/remove.
 - Canonical-key dedup: `C:\Foo` and `c:/foo/` produce the same key; second add is a no-op.
-- `add` rejects worktree paths.
+- `add` rejects worktree paths via `isWorktreePath()` (uses real predicate, no mock).
 - `add` rejects past 25-entry cap.
-- `relocate` preserves `id`; in-place update for canonical-equal new path.
-- `relocate` to a path already favorited drops the old entry; emits one `onDidChange`.
-- Read-side migration: `string[]` storage value upgrades to `FavoritesEntry[]` on first read.
-- `globalState.update` rejection rolls back in-memory state and re-emits.
+- `relocate` to canonical-equal path emits the "same path" toast.
+- `relocate` to a path already favorited drops the old entry; emits `{kind: "broad"}`.
+- v1 `string[]` storage value is read correctly without triggering a write (deferred-migration semantics).
+- First mutation after v1 read writes the `version: 2` envelope.
+- Future-version envelope (`version: 99`) toasts a warning and renders entries best-effort.
+- **Persist failure rollback:** mock `memento.update` to reject once. Add A. Then add B (chains behind). Assert: both rollbacks fire; final `entries` is empty; `onDidChange` fired three times (one for A applied, one for B applied, one for the rollback).
+- **Serialized persist:** mock `memento.update` to delay 100ms. Fire 5 mutations rapid-fire. Assert: only one update is in flight at a time (verified via per-call counters); all 5 land in storage in order.
 
 ### `favoritesProvider.test.ts`
 
-- **Empty state.** Provider returns `[]` when store has no entries. Tree shows VS Code's default empty-state placeholder.
-- **Single favorite, no worktrees.** Tree contains exactly one row; description is `""` (not `(missing)`); icon is the standard folder icon.
-- **Single favorite with worktrees.** Group renders top + N worktree children; children's contextValue does NOT contain `projectRoot.favorited`.
-- **Alphabetical ordering.** Adding `vscode-claude-conductor` then `claude-personal-configs` then `azure-skills`: tree renders `azure-skills`, `claude-personal-configs`, `vscode-claude-conductor`. Same-basename pair tie-broken by full path.
-- **Missing folder render** (behavior-first). Mock existence cache to return `"missing"` for path X. Assert: tree row's `description === "(missing)"`, icon is the dimmed ThemeIcon, contextValue contains `projectRoot.missing`, **and `command` is `undefined`** (no click action). This is the test the inquisitor demanded — it would fail if rendering returns an empty array for missing rows.
-- **Click-on-missing has no toast.** Mock `showInformationMessage`; assert it is *not* called when a missing row's `TreeItem.command` would have fired (which it shouldn't because `command` is undefined). Documents the behavior change from v1.
-- **Locate-folder dedup.** Setup: favorites contains entries A and B (B is missing). Trigger `locateFavorite(B.path)` → dialog returns A.path. Assert: tree's getChildren returns exactly one row whose path is A.path. Toast was shown.
-- **`addFavorite` past cap toasts and does not mutate.** Add 25 entries. Try the 26th. Assert: tree still shows 25 rows. Toast invoked.
-- **Refresh-only-on-decoration-change.** Spy on `getAllFolders()`. Toggle a favorite via store. Assert `getAllFolders` was called *zero* times. (RecentProjectsProvider's data-axis refresh is unaffected.)
+- Empty state.
+- Single favorite, no worktrees.
+- Single favorite with worktrees.
+- Alphabetical ordering with same-basename tiebreak.
+- **Missing folder render** (behavior-first): mock cache `peek` returns `{kind: "missing", stale: false}`. Assert: `description === "(missing)"`, dimmed icon, `contextValue === "favoriteProject.missing"`, `command.command === "claudeConductor.openMissingFavoriteRelocator"`, `command.arguments === [path]`.
+- **Stale-missing render**: mock cache returns `{kind: "missing", stale: true}`. Assert: same render as fresh-missing (no flicker).
+- **Optimistic-present on UNC**: mock cache returns `{kind: "unknown"}` for UNC path. Assert: rendered as present (no `(missing)` decoration).
+- **Click-on-missing fires relocator command**: mock `commands.executeCommand`; assert that triggering the row's `TreeItem.command` invokes `claudeConductor.openMissingFavoriteRelocator` with the path.
+- **Locate-folder dedup**: setup A and B (B is missing). Trigger `locateFavorite(B.path)` → dialog returns A.path. Assert: tree's getChildren returns exactly one row (A); toast `"already in your Favorites"` invoked.
+- **Locate same-path toast**: dialog returns the same path. Assert: toast `"That's the same path"` invoked; tree unchanged.
+- **`addFavorite` past cap toasts and does not mutate.**
+- **Render-path cap enforcement**: directly write 30 entries to `globalState`; instantiate provider. Assert: tree renders only first 25 (alphabetical); `console.warn` invoked once.
+- **Refresh-only-on-decoration-change**: spy on `getAllFolders()`. Toggle a favorite via store. Assert: `getAllFolders` called *zero* times.
+
+### `pathExistenceCache.test.ts`
+
+- `peek` returns `unknown` initially.
+- `peek` returns `exists` after fresh stat; `unknown` after TTL expiry on previously-exists.
+- `peek` returns `{missing, stale: false}` after fresh stat; `{missing, stale: true}` after TTL expiry — never returns `unknown` for stale-missing (regression guard against v2 flicker).
+- `markMissing` immediately flips state without I/O.
+- `evict` removes the entry; subsequent `peek` returns `unknown`.
+- `refresh` skips UNC paths (`\\server\share\foo`); they stay `unknown`.
+- Stat with simulated 1s delay times out at 500ms; entry stays `unknown`.
 
 ### `packageJsonContextKeys.test.ts`
 
-- Parses `package.json`, walks `menus.view/item/context`, extracts every `viewItem ==` and `viewItem =~` literal/regex.
-- Asserts every literal token (e.g., `projectRoot.favorited`, `projectRoot.missing`, `recentProject`, `worktreeChild`) appears as a value in `VIEW_ITEM` exported from `src/treeView.ts`.
-- This is the drift detector. If a future PR changes the constant or the JSON without updating both, this test fails.
+The drift detector. Asserts a **bijection** between `package.json` `viewItem` references and `VIEW_ITEM` constants.
+
+- Parse `package.json`; walk every `view/item/context` clause; extract every `viewItem == "X"` literal AND every `viewItem =~ /pattern/` regex.
+- For each literal: assert it is a value in `VIEW_ITEM`.
+- For each regex: assert at least one `VIEW_ITEM` value matches it.
+- For each `VIEW_ITEM` value: assert it is referenced by at least one menu clause (catches orphaned constants).
+- For each `\b`-anchored regex: assert it does not match a sibling token (e.g., `^recentProject\b` matches `recentProject.favorited` but not `recentProjectFoo`).
 
 ### `treeView.test.ts` additions
 
-- **Star icon coupling.** Add path X via store. Render Recent Projects row for X — inline action shows `$(star-full)` and contextValue contains `projectRoot.favorited`. Remove via store. Re-render — row shows `$(star-empty)` and contextValue contains `projectRoot.unfavorited`. Existing `recentProject` token is *still* in the contextValue throughout.
-- **`onDidChangeSessions` doesn't lose star state mid-toggle.** Setup: store has X favorited. Trigger `sessionManager._onDidChangeSessions.fire()` (full data refresh). Assert: rendered row for X still shows `projectRoot.favorited` (the live store read inside `getTreeItem` is the regression guard against the v1 race).
+- **Star icon coupling.** Add path X via store. Render Recent Projects row for X — inline action shows `$(star-full)` and `contextValue === "recentProject.favorited"`. Remove via store. Re-render — `$(star-empty)` and `recentProject.unfavorited`.
+- **`onDidChangeSessions` doesn't lose star state mid-toggle.** Setup: store has X favorited. Trigger a full data refresh. Assert: rendered row for X still shows `recentProject.favorited` (regression guard against the v1 race).
+- **Existing `recentProject` clause migration**: assert that the existing inline action ("open recent project") still fires when the user clicks an unfavorited Recent Projects row, after the contextValue has been migrated to `recentProject.unfavorited`. (The package.json clause is now `=~ /^recentProject\b/`; this test verifies it still matches.)
 
 ## File Touch List
 
 | File | Change |
 |---|---|
-| `package.json` | Add view contribution, three commands, six menu clauses (three inline + three non-inline). Bump version. |
-| `src/favoritesStore.ts` | **New.** `FavoritesStore` service, `canonicalKey`, `readAndMigrate`. Zero VS Code imports except `Memento` + `EventEmitter`. |
-| `src/pathExistenceCache.ts` | **New.** Async stat + TTL + UNC skip. Zero VS Code imports. |
-| `src/treeView.ts` | New `FavoritesProvider`. Add `VIEW_ITEM` constant. Update `RecentProjectsProvider` to consult `FavoritesStore.isFavorited` inside `getTreeItem` and emit multi-token contextValue. No changes to existing data-fetch path. |
-| `src/extension.ts` | Construct `FavoritesStore` and `PathExistenceCache` at activation. Register `FavoritesProvider`. Register the three new commands. Wire `store.onDidChange` to fire both providers' `_onDidChangeTreeData`. |
-| `src/projectGrouping.ts` | **No changes.** Reused as-is. |
-| `test/favoritesStore.test.ts` | **New.** Per test plan above. |
-| `test/favoritesProvider.test.ts` | **New.** Per test plan above. |
-| `test/packageJsonContextKeys.test.ts` | **New.** Drift detector. |
-| `test/treeView.test.ts` | Add cross-panel star coupling and race-regression tests. |
-| `README.md` | Document the Favorites section under "Activity Bar Sidebar". Note the 25-favorite cap. Note UNC paths render optimistic-present. |
-| `CHANGELOG.md` | New entry under the next version. |
+| `package.json` | Add view contribution (3rd view), 4 commands (incl. internal relocator), 7 menu clauses (inline + context). **Migrate existing `recentProject == ` clause to `=~ /^recentProject\b/`.** Bump version. |
+| `src/favoritesStore.ts` | **New.** `FavoritesStore` service, `canonicalKey`, `readWithoutMigrating`, deferred migration on first mutation, serialized persist queue. |
+| `src/pathExistenceCache.ts` | **New.** Async stat, TTL, UNC skip, `markMissing`/`evict`. |
+| `src/projectGrouping.ts` | **Add export:** `isWorktreePath(p): boolean`. No other changes. |
+| `src/treeView.ts` | New `FavoritesProvider`. Add `VIEW_ITEM` constant. Update `RecentProjectsProvider` `contextValue` to `recentProject.{favorited,unfavorited,missing}`. Wire missing-row `command` to `claudeConductor.openMissingFavoriteRelocator`. |
+| `src/extension.ts` | Construct store + cache at activation. Register `FavoritesProvider`. Register 4 commands. Wire `markMissing` callback into `launchSession` failure path. |
+| `src/sessionManager.ts` | (or wherever `launchSession` lives) — call `existenceCache.markMissing(path)` on launch failure for paths that come from favorites/recents. |
+| `test/favoritesStore.test.ts` | **New.** |
+| `test/favoritesProvider.test.ts` | **New.** |
+| `test/pathExistenceCache.test.ts` | **New.** |
+| `test/packageJsonContextKeys.test.ts` | **New** drift detector with bidirectional bijection assertions. |
+| `test/treeView.test.ts` | Additions per test plan. |
+| `README.md` | Document Favorites section. Note 25-cap, click-to-relocate, UNC behavior (optimistic-present until launch failure). |
+| `CHANGELOG.md` | New entry. |
 
 ## Open Questions Resolved During Brainstorm
 
 | Question | Resolution |
 |---|---|
-| Parallel vs mutually exclusive lists? | **Parallel.** Favorites is a curated overlay; Recent stays untouched. |
-| Star button placement? | **Inline-on-hover + right-click context menu** (both interaction paths). |
-| Ordering scheme? | **Alphabetical** by folder basename, full path tiebreak. Drag-to-reorder deferred. Soft cap at 25. |
-| Per-worktree favorites? | **No.** Project-only; worktrees come along via grouping. Both `addFavorite` and `locateFavorite` reject worktree paths. |
-| Missing-folder behavior? | **Dim + `(missing)` suffix + tooltip; right-click to relocate or remove.** No click intercept. |
+| Parallel vs mutually exclusive lists? | **Parallel.** |
+| Star button placement? | **Inline-on-hover + right-click context menu.** |
+| Ordering scheme? | **Alphabetical** by basename, full path tiebreak. Drag-to-reorder deferred. |
+| Per-worktree favorites? | **No.** Project-only, enforced via shared `isWorktreePath()`. |
+| Missing-folder behavior? | **Dim + `(missing)` + click opens relocate dialog directly. Tooltip + right-click for explicit options.** |
 
 ## Risks & Mitigations
 
-- **Risk:** `viewItem` constants drift between TS and `package.json`.
-  **Mitigation:** `packageJsonContextKeys.test.ts` parses package.json menu clauses and asserts every literal token exists in the `VIEW_ITEM` exported constant. Test fails if either side changes without the other.
-- **Risk:** Symlink/junction-resolved paths produce duplicate entries (two distinct strings → same directory).
-  **Mitigation:** Acknowledged tradeoff. v1 uses string-canonical key only (no `realpathSync`), because `realpathSync` on missing paths throws and the relocate flow needs to handle missing paths uniformly. Document in README: "Favorites tracks paths as you typed them — `C:\Code\Foo` and a junction pointing to it are tracked separately."
-- **Risk:** A user opens a workspace where most favorites are unreachable; panel shows mostly `(missing)` rows.
-  **Mitigation:** Acknowledged as v1 cost (see Non-Goals). Dimmed visual treatment is intentionally low-noise. v2 might add per-workspace filtering.
-- **Risk:** Background stat refresh storms on rapid `onDidChangeSessions` events.
-  **Mitigation:** 30s TTL means stat runs at most twice per minute per path even with refresh churn. UNC paths skipped entirely.
-- **Risk:** `globalState.update` rejection mid-mutation leaves in-memory and persisted state divergent.
-  **Mitigation:** `.catch(handlePersistError)` rolls back the in-memory mutation and fires `onDidChange` again to re-render the rolled-back state. User sees the toggle "snap back" with an error toast.
-- **Risk:** Path containing only-case-different favorites on case-insensitive filesystems.
-  **Mitigation:** Canonical key case-folds. `C:\Foo` and `c:/foo` collapse to one entry.
-- **Risk:** User sets up Favorites on machine A; on machine B the paths don't exist.
-  **Mitigation:** `globalState` is per-machine; this is by design (see Non-Goals — Settings Sync). The `id` field future-proofs the eventual sync story.
+- **Risk:** A v1 build encountering v2's envelope `{version, entries}`.
+  **Mitigation:** Object-shape envelope means v1's `Array.isArray` check fails → empty-state branch. No crash, no data corruption. User loses pinned state on downgrade (acceptable for manual curation).
+- **Risk:** `viewItem` drift between TS and `package.json` (either direction).
+  **Mitigation:** `packageJsonContextKeys.test.ts` enforces bidirectional bijection — JSON references must exist in `VIEW_ITEM`, AND `VIEW_ITEM` values must be referenced. Catches typos in either file.
+- **Risk:** Symlink/junction → duplicate entries.
+  **Mitigation:** Documented tradeoff (Non-Goals). README notes paths are tracked as typed.
+- **Risk:** Unreachable workspace context (most favorites missing in current workspace).
+  **Mitigation:** Acknowledged v1 cost (Non-Goals). Dimmed treatment is low-noise.
+- **Risk:** Background stat refresh storms.
+  **Mitigation:** 30s TTL caps re-stat frequency; UNC paths skipped; targeted invalidation (single-path `onDidChange`) avoids full re-renders.
+- **Risk:** Persist queue starves under rapid mutations.
+  **Mitigation:** Serialized queue's worst case is one persist per mutation, 25-entry cap means bounded list size, and persist latency is dominated by VS Code's `globalState.update` (typically <10ms locally). Acceptable.
+- **Risk:** UNC path "looks present" until the user tries to launch it.
+  **Mitigation:** `markMissing` is wired into the launch-failure path so the cache learns from the launch attempt; subsequent renders dim the row.
+- **Risk:** Relocate dialog accepts a worktree path the existence-only check would have allowed.
+  **Mitigation:** Both `addFavorite` and `locateFavorite` route through the same `isWorktreePath()` predicate; tested with shared fixtures.
+- **Risk:** Multi-window simultaneous mutation overwriting each other.
+  **Mitigation:** Last-writer-wins on the entries array — same semantics as any concurrent storage update. Because there's no per-entry identifier, no identity is lost; only the merged set differs from each window's view. Acceptable for v1; full sync resolution is deferred.

--- a/docs/superpowers/specs/2026-04-28-75-favorites-design.md
+++ b/docs/superpowers/specs/2026-04-28-75-favorites-design.md
@@ -1,0 +1,223 @@
+# Design Spec — Favorites Sidebar Section (Issue #75)
+
+**Status:** Draft
+**Date:** 2026-04-28
+**Issue:** [#75](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/75)
+**Branch:** `75-favorites`
+
+## Summary
+
+Add a third top-level tree view, **Favorites**, to the Claude Conductor sidebar. It sits between **Active Sessions** and **Recent Projects** and renders user-pinned project roots, reusing the existing two-level grouping helper so worktrees nest under their parent project exactly as they do in Recent Projects today.
+
+Favorites is a **manual curation overlay**, not a usage tracker. Pinning a project does not affect Recent Projects (parallel lists). Favoriting is per-machine via `globalState`. There is no auto-frequency tracking and no Settings Sync involvement.
+
+## Goals
+
+- One-click access to a curated set of project roots, near the top of the sidebar.
+- Reuse `projectGrouping.ts` and `RecentProjectsProvider` patterns — minimal new architecture.
+- Tolerate transient absence (unmounted drives) and intentional moves (folder relocated on disk) without silent data loss.
+- Keep the design scoped — no drag-to-reorder, no per-worktree pinning, no auto-tracking.
+
+## Non-Goals
+
+- Drag-to-reorder. Deferred until evidence the alphabetical default is insufficient.
+- Per-worktree favorites. Explicitly excluded — favorites are project-rooted; worktrees come along for free via grouping.
+- Auto-frequency tracking. Out of scope per the issue.
+- Cross-machine sync. `globalState` is per-machine by design.
+- Promoting Favorites into a workspace-level (per-folder) setting. Stays user-global.
+
+## Architecture
+
+### View Registration
+
+Add a third `TreeView` contribution in `package.json`:
+
+```json
+"views": {
+  "claudeConductor": [
+    { "id": "claudeConductor.activeSessions", "name": "Active Sessions" },
+    { "id": "claudeConductor.favorites",      "name": "Favorites" },
+    { "id": "claudeConductor.recentProjects", "name": "Recent Projects" }
+  ]
+}
+```
+
+`Favorites` deliberately renders between the other two so curated items sit above the noisy recents feed without obscuring active session state.
+
+### Provider
+
+A new `FavoritesProvider implements vscode.TreeDataProvider<TreeNode>` lives in `src/treeView.ts`, parallel to `RecentProjectsProvider`. It:
+
+1. Reads `globalState["claudeConductor.favorites"]: string[]` on demand.
+2. For each path, runs `fs.existsSync(path)` to compute a `missing` flag (synchronous; the same approach `RecentProjectsProvider` uses for `addFolderPrompt` parity).
+3. Feeds the resolved list through `groupByProjectRoot` (reused, not modified) so worktrees nest under each favorited root.
+4. Sorts top-level groups alphabetically by `path.basename(root)`, with the full `root` path as the tiebreak.
+5. Emits a `_onDidChangeTreeData` event whenever the underlying `globalState` array changes.
+
+### Storage
+
+| Key | Type | Scope | Notes |
+|---|---|---|---|
+| `claudeConductor.favorites` | `string[]` | `globalState` (per-machine) | Flat list of normalized project root paths. Order is **not** UX-visible — alphabetical sort happens at render time. Storage order is whatever `addFavorite` produces (insertion). |
+
+Path normalization: trim trailing separators; preserve original case (Windows is case-insensitive, but we render the user's own path back to them). Comparison index uses `lowerCase` for the duplicate-detection set.
+
+### Star Toggle (cross-panel)
+
+Both `RecentProjectsProvider` and `FavoritesProvider` consult the same lookup index — a `Set<string>` of lowercased favorited paths — built once per refresh. This drives:
+
+- The inline action button icon: `$(star-empty)` if not favorited, `$(star-full)` if favorited.
+- The `viewItem` context value (`projectRoot.favorited` / `projectRoot.unfavorited` / `projectRoot.missing`) used by `package.json` `menus.view/item/context` clauses.
+
+When a favorite is added or removed, *both* providers fire `onDidChangeTreeData` so the star flips state in both panels simultaneously.
+
+### Worktree Children
+
+Worktree rows render as today (no star, no special context value beyond what they already carry). Favoriting only happens at project-root granularity; storage never contains a `.worktrees/<branch>` path.
+
+## Commands
+
+| Command ID | Args | Behavior |
+|---|---|---|
+| `claudeConductor.addFavorite` | `path: string` | Validate path is a project root (not a worktree child). Normalize. Append to `globalState` array if not already present. Fire refresh event. |
+| `claudeConductor.removeFavorite` | `path: string` | Remove the matching entry (case-insensitive). Fire refresh event. No-op if absent. |
+| `claudeConductor.locateFavorite` | `path: string` | Show `vscode.window.showOpenDialog({ canSelectFolders: true, canSelectFiles: false, canSelectMany: false, openLabel: "Select new location" })`. On selection, replace the missing path **in place** in the storage array (preserves alphabetical position via re-sort on next render). If the chosen path is already a favorite, drop the missing entry instead and toast `"That folder is already in your Favorites — removed the missing entry."` |
+
+All three commands accept a path argument so they can be invoked both from inline action buttons (which pass the tree item's resource) and from the right-click context menu.
+
+## Menus
+
+```jsonc
+"menus": {
+  "view/item/context": [
+    {
+      "command": "claudeConductor.addFavorite",
+      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.unfavorited",
+      "group": "inline@1"
+    },
+    {
+      "command": "claudeConductor.removeFavorite",
+      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.favorited",
+      "group": "inline@1"
+    },
+    {
+      "command": "claudeConductor.removeFavorite",
+      "when": "view == claudeConductor.favorites && viewItem == projectRoot.missing",
+      "group": "missing@2"
+    },
+    {
+      "command": "claudeConductor.locateFavorite",
+      "when": "view == claudeConductor.favorites && viewItem == projectRoot.missing",
+      "group": "missing@1"
+    }
+    // ... plus the same add/remove pair under a non-inline group for context-menu discoverability
+  ]
+}
+```
+
+The inline `@1` slot is the on-hover star button. The non-inline duplicates appear in the right-click menu so users who don't hover still discover the action.
+
+## Missing-Folder Behavior
+
+When `fs.existsSync(path) === false`:
+
+1. **Render** — `TreeItem.description = "(missing)"`, `TreeItem.iconPath = new ThemeIcon("folder", new ThemeColor("disabledForeground"))`. The `viewItem` context value becomes `projectRoot.missing`.
+2. **Click** — the `command` on the tree item is intercepted to a small handler that shows:
+
+   `vscode.window.showInformationMessage("This folder is missing on disk.", "Locate Folder...", "Remove from Favorites")`
+
+   - `"Locate Folder..."` → invokes `claudeConductor.locateFavorite`.
+   - `"Remove from Favorites"` → invokes `claudeConductor.removeFavorite`.
+   - Dismiss → no action; entry stays.
+3. **Right-click** — same two actions appear in the context menu (see `menus` above), so the user does not have to click and dismiss the toast first.
+
+Worktree children of a missing favorite are never queried (the parent's missing render short-circuits expansion). Returning to a present folder simply unsets the missing flag on the next refresh — no state is lost across the missing→present transition.
+
+## Data Flow
+
+```
+User clicks star (Recent Projects, unfavorited row)
+  └─> command: claudeConductor.addFavorite(path)
+        └─> globalState.update("claudeConductor.favorites", [...current, path])
+              └─> emit favoritesChanged event
+                    ├─> FavoritesProvider.refresh()
+                    └─> RecentProjectsProvider.refresh()  // star icon flips
+```
+
+```
+User clicks a missing favorite
+  └─> command: internal "showMissingFavoriteToast" handler
+        └─> showInformationMessage(..., "Locate Folder...", "Remove from Favorites")
+              ├─ "Locate Folder..." → claudeConductor.locateFavorite(path)
+              │     └─> showOpenDialog → globalState.update(replace-in-place)
+              │           └─> emit favoritesChanged
+              ├─ "Remove from Favorites" → claudeConductor.removeFavorite(path)
+              └─ dismiss → no-op
+```
+
+## Error Handling
+
+| Failure | Treatment |
+|---|---|
+| `globalState.update` rejection | Log via `console.error`; toast `"Couldn't save Favorites — please try again."`; do not mutate in-memory state. |
+| `showOpenDialog` returns `undefined` (user cancelled) | No-op. Missing entry stays as-is. |
+| `addFavorite` called with a path already present (case-insensitive) | No-op. Do not duplicate. Do not toast — silent dedup is fine for this case since the user expects "make this a favorite" to be idempotent. |
+| `addFavorite` called with a `.worktrees/<branch>` path | Reject with toast `"Favorite the project root, not a worktree."` and do not mutate storage. The view-context guards make this unreachable from UI clicks, but the command is still callable from the command palette. |
+| `removeFavorite` called with a path not in storage | Silent no-op. |
+| `locateFavorite` chosen path equals the original missing path | Treat as no-op (user picked the same path that doesn't exist). Toast `"That's the same path. Choose a different folder."` |
+
+## Testing
+
+New file: `test/favoritesProvider.test.ts`. Additions to `test/treeView.test.ts` for the cross-panel star icon coupling.
+
+### `favoritesProvider.test.ts`
+
+- Empty state — provider returns `[]` when `globalState` key is unset or `[]`.
+- Single favorite, no worktrees — top-level row renders, no children.
+- Single favorite with worktrees — group renders with worktree children, no star on children.
+- Multiple favorites — alphabetical by basename; same-basename pair tie-broken by full path.
+- Missing folder — `description` is `"(missing)"`, icon dimmed, `contextValue` is `projectRoot.missing`.
+- `addFavorite` idempotence — calling twice with the same path produces a single entry.
+- `addFavorite` rejects worktree paths — storage unchanged, toast invoked.
+- `removeFavorite` removes case-insensitively (Windows behavior).
+- `locateFavorite` happy path — replaces path in-place; alphabetical position recomputed on next render.
+- `locateFavorite` dedup path — chosen path already favorited → missing entry dropped, toast emitted.
+- `locateFavorite` cancel — no storage mutation.
+- Refresh propagation — toggling a favorite fires `onDidChangeTreeData` on **both** providers (use a spy).
+
+### `treeView.test.ts` additions
+
+- Star icon state — when `path X` is in `globalState["claudeConductor.favorites"]`, the inline icon on the corresponding `RecentProjectsProvider` row is `$(star-full)`; remove and it flips to `$(star-empty)`.
+- View ordering — registration order in the test harness puts Favorites between Active and Recent.
+
+## File Touch List
+
+| File | Change |
+|---|---|
+| `package.json` | Add view contribution, three commands, menu clauses. Bump version. |
+| `src/treeView.ts` | New `FavoritesProvider`. New shared favorites lookup index. Stars on `RecentProjectsProvider` rows. Missing-folder click interception handler. |
+| `src/extension.ts` | Register `FavoritesProvider`, register the three new commands, wire the cross-provider refresh fan-out. |
+| `src/projectGrouping.ts` | **No changes.** Reused as-is. |
+| `test/favoritesProvider.test.ts` | New file (per the test plan above). |
+| `test/treeView.test.ts` | Add star-state and ordering tests. |
+| `README.md` | Document the Favorites section under "Activity Bar Sidebar". |
+| `CHANGELOG.md` | New entry under the next version. |
+
+## Open Questions Resolved During Brainstorm
+
+| Question | Resolution |
+|---|---|
+| Parallel vs mutually exclusive lists? | **Parallel.** Favorites is a curated overlay; Recent stays untouched. |
+| Star button placement? | **Inline-on-hover + right-click context menu** (both interaction paths). |
+| Ordering scheme? | **Alphabetical** by folder basename, full path tiebreak. Drag-to-reorder deferred. |
+| Per-worktree favorites? | **No.** Project-only; worktrees come along via grouping. |
+| Missing-folder behavior? | **Dim + `(missing)` suffix; click shows toast with `[Locate Folder...]` and `[Remove from Favorites]`.** Locate-folder relocates in place with dedup. |
+
+## Risks & Mitigations
+
+- **Risk:** `fs.existsSync` on every refresh adds I/O overhead.
+  **Mitigation:** Favorites lists are small (target ≤10 entries). Sync stat is fine; if profiling later shows pain, cache results between events.
+- **Risk:** `viewItem` context-value churn — three values (`favorited`/`unfavorited`/`missing`) on the same row class could break menu `when` clauses if they're spelled inconsistently.
+  **Mitigation:** Define them as exported string constants in `treeView.ts`; reference from both `package.json` (manually kept in sync) and tests.
+- **Risk:** A user favorites a path during a session, then `clean_gone` deletes the worktree the path *was* (but shouldn't be — favorites are project-rooted, not worktree-rooted, so this shouldn't happen by design). The guard against worktree paths in `addFavorite` prevents this.
+  **Mitigation:** Hard reject worktree-path favorites at command boundary; covered in tests.

--- a/docs/superpowers/specs/2026-04-28-75-favorites-design.md
+++ b/docs/superpowers/specs/2026-04-28-75-favorites-design.md
@@ -1,6 +1,6 @@
 # Design Spec — Favorites Sidebar Section (Issue #75)
 
-**Status:** Draft v3 (post second inquisitor review)
+**Status:** Draft v4 (post third inquisitor review)
 **Date:** 2026-04-28
 **Issue:** [#75](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/75)
 **Branch:** `75-favorites`
@@ -8,11 +8,13 @@
 ## Revision History
 
 - **v1 (2026-04-28)** — initial brainstorm output.
-- **v2 (2026-04-28)** — addressed inquisitor pass 1 (cross-panel race, UNC hangs, viewItem migration first attempt, storage shape, click-hijack).
-- **v3 (2026-04-28)** — addressed inquisitor pass 2:
-  - **Blocker fixes:** composite single-token contextValues (no multi-token regex matching); serialized persist queue with snapshot rollback; `version` envelope on storage with deferred-on-mutation migration; click-on-missing opens relocate dialog directly.
-  - **Smaller fixes:** `peek()` keeps last-known on TTL expiry with `stale` flag; regex anchoring; bidirectional drift test; render-path 25-cap enforcement; relocate same-path toast restored; targeted `onDidChangeTreeData` invalidation; UNC launch failure feeds existence cache; cache eviction on remove/relocate; explicit `isWorktreePath` predicate sourced from `projectGrouping.ts`.
-  - **YAGNI cut:** removed the `id: string` UUID field. Storage shape stays object-based (extensible) without a speculative identifier no v1 feature reads.
+- **v2 (2026-04-28)** — addressed inquisitor pass 1.
+- **v3 (2026-04-28)** — addressed inquisitor pass 2.
+- **v4 (2026-04-28)** — addressed inquisitor pass 3 blockers:
+  - **Persist serialization changed from "chained with cascade rollback" to "await-prior-then-apply."** Each mutation waits for the prior persist to fully resolve (success or rollback) before snapshotting and applying. Eliminates the cascade rollback that destroyed later mutations on transient persist failure.
+  - **`launchSession` now returns a result.** Caller (favorites click handler) uses the result to call `markMissing` or `markPresent` on the existence cache. `markPresent` was added — UNC favorites that flip missing on a launch failure now unflip on a subsequent successful launch.
+  - **`_onDidChange` payload is now typed** as `FavoritesChangeEvent`. All `fire()` sites pass the typed payload. Targeted invalidation is now actually implementable.
+  - **Smaller fixes:** `TreeItem.command` on missing rows uses `claudeConductor.locateFavorite` directly (no internal hidden command, no `when: "false"` folklore); `isWorktreePath` trims trailing separators before regex; `viewItem` prefix split collapsed to a single set of tokens shared across providers; render-path no longer silently truncates >25 entries (renders all with a banner); drift detector has an explicit negative fixture list; multi-window last-writer-wins is justified with engineering rationale rather than dismissed.
 
 ## Summary
 
@@ -30,13 +32,14 @@ Favorites is a **manual curation overlay**, not a usage tracker. Pinning a proje
 
 ## Non-Goals (with rationale)
 
-- **Drag-to-reorder.** Deferred. Soft cap of 25 favorites enforced both at `addFavorite` (toast on overflow) AND at the render path (truncate display + log warning if storage drifts past). Past 25 alphabetical-only ordering is unusable; that's the trigger to revisit.
-- **Per-worktree favorites.** Excluded. Favorites are project-rooted; worktrees come along via grouping. Both `addFavorite` and `locateFavorite` reject worktree paths via the shared `isWorktreePath()` predicate.
+- **Drag-to-reorder.** Deferred. Soft cap of 25 favorites enforced at `addFavorite` only. Past 25 alphabetical-only ordering is unusable; that's the trigger to revisit.
+- **Per-worktree favorites.** Excluded. Both `addFavorite` and `locateFavorite` reject worktree paths via the shared `isWorktreePath()` predicate.
 - **Auto-frequency tracking.** Out of scope per the issue.
-- **Settings Sync (`setKeysForSync`).** Explicitly NOT registered in v1 because path portability across machines is unsolved (drive letters, project locations differ). The object-shape storage means adding sync later is non-breaking. A sync-portable identifier (UUID, content hash, or symbolic name) would be added at that time — *not* speculatively now.
-- **Stable per-entry identifier.** Removed from v3. v2 added `id: string` to "future-proof" sync; the inquisitor pass correctly flagged this as YAGNI — no v1 feature reads it, multi-window cold-start migrates the same v1 data twice and races UUIDs, and any future identifier scheme has constraints we don't know yet (deterministic vs random, content vs path). Storage stays `[{path: string}]`; the object envelope is the actual extensibility hedge.
-- **Cross-workspace filtering.** Favorites are user-global. Opening a workspace where most favorited paths live elsewhere produces `(missing)` rows for those paths. v1 accepts this; the dimmed visual treatment is intentionally unobtrusive.
-- **Symlink/junction canonicalization.** Canonical key skips `realpathSync` (which throws on missing paths the relocate flow needs to handle uniformly). Documented tradeoff: two distinct path strings resolving to the same directory produce duplicate entries.
+- **Settings Sync (`setKeysForSync`).** Explicitly NOT registered in v1 because path portability across machines is unsolved. The object envelope storage means adding sync later is non-breaking.
+- **Stable per-entry identifier.** Removed in v3 as YAGNI. Storage stays `[{path: string}]`.
+- **Cross-workspace filtering.** Favorites are user-global. Dimmed `(missing)` rows for unreachable paths are accepted.
+- **Symlink/junction canonicalization.** Canonical key skips `realpathSync`. Documented tradeoff: distinct path strings resolving to the same directory produce duplicate entries.
+- **Multi-window read-merge-write merge semantics.** Last-writer-wins is accepted for v1. **Engineering rationale:** the favorites set is bounded at 25 entries with human-rate mutation frequency (not bulk imports). Collision probability across windows in a realistic workflow (user adds A in window 1, switches to window 2, adds B) is dominated by the *user* serializing their own actions. The expensive alternative — read-merge-write inside `enqueueMutation`, with operational-transform-style merge for conflicting mutations — is correct but heavyweight for a feature without measured collision incidents. Revisit when (a) Settings Sync ships and brings genuine concurrent multi-machine writes, or (b) a user reports lost favorites from concurrent windows. v1 documents the limitation in the README's "Known Limits" section.
 
 ## Architecture
 
@@ -54,64 +57,97 @@ Add a third `TreeView` contribution in `package.json`:
 }
 ```
 
-### `FavoritesStore` service (new file: `src/favoritesStore.ts`)
-
-A standalone service that owns all favorites state. Both providers consult it; neither owns it. The persist path is **serialized**: at most one `memento.update` is in flight at a time, ensuring rollback semantics are deterministic.
+### `FavoritesStore` service (`src/favoritesStore.ts`)
 
 ```typescript
 export interface FavoritesEntry { path: string; }
-export interface FavoritesStorageEnvelope {
+
+export type FavoritesChangeEvent =
+  | { kind: "single"; path: string }
+  | { kind: "broad" };
+
+interface FavoritesStorageEnvelope {
   version: 2;
   entries: FavoritesEntry[];
 }
 
+const STORAGE_KEY = "claudeConductor.favorites";
+const MAX_FAVORITES = 25;
+
 export class FavoritesStore {
   private entries: FavoritesEntry[] = [];
   private keyIndex: Set<string> = new Set();
-  private readonly _onDidChange = new vscode.EventEmitter<void>();
+  private readonly _onDidChange = new vscode.EventEmitter<FavoritesChangeEvent>();
   readonly onDidChange = this._onDidChange.event;
 
-  // Serialized persist queue
+  /** Tracks the latest persist so the next mutation can wait for it. */
   private persistChain: Promise<void> = Promise.resolve();
 
   constructor(private readonly memento: vscode.Memento) {
-    this.entries = readWithoutMigrating(memento);  // pure read; no write side effects
+    this.entries = readWithoutMigrating(memento);
     this.rebuildIndex();
   }
 
-  // ---- Synchronous reads (called from getTreeItem) ----
+  // ---- Synchronous reads ----
   isFavorited(path: string): boolean {
     return this.keyIndex.has(canonicalKey(path));
   }
   list(): readonly FavoritesEntry[] { return this.entries; }
+  isOverCap(): boolean { return this.entries.length > MAX_FAVORITES; }
 
-  // ---- Async mutations — all routed through enqueueMutation ----
-  async add(path: string): Promise<{ ok: boolean; reason?: string }> { ... }
-  async remove(path: string): Promise<void> { ... }
-  async relocate(oldPath: string, newPath: string): Promise<{ ok: boolean; reason?: string }> { ... }
+  // ---- Async mutations ----
+  async add(path: string): Promise<{ ok: boolean; reason?: string }> { /* ... */ }
+  async remove(path: string): Promise<void> { /* ... */ }
+  async relocate(oldPath: string, newPath: string): Promise<{ ok: boolean; reason?: string }> { /* ... */ }
 
   /**
-   * Serialized mutation: snapshot, apply in memory, fire change, then chain
-   * the persist behind any in-flight persist. Rollback to snapshot on reject.
+   * Mutation contract:
+   *   1. Wait for any in-flight persist to fully resolve (success OR rollback).
+   *   2. Snapshot current entries.
+   *   3. Run apply(snapshot) inside try/catch — on throw, do NOT mutate state and reject the caller.
+   *   4. Apply the result to in-memory state.
+   *   5. Fire onDidChange with the supplied payload.
+   *   6. Persist; on rejection, restore from snapshot, fire onDidChange (broad), toast.
+   *
+   * Step 1 means each mutation operates on the actual current state, not on a
+   * speculative state that depends on prior persists succeeding. There is no
+   * cascade rollback — if persist N fails, only mutation N is rolled back.
+   * Mutations N+1, N+2 ... were already serialized to wait for N's resolution
+   * and will snapshot the post-rollback state when their turn comes.
    */
-  private enqueueMutation(apply: (entries: FavoritesEntry[]) => FavoritesEntry[]): Promise<void> {
-    const snapshot = [...this.entries];
-    this.entries = apply(snapshot);
-    this.rebuildIndex();
-    this._onDidChange.fire();
+  private async enqueueMutation(
+    apply: (snapshot: FavoritesEntry[]) => FavoritesEntry[],
+    payload: FavoritesChangeEvent
+  ): Promise<void> {
+    // Step 1: wait for any prior persist (success or rollback) to fully resolve.
+    await this.persistChain.catch(() => undefined);
 
-    this.persistChain = this.persistChain
-      .catch(() => { /* swallow prior errors; each link handles its own rollback */ })
-      .then(() => this.memento.update(STORAGE_KEY, { version: 2, entries: this.entries }))
-      .catch(err => {
-        // Roll back to the snapshot taken when *this* mutation was enqueued.
-        // If subsequent mutations succeeded on top of this one, they're now
-        // also rolled back — that's the contract of serialized persists:
-        // failure of an earlier persist invalidates all later in-memory
-        // mutations chained on it.
+    // Step 2: snapshot the *actual current* state.
+    const snapshot = [...this.entries];
+
+    // Step 3: run apply guarded.
+    let next: FavoritesEntry[];
+    try {
+      next = apply(snapshot);
+    } catch (err) {
+      // Apply itself threw — do not mutate, do not fire, surface to caller.
+      log(`[favoritesStore] apply threw: ${err}`);
+      throw err;
+    }
+
+    // Step 4 + 5: in-memory mutation + fire change.
+    this.entries = next;
+    this.rebuildIndex();
+    this._onDidChange.fire(payload);
+
+    // Step 6: persist; rollback this mutation only on failure.
+    this.persistChain = this.memento
+      .update(STORAGE_KEY, { version: 2, entries: this.entries } as FavoritesStorageEnvelope)
+      .then(() => undefined)
+      .catch((err: unknown) => {
         this.entries = snapshot;
         this.rebuildIndex();
-        this._onDidChange.fire();
+        this._onDidChange.fire({ kind: "broad" });
         showPersistErrorToast(err);
       });
 
@@ -124,18 +160,13 @@ export class FavoritesStore {
 }
 ```
 
-**Why the persist queue is serialized:** the inquisitor's pass-2 charge correctly identified that `memento.update` rejecting after multiple mutations have stacked produces undefined rollback behavior. Serializing means there's only ever one in-flight persist whose rejection has unambiguous semantics: roll the in-memory state back to the snapshot taken when *that mutation* was enqueued. Any subsequent mutations chained behind it are also rolled back — they were predicated on the failed persist's success.
+**Why "await prior, then apply":** the v3 design chained mutations and on rejection restored the *first* failing mutation's snapshot, which clobbered later in-memory mutations that had already been applied speculatively. The v4 design serializes mutations end-to-end: each waits for the prior persist's resolution (success → entries reflect the success; rollback → entries reflect the rollback) before snapshotting. There is no speculative state. A persist failure rolls back exactly one mutation and toasts exactly once.
 
-This costs latency on rapid-fire toggles (each waits behind the previous's persist) but is correct. For a curated list capped at 25 entries, latency is irrelevant.
+**Trade-off:** rapid mutations are now strictly serial — clicking the star 5 times in 100ms means 5 persists serialized one after the other. With `MAX_FAVORITES = 25` and `globalState.update` typically completing in <10ms locally, total worst-case latency is ~50ms for a burst of 5. Acceptable.
 
 ### Canonical Key
 
 ```typescript
-/**
- * Canonical lookup key. Pipeline: separator normalize → trim trailing
- * separator → case-fold (lower). Does NOT consult realpathSync — see
- * Non-Goals for the symlink tradeoff rationale.
- */
 function canonicalKey(p: string): string {
   return p
     .replace(/\\/g, "/")
@@ -144,151 +175,160 @@ function canonicalKey(p: string): string {
 }
 ```
 
-Used identically in: `add` dedup, `relocate` dedup, `isFavorited`, and the existence cache key. No alternate normalizations anywhere.
-
 ### Worktree Path Predicate
 
-`isWorktreePath(p: string): boolean` is exported from `src/projectGrouping.ts` (the same module that already has the worktree-detection regex internally). The predicate matches the existing detection rule: path ends with `/.worktrees/<single-segment>` after separator normalization, case-insensitive.
+`isWorktreePath()` trims trailing separators before the regex test, matching how the rest of the codebase normalizes paths. This closes the v3 gap where `C:\proj\.worktrees\fix\` (trailing slash) bypassed the worktree gate.
 
 ```typescript
 // Exported from src/projectGrouping.ts
 export function isWorktreePath(p: string): boolean {
-  return /\/\.worktrees\/[^/]+$/i.test(p.replace(/\\/g, "/"));
+  const normalized = p.replace(/\\/g, "/").replace(/\/+$/, "");
+  return /\/\.worktrees\/[^/]+$/i.test(normalized);
 }
 ```
 
-This is the *only* predicate used to reject worktree paths in `addFavorite` and `locateFavorite`. No other heuristics, no shell-out to git.
+### `launchSession` result type + cache feedback loop (charge 4 fix)
 
-### Existence Cache (async, stale-aware, UNC-skipping)
+`sessionManager.ts:launchSession` is refactored from `Promise<void>` to:
+
+```typescript
+type LaunchResult =
+  | { ok: true; reused: boolean }
+  | { ok: false; reason: "missing" | "other"; message: string };
+
+async launchSession(folderPath: string): Promise<LaunchResult> {
+  const normalized = path.normalize(folderPath);
+
+  // For non-UNC paths, pre-flight existsSync is fast and informative.
+  // For UNC paths, skip pre-flight to avoid SMB-timeout hang.
+  if (!isLikelyNetworkPath(normalized)) {
+    if (!fs.existsSync(normalized)) {
+      log(`[launch] missing cwd: ${normalized}`);
+      return { ok: false, reason: "missing", message: `Folder does not exist: ${normalized}` };
+    }
+  }
+
+  // ... existing terminal creation ...
+
+  return { ok: true, reused: false };
+}
+```
+
+**Caller integration** (favorites/recents click handlers in `extension.ts`):
+
+```typescript
+const result = await sessionManager.launchSession(path);
+if (result.ok) {
+  existenceCache.markPresent(path);  // unsticks UNC favorites previously markMissing'd
+} else if (result.reason === "missing") {
+  existenceCache.markMissing(path);
+  vscode.window.showErrorMessage(result.message);
+}
+// reason === "other" does not flip the cache — only existence-derived signals do.
+```
+
+**Coverage matrix:**
+
+| Path type | Pre-flight result | Cache update on outcome |
+|---|---|---|
+| Local, exists | passes | `markPresent` on success |
+| Local, missing | fails | `markMissing` on missing-result; user-visible error |
+| UNC, share online | (skipped) | `markPresent` on launch success |
+| UNC, share offline | (skipped) | NO automated `markMissing` (createTerminal returns sync without throwing). User feedback path: VS Code's terminal output shows `"starting directory does not exist"`; user right-clicks → Locate or Remove. **Crucially, the next time the user clicks the same UNC favorite after the share is back online, launchSession succeeds → `markPresent` flips the cache.** No stuck-missing state. |
+
+This closes the v3 "stuck forever in missing" charge: even though we can't detect post-spawn UNC failures synchronously, we can detect successful launches, and the success signal is sufficient to recover from a previously-set missing state.
+
+### Existence Cache (async, stale-aware, UNC-skipping, with markPresent)
 
 ```typescript
 type ExistenceState =
   | { kind: "exists"; checkedAt: number }
   | { kind: "missing"; checkedAt: number }
-  | { kind: "unknown" };  // never checked
+  | { kind: "unknown" };
 
 class PathExistenceCache {
   private cache = new Map<string, ExistenceState>();
+  private readonly _onDidChange = new vscode.EventEmitter<{ kind: "single"; path: string } | { kind: "broad" }>();
+  readonly onDidChange = this._onDidChange.event;
   private readonly TTL_MS = 30_000;
   private readonly STAT_TIMEOUT_MS = 500;
 
-  /**
-   * Synchronous read for getTreeItem.
-   * Returns: 'exists' | 'missing' | { kind: 'missing', stale: true } | 'unknown'.
-   * Stale-missing keeps the dimmed render until the next stat lands.
-   */
   peek(path: string): { kind: "exists" } | { kind: "missing"; stale: boolean } | { kind: "unknown" } {
     const e = this.cache.get(canonicalKey(path));
     if (!e || e.kind === "unknown") return { kind: "unknown" };
     const stale = Date.now() - e.checkedAt > this.TTL_MS;
     if (e.kind === "missing") return { kind: "missing", stale };
-    if (stale) return { kind: "unknown" };  // exists+stale → re-confirm; safe to show present optimistically meanwhile
+    if (stale) return { kind: "unknown" };
     return { kind: "exists" };
   }
 
-  /** Mark a path missing immediately (e.g., after a launch failure). */
-  markMissing(path: string): void { ... }
+  /** Force-mark missing (e.g., from launchSession failure or post-stat). */
+  markMissing(path: string): void {
+    this.cache.set(canonicalKey(path), { kind: "missing", checkedAt: Date.now() });
+    this._onDidChange.fire({ kind: "single", path });
+  }
 
-  /** Evict cache entry — called on remove/relocate. */
-  evict(path: string): void { ... }
+  /** Force-mark present (e.g., from launchSession success — the canonical "this works" signal). */
+  markPresent(path: string): void {
+    this.cache.set(canonicalKey(path), { kind: "exists", checkedAt: Date.now() });
+    this._onDidChange.fire({ kind: "single", path });
+  }
 
-  /** Background refresh; non-blocking, with timeout. UNC paths skipped. */
-  async refresh(paths: string[]): Promise<void> { ... }
-}
+  /** Drop the cache entry — called from FavoritesStore on remove/relocate. */
+  evict(path: string): void { /* ... */ }
 
-function isLikelyNetworkPath(p: string): boolean {
-  return p.startsWith("\\\\") || p.startsWith("//");
+  /** Background refresh — async stat with timeout, UNC-skipped. */
+  async refresh(paths: string[]): Promise<void> { /* ... */ }
 }
 ```
-
-**Behavior:**
-- `peek`'s asymmetric staleness (return `unknown` for stale-exists but stale-missing for stale-missing) avoids the v2 flicker: a confirmed-missing entry stays dimmed across TTL expiry until a fresh stat result lands. No 30s on/off oscillation.
-- `markMissing(path)` is called from `launchSession` failure handlers when launching a UNC favorite fails — the cache learns from launch attempts so repeated clicks don't keep optimistic-rendering an unreachable path.
-- `evict(path)` is called by `FavoritesStore` from `remove` and `relocate` so stat results landing for stale paths never fire `onDidChange` for non-existent entries.
-- UNC paths skipped by `refresh()` are still rendered as optimistic-present until a launch failure flips them to missing via `markMissing()` — feedback loop closes the v2 gap.
 
 ### Provider Refresh Decoupling
 
-| Event | Trigger | Provider response |
-|---|---|---|
-| `onDidChangeSessions` (existing) | Active session set changes | RecentProjectsProvider re-fetches `getAllFolders()`, re-groups, fires `onDidChangeTreeData(undefined)` |
-| `FavoritesStore.onDidChange` | Favorites set changes | Both providers fire `onDidChangeTreeData(toggledElement)` (targeted) when a single path was toggled. For multi-path mutations (e.g., relocate-with-dedup which removes one and updates another), fire `onDidChangeTreeData(undefined)`. |
-| `existenceCache.onDidChange` | A row's existence state transitioned (e.g., stat result landed, `markMissing` called) | Both providers fire `onDidChangeTreeData(specificElement)` if the change is single-path; broad invalidation only when refresh batch returns >1 transition. |
+Single source of truth for change events; all providers subscribe to:
+- `FavoritesStore.onDidChange` — typed `FavoritesChangeEvent`. Single-path payloads enable targeted `onDidChangeTreeData(treeNode)`.
+- `existenceCache.onDidChange` — same shape.
+- Existing `sessionManager.onDidChangeSessions` — drives RecentProjectsProvider data refresh only.
 
-**Targeted invalidation:** `FavoritesStore` exposes `onDidChange` as `Event<{ kind: "single"; path: string } | { kind: "broad" }>` (instead of `Event<void>`) so consumers can choose targeted vs full invalidation. Star-toggles emit `{ kind: "single", path }`; relocate-with-dedup and bulk operations emit `{ kind: "broad" }`.
+Providers route the `kind` to either `_onDidChangeTreeData.fire(specificElement)` (single) or `_onDidChangeTreeData.fire(undefined)` (broad). Single-path operations: star toggle, single-favorite cache flip, `markMissing`/`markPresent`. Broad operations: relocate-with-dedup, persist rollback, multi-path stat refresh batches.
 
-### `viewItem` Context Values — Composite Single Tokens
+### `viewItem` Context Values — Shared Single Token Set (v3 prefix split collapsed)
 
-**Crux of the v3 fix:** VS Code's `viewItem` matching with `==` is literal string equality. v2's "space-separated multi-token" claim was wrong. v3 uses *single composite tokens*.
+The v3 design used distinct prefixes (`recentProject.*` vs `favoriteProject.*`) for the same logical row state. v4 collapses to a single token set used by both providers, with `view ==` doing all panel disambiguation:
 
 | Provider | Row state | `contextValue` |
 |---|---|---|
-| RecentProjectsProvider (top-level) | not favorited | `recentProject.unfavorited` |
-| RecentProjectsProvider (top-level) | favorited | `recentProject.favorited` |
-| RecentProjectsProvider (top-level) | favorited + missing | `recentProject.missing` |
-| FavoritesProvider (top-level) | present | `favoriteProject.favorited` |
-| FavoritesProvider (top-level) | missing | `favoriteProject.missing` |
+| RecentProjectsProvider (top-level) | not favorited | `projectRoot.unfavorited` |
+| RecentProjectsProvider (top-level) | favorited | `projectRoot.favorited` |
+| RecentProjectsProvider (top-level) | favorited + missing | `projectRoot.missing` |
+| FavoritesProvider (top-level) | present | `projectRoot.favorited` |
+| FavoritesProvider (top-level) | missing | `projectRoot.missing` |
 | Either provider (worktree child) | any | `worktreeChild` |
 | ActiveSessionsProvider | unchanged | `activeSession` |
-
-**`package.json` migration of the existing `recentProject` clause:**
-
-```jsonc
-{
-  "command": "claudeConductor.openRecentProject",  // existing command
-  "when": "view == claudeConductor.recentProjects && viewItem =~ /^recentProject\\b/",
-  "group": "inline"
-}
-```
-
-The `\b` word-boundary anchor ensures `recentProject.favorited` matches but a hypothetical future `recentProjectFoo` does not. The `^` ensures we don't match `xyzrecentProject.favorited`.
-
-**Existing three `activeSession` clauses are unchanged** — `activeSession` is still a single literal token.
 
 ```typescript
 // Exported from src/treeView.ts
 export const VIEW_ITEM = {
-  RECENT_PROJECT_FAVORITED:    "recentProject.favorited",
-  RECENT_PROJECT_UNFAVORITED:  "recentProject.unfavorited",
-  RECENT_PROJECT_MISSING:      "recentProject.missing",
-  FAVORITE_PROJECT_FAVORITED:  "favoriteProject.favorited",
-  FAVORITE_PROJECT_MISSING:    "favoriteProject.missing",
-  WORKTREE_CHILD:              "worktreeChild",
-  ACTIVE_SESSION:              "activeSession",
+  PROJECT_ROOT_FAVORITED:   "projectRoot.favorited",
+  PROJECT_ROOT_UNFAVORITED: "projectRoot.unfavorited",
+  PROJECT_ROOT_MISSING:     "projectRoot.missing",
+  WORKTREE_CHILD:           "worktreeChild",
+  ACTIVE_SESSION:           "activeSession",
 } as const;
 ```
 
-### Storage Envelope
+**Migration of existing `recentProject` clause** (`package.json:143`):
 
-```typescript
-const STORAGE_KEY = "claudeConductor.favorites";
-
-interface FavoritesStorageEnvelope {
-  version: 2;
-  entries: { path: string }[];
-}
-```
-
-| Stored value | Interpretation |
-|---|---|
-| `undefined` or `null` | No favorites; treat as `[]`. |
-| `[]` | No favorites. |
-| `string[]` (no version field) | v1 legacy. Read-time: convert to envelope shape and replace storage atomically on first **mutation** (not on first read). Multiple windows reading concurrently see the same legacy data; the migration write happens once, when the user actually changes something. |
-| `{ version: 2, entries: [...] }` | v2 native; use as-is. |
-| `{ version: <other>, ... }` | Future shape unknown to this build. Toast: `"Favorites storage was written by a newer version of the extension; v1 read-only mode."` Treat as `[]` for writes (no destructive overwrite), render entries best-effort if `entries` is an array. |
-
-**Multi-window race resolution:** because migration is deferred to first mutation, two windows opening v1 data both display it correctly without writing. The first window to actually mutate triggers the migration write. The second window's `globalState` change listener (if VS Code provides one) or its next read picks up the new shape. Even if both windows mutate simultaneously, *no UUIDs are at stake* — `entries` is just `{path}` objects, dedup is canonical-key-based, and the worst case is a last-writer-wins on the entries array which is the same semantics as any concurrent storage update.
-
-**v1-build compatibility:** the envelope shape is an object, not an array. A v1 build reading the envelope would see `Array.isArray(raw) === false` and fall through to its empty-state branch — no crash, no misinterpretation, just "no favorites" until the user upgrades again or downgrades v2. This is acceptable for a manual-curation feature where loss of pinned-state on downgrade is recoverable (re-pin a few projects).
+The existing clause `"viewItem == recentProject"` becomes — *after deciding whether the existing inline action should fire on favorited rows too*. The existing inline action is "open recent project," which should fire on any state. New clause: `"viewItem =~ /^projectRoot\\./"`. This matches all three states (`favorited`, `unfavorited`, `missing`). The `^` anchor and `\\.` separator anchor prevent partial-match false positives on hypothetical future `projectRootSomething` values.
 
 ## Commands
 
 | Command ID | Args | Behavior |
 |---|---|---|
-| `claudeConductor.addFavorite` | `path: string` | Reject worktree paths via `isWorktreePath()` (toast). Reject when `entries.length >= 25` (toast: `"Favorites cap reached (25). Remove an entry first."`). Normalize. Append entry if not already present (canonical-key match). Idempotent. |
-| `claudeConductor.removeFavorite` | `path: string` | Remove entries whose canonical key matches. Evict from existence cache. No-op if absent. |
-| `claudeConductor.locateFavorite` | `oldPath: string` | Show `vscode.window.showOpenDialog({ canSelectFolders: true, canSelectFiles: false, canSelectMany: false, openLabel: "Select new location" })`. Reject if user cancels (no-op). Reject worktree paths via `isWorktreePath()` (toast). If `canonicalKey(newPath) === canonicalKey(oldPath)`: toast `"That's the same path. Choose a different folder."` and no-op. If `canonicalKey(newPath)` matches a different existing entry: drop the old entry, evict its cache key, toast `"That folder is already in your Favorites — removed the missing entry."`. Otherwise: replace `path` on the matched entry, evict the old cache key. |
-| `claudeConductor.openMissingFavoriteRelocator` | `path: string` | **New** — invoked from `TreeItem.command` on a missing favorite row (click handler). Internally just calls `claudeConductor.locateFavorite(path)`. Exists separately so the on-click and right-click-menu paths can be tested and potentially diverge later. Registered but hidden from the command palette via `commandPalette` menu `when` clause set to `false`. |
+| `claudeConductor.addFavorite` | `path: string` | Reject worktree (`isWorktreePath` toast). Reject if `entries.length >= MAX_FAVORITES` (toast). Idempotent: canonical-key match → no-op. |
+| `claudeConductor.removeFavorite` | `path: string` | Remove canonical-key match. Evict from existence cache. No-op if absent. |
+| `claudeConductor.locateFavorite` | `oldPath: string` | `showOpenDialog`. Reject cancel (no-op). Reject worktree (toast). If new canonical = old canonical: toast `"That's the same path. Choose a different folder."` and no-op. If new canonical = some *other* entry: drop old entry, evict cache, toast `"already in your Favorites"`. Otherwise replace path on entry, evict old cache key. |
+
+**No internal `openMissingFavoriteRelocator` command** (v3 introduced one; v4 drops it). Missing-row `TreeItem.command` directly references `claudeConductor.locateFavorite` with the path as argument. This avoids the `when: "false"` folklore concern entirely.
 
 ## Menus
 
@@ -298,65 +338,76 @@ interface FavoritesStorageEnvelope {
     // Star toggle (inline) — Recent + Favorites, unfavorited row → add
     {
       "command": "claudeConductor.addFavorite",
-      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == recentProject.unfavorited",
+      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.unfavorited",
       "group": "inline@1"
     },
-    // Star toggle (inline) — Recent, favorited row → remove (Recent shows the favorited state too)
+    // Star toggle (inline) — Recent + Favorites, favorited row → remove
     {
       "command": "claudeConductor.removeFavorite",
-      "when": "view == claudeConductor.recentProjects && viewItem == recentProject.favorited",
-      "group": "inline@1"
-    },
-    // Star toggle (inline) — Favorites row → remove
-    {
-      "command": "claudeConductor.removeFavorite",
-      "when": "view == claudeConductor.favorites && viewItem == favoriteProject.favorited",
+      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.favorited",
       "group": "inline@1"
     },
     // Missing favorite — Locate Folder (inline + context)
     {
       "command": "claudeConductor.locateFavorite",
-      "when": "view == claudeConductor.favorites && viewItem =~ /^(favoriteProject|recentProject)\\.missing$/",
+      "when": "view == claudeConductor.favorites && viewItem == projectRoot.missing",
       "group": "inline@1"
     },
-    // Missing favorite — Remove (context only, secondary)
+    // Missing favorite — Remove (context only)
     {
       "command": "claudeConductor.removeFavorite",
-      "when": "view == claudeConductor.favorites && viewItem =~ /^(favoriteProject|recentProject)\\.missing$/",
+      "when": "view == claudeConductor.favorites && viewItem == projectRoot.missing",
       "group": "missing@2"
     },
-    // Non-inline duplicates for right-click discoverability
+    // Right-click discoverability (non-inline)
     {
       "command": "claudeConductor.addFavorite",
-      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == recentProject.unfavorited",
+      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.unfavorited",
       "group": "favorites@1"
     },
     {
       "command": "claudeConductor.removeFavorite",
-      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && (viewItem == recentProject.favorited || viewItem == favoriteProject.favorited)",
+      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.favorited",
       "group": "favorites@1"
     }
-  ],
-  "commandPalette": [
-    { "command": "claudeConductor.openMissingFavoriteRelocator", "when": "false" }
   ]
 }
 ```
 
-**Migration to existing `recentProject` clause** (`package.json:143`): change `"viewItem == recentProject"` → `"viewItem =~ /^recentProject\\b/"`. The regex matches any `recentProject.<state>` composite. `\b` prevents partial matches against future tokens.
+**Migration to existing `recentProject` clause** (`package.json:143`): change `"viewItem == recentProject"` → `"viewItem =~ /^projectRoot\\./"`.
 
-## Missing-Folder Behavior (revised — click opens relocate)
+## Missing-Folder Behavior
 
 When the existence cache reports `missing` (fresh or stale) for a row's path:
 
-1. **Render** — `TreeItem.description = "(missing)"`, `TreeItem.iconPath = new ThemeIcon("folder", new ThemeColor("disabledForeground"))`, `contextValue = "favoriteProject.missing"` (or `recentProject.missing` for a favorited+missing Recent row).
+1. **Render** — `TreeItem.description = "(missing)"`, dimmed icon, `contextValue = "projectRoot.missing"`.
 2. **Tooltip** — `"This folder is missing on disk. Click or press Enter to relocate; right-click for more options."`
-3. **`TreeItem.command`** — `{ command: "claudeConductor.openMissingFavoriteRelocator", arguments: [path], title: "Relocate Folder" }`. **Click and Enter both open the relocate dialog.** This is the keyboard-only path the inquisitor demanded.
-4. **Right-click menu** — offers `Locate Folder...` (group `inline@1` — shows on hover too as a button) and `Remove from Favorites` (group `missing@2`).
-5. **Worktree children** — a missing favorite's grouping yields zero worktree children (worktrees aren't in storage). Missing rows render as leaves.
+3. **`TreeItem.command`** — `{ command: "claudeConductor.locateFavorite", arguments: [path], title: "Relocate Folder" }`. Click and Enter both open the relocate dialog.
+4. **Right-click menu** — `Locate Folder...` (inline + context) and `Remove from Favorites` (context only).
+5. **Worktree children** — none (worktrees aren't in storage).
 
-**Keyboard-only journey from "I see missing" to "relocated":**
-- Tab/arrow to the Favorites view → arrow-down to the missing row → press Enter → relocate dialog opens → arrow-keys + Enter through dialog → relocated.
+## Render-Path Cap Behavior (v3 silent-truncation fixed)
+
+The 25-cap is enforced only at `addFavorite`. If storage drifts past 25 (multi-window race, manual edit, future migration bug), the render path:
+
+- **Renders all entries**, sorted alphabetically. No truncation, no silent hiding.
+- **Displays a panel header banner** above the tree: `"Favorites: N entries (over the 25 cap — consider removing some)"`. Implemented via `TreeView.message` (the supported VS Code API for this — text shown above tree contents).
+- Subsequent `addFavorite` calls continue to reject with the cap toast.
+
+Rationale: silent truncation is data hiding. Showing all entries with a banner makes the over-cap state user-visible and self-correcting (the user removes some, the banner clears). The 25-cap is preserved as a soft policy on adds, not as a render-time invariant.
+
+## Storage Envelope
+
+Same as v3:
+
+| Stored value | Interpretation |
+|---|---|
+| `undefined` / `null` / `[]` | No favorites. |
+| `string[]` (no `version`) | v1 legacy. Read-only on first load. Convert to envelope shape on first mutation. |
+| `{ version: 2, entries: [...] }` | v2 native. |
+| `{ version: <other>, ... }` | Future-version warning toast. Render `entries` best-effort. Block writes. |
+
+Multi-window race for v1→v2 migration: deferred to first mutation, so concurrent v1 reads don't write. First mutation wins; subsequent windows pick up via their own next read or activation.
 
 ## Data Flow
 
@@ -364,51 +415,59 @@ When the existence cache reports `missing` (fresh or stale) for a row's path:
 User clicks star (Recent Projects, unfavorited row)
   └─> command: claudeConductor.addFavorite(path)
         └─> store.add(path)
-              └─> enqueueMutation(snapshot, applyAdd)
-                    ├─> entries.push(...); rebuildIndex(); _onDidChange.fire({kind: "single", path})
-                    │     ├─> RecentProjectsProvider fires onDidChangeTreeData(theElement)
-                    │     └─> FavoritesProvider fires onDidChangeTreeData(undefined) (new row appears)
-                    └─> persistChain.then(() => memento.update(...))
-                          └─> .catch(err) → entries = snapshot; rebuild; fire; toast
+              └─> enqueueMutation(applyAdd, {kind: "single", path})
+                    1. await persistChain    // wait for prior to fully resolve
+                    2. snapshot = [...entries]
+                    3. try { next = applyAdd(snapshot) } catch → throw
+                    4. entries = next; rebuildIndex()
+                    5. _onDidChange.fire({kind: "single", path})
+                       ├─> RecentProjectsProvider fires onDidChangeTreeData(theNode)
+                       └─> FavoritesProvider fires onDidChangeTreeData(undefined) (new row appears)
+                    6. persistChain = memento.update(...)
+                       └─ on reject: entries = snapshot; rebuild; fire {kind:"broad"}; toast
 ```
 
 ```
-User right-clicks a missing favorite → "Locate Folder..." (or clicks the row, or presses Enter)
-  └─> command: claudeConductor.locateFavorite(oldPath)
-        └─> showOpenDialog → newPath?
-              ├─ undefined → no-op
-              ├─ isWorktreePath(newPath) → reject + toast
-              ├─ canonicalKey(newPath) === canonicalKey(oldPath) → toast "same path" + no-op
-              ├─ canonicalKey(newPath) matches another entry → drop old, evict cache, toast "already favorited"
-              └─ otherwise → entry.path = newPath; evict oldPath from cache
-        └─> store.relocate(...) → enqueueMutation → persist
-```
-
-```
-launchSession on a UNC favorite fails
-  └─> caller catches error
-        └─> existenceCache.markMissing(path)
+User clicks a favorite that points at a UNC share that just came online
+  └─> command: claudeConductor.openFavorite(path)  (existing pattern)
+        └─> sessionManager.launchSession(path)
+              ├─ pre-flight skipped for UNC
+              ├─ createTerminal succeeds
+              └─ returns { ok: true, reused: false }
+        └─> existenceCache.markPresent(path)
               └─> _onDidChange.fire({kind: "single", path})
-                    └─> Both providers re-render that one row as (missing)
+                    └─> All providers re-render that row as present
+              ↑
+              This is the unstick path the v3 spec was missing.
+```
+
+```
+User clicks a favorite whose folder was deleted (local path)
+  └─> launchSession(path) → { ok: false, reason: "missing", message: ... }
+        └─> existenceCache.markMissing(path)
+              └─> Providers re-render row as (missing)
+        └─> showErrorMessage(message)
 ```
 
 ## Error Handling
 
 | Failure | Treatment |
 |---|---|
-| `globalState.update` rejection | Roll back in-memory state to the mutation's pre-snapshot. Toast `"Couldn't save Favorites — please try again."` Subsequent in-flight mutations chained behind this one are also rolled back (serialized-persist contract). |
-| `showOpenDialog` returns `undefined` | No-op. Missing entry stays. |
-| `addFavorite` called with a path already favorited | Silent no-op. |
-| `addFavorite` called with a worktree path | Reject with toast `"Favorite the project root, not a worktree."` |
-| `addFavorite` called when `entries.length >= 25` | Reject with toast `"Favorites cap reached (25). Remove an entry first."` |
-| Render path encounters `entries.length > 25` (storage drift) | Truncate display to first 25 entries (sorted alphabetically). `console.warn` once per session. Subsequent `addFavorite` calls continue to reject at the cap. |
-| `removeFavorite` called with absent path | Silent no-op. |
-| `locateFavorite` chosen path equals the old path (canonical) | Toast `"That's the same path. Choose a different folder."` No mutation. |
-| `locateFavorite` chosen path is a worktree | Reject with toast (same as `addFavorite`). |
-| Background stat throws (EACCES, etc.) | Cache as `missing`. Logged once per path per session. |
-| Stat times out (>500ms) | No cache entry written; `peek` returns `unknown` next time; render as optimistic-present; re-checked on next refresh cycle. |
-| `launchSession` fails on a favorite | `existenceCache.markMissing(path)`. Row dims on next render. |
-| Read encounters unknown storage version (`version > 2`) | Toast warning. Render entries best-effort if `entries` is an array. Block writes until reset (skipping mutations with a different toast). |
+| `globalState.update` rejection | Roll back this mutation only (the prior await ensured no later mutation has been applied). Toast once. Fire broad `onDidChange`. Subsequent enqueued mutations operate on the post-rollback state. |
+| `apply` callback throws | Do not mutate. Reject the caller's promise with the error. Do not fire `onDidChange`. Log. |
+| `showOpenDialog` returns `undefined` | No-op. |
+| `addFavorite` already favorited | Silent no-op. |
+| `addFavorite` worktree path | Reject + toast `"Favorite the project root, not a worktree."` |
+| `addFavorite` at or above cap | Reject + toast `"Favorites cap reached (25). Remove an entry first."` |
+| Render encounters >25 entries | Render all + show `TreeView.message` banner. No `console.warn` (banner is the user signal). |
+| `removeFavorite` absent path | Silent no-op. |
+| `locateFavorite` same-path | Toast `"That's the same path. Choose a different folder."` No mutation. |
+| `locateFavorite` worktree | Reject + toast (same as `addFavorite`). |
+| Background stat throws | Cache as `missing`. Logged once per path per session. |
+| Stat times out (>500ms) | No cache write. Render as optimistic-present (or last-known). |
+| `launchSession` returns `{ok: false, reason: "missing"}` | `markMissing(path)`; show error toast. |
+| `launchSession` returns `{ok: true}` | `markPresent(path)` — unsticks any prior `missing` state. |
+| Read encounters unknown storage version | Toast warning. Render `entries` best-effort. Block writes. |
 
 ## Testing (behavior-first)
 
@@ -418,111 +477,128 @@ New files:
 - `test/packageJsonContextKeys.test.ts`
 - `test/pathExistenceCache.test.ts`
 
-Additions to:
+Additions:
 - `test/treeView.test.ts`
+- `test/sessionManager.test.ts` (existing, augment for `LaunchResult`)
 
 ### `favoritesStore.test.ts`
 
 - `isFavorited` returns true/false synchronously after add/remove.
-- Canonical-key dedup: `C:\Foo` and `c:/foo/` produce the same key; second add is a no-op.
-- `add` rejects worktree paths via `isWorktreePath()` (uses real predicate, no mock).
-- `add` rejects past 25-entry cap.
-- `relocate` to canonical-equal path emits the "same path" toast.
-- `relocate` to a path already favorited drops the old entry; emits `{kind: "broad"}`.
-- v1 `string[]` storage value is read correctly without triggering a write (deferred-migration semantics).
-- First mutation after v1 read writes the `version: 2` envelope.
-- Future-version envelope (`version: 99`) toasts a warning and renders entries best-effort.
-- **Persist failure rollback:** mock `memento.update` to reject once. Add A. Then add B (chains behind). Assert: both rollbacks fire; final `entries` is empty; `onDidChange` fired three times (one for A applied, one for B applied, one for the rollback).
-- **Serialized persist:** mock `memento.update` to delay 100ms. Fire 5 mutations rapid-fire. Assert: only one update is in flight at a time (verified via per-call counters); all 5 land in storage in order.
+- Canonical-key dedup: `C:\Foo` and `c:/foo/` collapse.
+- `add` rejects worktree paths via real `isWorktreePath()`.
+- `add` rejects past 25-cap; `isOverCap()` reports correctly.
+- `relocate` to canonical-equal path emits "same path" toast and no-op.
+- `relocate` to a path already favorited drops old entry; emits `{kind: "broad"}`.
+- v1 `string[]` storage value reads correctly without writing (deferred migration).
+- First mutation after v1 read writes `version: 2` envelope.
+- Future-version envelope (`version: 99`) toasts warning and renders best-effort.
+- **Persist failure rolls back exactly one mutation** (regression guard for v3 cascade bug):
+  - Mock `memento.update` to reject only on the *first* call, then succeed.
+  - Add A (persist 1, will reject). Add B (persist 2, will succeed).
+  - Assert: B's enqueue waited for A's persist to resolve. After A rolls back, B's snapshot is `[]`, B applies, B persists `[B]`. Final state = `[B]`. **Not** `[A, B]` rolled back to `[]`, and **not** `[A, B]` rolled back to `[B]`. The await-prior-then-apply contract is what makes this deterministic.
+- **`apply` throw is contained**: pass an `apply` that throws. Assert `entries` unchanged, no `onDidChange` fired, returned promise rejects.
+- **`apply` is wrapped in try/catch**: same as above but with a real mutation that hits an internal invariant violation.
 
 ### `favoritesProvider.test.ts`
 
 - Empty state.
-- Single favorite, no worktrees.
-- Single favorite with worktrees.
+- Single favorite (with/without worktrees).
 - Alphabetical ordering with same-basename tiebreak.
-- **Missing folder render** (behavior-first): mock cache `peek` returns `{kind: "missing", stale: false}`. Assert: `description === "(missing)"`, dimmed icon, `contextValue === "favoriteProject.missing"`, `command.command === "claudeConductor.openMissingFavoriteRelocator"`, `command.arguments === [path]`.
-- **Stale-missing render**: mock cache returns `{kind: "missing", stale: true}`. Assert: same render as fresh-missing (no flicker).
-- **Optimistic-present on UNC**: mock cache returns `{kind: "unknown"}` for UNC path. Assert: rendered as present (no `(missing)` decoration).
-- **Click-on-missing fires relocator command**: mock `commands.executeCommand`; assert that triggering the row's `TreeItem.command` invokes `claudeConductor.openMissingFavoriteRelocator` with the path.
-- **Locate-folder dedup**: setup A and B (B is missing). Trigger `locateFavorite(B.path)` → dialog returns A.path. Assert: tree's getChildren returns exactly one row (A); toast `"already in your Favorites"` invoked.
-- **Locate same-path toast**: dialog returns the same path. Assert: toast `"That's the same path"` invoked; tree unchanged.
-- **`addFavorite` past cap toasts and does not mutate.**
-- **Render-path cap enforcement**: directly write 30 entries to `globalState`; instantiate provider. Assert: tree renders only first 25 (alphabetical); `console.warn` invoked once.
-- **Refresh-only-on-decoration-change**: spy on `getAllFolders()`. Toggle a favorite via store. Assert: `getAllFolders` called *zero* times.
+- Missing folder render: assert `description === "(missing)"`, dimmed icon, `contextValue === "projectRoot.missing"`, `command.command === "claudeConductor.locateFavorite"`, `command.arguments === [path]`.
+- Stale-missing render: same as fresh-missing (no flicker regression).
+- Optimistic-present on UNC: `peek` returns `unknown` for UNC path → row rendered without `(missing)`.
+- Locate-folder dedup, same-path toast, worktree rejection.
+- `addFavorite` past cap: toast, no mutation.
+- **Render path with storage drift >25**: directly write 30 entries to `globalState`. Instantiate provider. Assert: `getChildren` returns 30 nodes (sorted alphabetically); `TreeView.message` is set to the over-cap banner string. `console.warn` is NOT invoked.
+- Refresh-only-on-decoration-change: spy on `getAllFolders()`. Star toggle. Assert zero data calls.
 
 ### `pathExistenceCache.test.ts`
 
 - `peek` returns `unknown` initially.
-- `peek` returns `exists` after fresh stat; `unknown` after TTL expiry on previously-exists.
-- `peek` returns `{missing, stale: false}` after fresh stat; `{missing, stale: true}` after TTL expiry — never returns `unknown` for stale-missing (regression guard against v2 flicker).
-- `markMissing` immediately flips state without I/O.
-- `evict` removes the entry; subsequent `peek` returns `unknown`.
+- `peek` after `markPresent`: `{kind: "exists"}`; after TTL → `{kind: "unknown"}`.
+- `peek` after `markMissing`: `{kind: "missing", stale: false}`; after TTL → `{kind: "missing", stale: true}` (regression guard against v2 flicker).
+- `markPresent` after a prior `markMissing` flips state and fires `{kind: "single"}` (regression guard for v3 stuck-missing).
+- `evict` removes entry.
 - `refresh` skips UNC paths (`\\server\share\foo`); they stay `unknown`.
 - Stat with simulated 1s delay times out at 500ms; entry stays `unknown`.
 
 ### `packageJsonContextKeys.test.ts`
 
-The drift detector. Asserts a **bijection** between `package.json` `viewItem` references and `VIEW_ITEM` constants.
-
-- Parse `package.json`; walk every `view/item/context` clause; extract every `viewItem == "X"` literal AND every `viewItem =~ /pattern/` regex.
+- Parse `package.json` `view/item/context` clauses; extract every `viewItem ==` literal AND every `viewItem =~` regex.
 - For each literal: assert it is a value in `VIEW_ITEM`.
 - For each regex: assert at least one `VIEW_ITEM` value matches it.
-- For each `VIEW_ITEM` value: assert it is referenced by at least one menu clause (catches orphaned constants).
-- For each `\b`-anchored regex: assert it does not match a sibling token (e.g., `^recentProject\b` matches `recentProject.favorited` but not `recentProjectFoo`).
+- For each `VIEW_ITEM` value: assert it is referenced by at least one menu clause (orphan detection).
+- **Explicit negative-fixture list for regex anchoring**:
+  ```typescript
+  const negativeFixtures = [
+    "projectRootSomething",   // missing dot separator
+    "projectRoot",            // missing state suffix
+    "myprojectRoot.favorited", // prefix
+    "projectRoot.favoritedExtra", // suffix beyond a state token
+    "recentProject",          // legacy un-migrated value
+  ];
+  ```
+  For each `\b`/`\.`-anchored regex in `package.json`, assert that none of these strings match. This is the spec's explicit answer to the v3 "what counts as a sibling token?" charge.
 
 ### `treeView.test.ts` additions
 
-- **Star icon coupling.** Add path X via store. Render Recent Projects row for X — inline action shows `$(star-full)` and `contextValue === "recentProject.favorited"`. Remove via store. Re-render — `$(star-empty)` and `recentProject.unfavorited`.
-- **`onDidChangeSessions` doesn't lose star state mid-toggle.** Setup: store has X favorited. Trigger a full data refresh. Assert: rendered row for X still shows `recentProject.favorited` (regression guard against the v1 race).
-- **Existing `recentProject` clause migration**: assert that the existing inline action ("open recent project") still fires when the user clicks an unfavorited Recent Projects row, after the contextValue has been migrated to `recentProject.unfavorited`. (The package.json clause is now `=~ /^recentProject\b/`; this test verifies it still matches.)
+- Star icon coupling (Recent ↔ Favorites).
+- `onDidChangeSessions` mid-toggle does not lose star state (race regression guard).
+- **Existing `recentProject` clause migration test**: in a test harness, register a fake command bound to `viewItem =~ /^projectRoot\\./`. Render a Recent Projects row in any state (favorited, unfavorited, missing). Assert the menu clause matches all three. Verifies the migration of `package.json:143`.
+
+### `sessionManager.test.ts` (additions)
+
+- `launchSession` returns `{ok: false, reason: "missing"}` for a non-UNC path that doesn't exist.
+- `launchSession` returns `{ok: true}` for a path that exists (mock `createTerminal`).
+- `launchSession` skips pre-flight existsSync for UNC paths (verified by spying on `fs.existsSync` not being called for `\\server\share\foo`).
 
 ## File Touch List
 
 | File | Change |
 |---|---|
-| `package.json` | Add view contribution (3rd view), 4 commands (incl. internal relocator), 7 menu clauses (inline + context). **Migrate existing `recentProject == ` clause to `=~ /^recentProject\b/`.** Bump version. |
-| `src/favoritesStore.ts` | **New.** `FavoritesStore` service, `canonicalKey`, `readWithoutMigrating`, deferred migration on first mutation, serialized persist queue. |
-| `src/pathExistenceCache.ts` | **New.** Async stat, TTL, UNC skip, `markMissing`/`evict`. |
-| `src/projectGrouping.ts` | **Add export:** `isWorktreePath(p): boolean`. No other changes. |
-| `src/treeView.ts` | New `FavoritesProvider`. Add `VIEW_ITEM` constant. Update `RecentProjectsProvider` `contextValue` to `recentProject.{favorited,unfavorited,missing}`. Wire missing-row `command` to `claudeConductor.openMissingFavoriteRelocator`. |
-| `src/extension.ts` | Construct store + cache at activation. Register `FavoritesProvider`. Register 4 commands. Wire `markMissing` callback into `launchSession` failure path. |
-| `src/sessionManager.ts` | (or wherever `launchSession` lives) — call `existenceCache.markMissing(path)` on launch failure for paths that come from favorites/recents. |
+| `package.json` | Add 3rd view contribution. Add 3 commands (no internal hidden command). 6 menu clauses. Migrate existing `recentProject ==` clause to `=~ /^projectRoot\\./`. Bump version. |
+| `src/favoritesStore.ts` | **New.** Service per spec. |
+| `src/pathExistenceCache.ts` | **New.** Cache per spec, with `markPresent`. |
+| `src/projectGrouping.ts` | Add `isWorktreePath` export with trailing-separator trim. |
+| `src/treeView.ts` | New `FavoritesProvider`. `VIEW_ITEM` constants. `RecentProjectsProvider` `contextValue` migrated. Missing-row `TreeItem.command` → `claudeConductor.locateFavorite`. |
+| `src/extension.ts` | Construct store + cache. Register `FavoritesProvider`. Register 3 commands. Wire `markMissing`/`markPresent` callbacks into the favorite-launch click handler. |
+| `src/sessionManager.ts` | `launchSession` returns `LaunchResult` instead of `void`. UNC pre-flight skipped. |
 | `test/favoritesStore.test.ts` | **New.** |
 | `test/favoritesProvider.test.ts` | **New.** |
 | `test/pathExistenceCache.test.ts` | **New.** |
-| `test/packageJsonContextKeys.test.ts` | **New** drift detector with bidirectional bijection assertions. |
-| `test/treeView.test.ts` | Additions per test plan. |
-| `README.md` | Document Favorites section. Note 25-cap, click-to-relocate, UNC behavior (optimistic-present until launch failure). |
+| `test/packageJsonContextKeys.test.ts` | **New.** With explicit negative fixtures. |
+| `test/treeView.test.ts` | Cross-panel coupling, race regression guard, migration verification. |
+| `test/sessionManager.test.ts` | `LaunchResult` cases. |
+| `README.md` | Favorites section, 25-cap, click-to-relocate, UNC behavior, multi-window last-writer-wins limit. |
 | `CHANGELOG.md` | New entry. |
 
-## Open Questions Resolved During Brainstorm
+## Open Questions Resolved
 
 | Question | Resolution |
 |---|---|
 | Parallel vs mutually exclusive lists? | **Parallel.** |
 | Star button placement? | **Inline-on-hover + right-click context menu.** |
-| Ordering scheme? | **Alphabetical** by basename, full path tiebreak. Drag-to-reorder deferred. |
-| Per-worktree favorites? | **No.** Project-only, enforced via shared `isWorktreePath()`. |
-| Missing-folder behavior? | **Dim + `(missing)` + click opens relocate dialog directly. Tooltip + right-click for explicit options.** |
+| Ordering scheme? | **Alphabetical** (basename, full path tiebreak). Drag-to-reorder deferred. |
+| Per-worktree favorites? | **No.** Project-only; shared `isWorktreePath()` predicate. |
+| Missing-folder behavior? | **Dim + `(missing)` + click opens relocate dialog directly.** |
 
 ## Risks & Mitigations
 
-- **Risk:** A v1 build encountering v2's envelope `{version, entries}`.
-  **Mitigation:** Object-shape envelope means v1's `Array.isArray` check fails → empty-state branch. No crash, no data corruption. User loses pinned state on downgrade (acceptable for manual curation).
-- **Risk:** `viewItem` drift between TS and `package.json` (either direction).
-  **Mitigation:** `packageJsonContextKeys.test.ts` enforces bidirectional bijection — JSON references must exist in `VIEW_ITEM`, AND `VIEW_ITEM` values must be referenced. Catches typos in either file.
-- **Risk:** Symlink/junction → duplicate entries.
-  **Mitigation:** Documented tradeoff (Non-Goals). README notes paths are tracked as typed.
-- **Risk:** Unreachable workspace context (most favorites missing in current workspace).
-  **Mitigation:** Acknowledged v1 cost (Non-Goals). Dimmed treatment is low-noise.
-- **Risk:** Background stat refresh storms.
-  **Mitigation:** 30s TTL caps re-stat frequency; UNC paths skipped; targeted invalidation (single-path `onDidChange`) avoids full re-renders.
+- **Risk:** v1 build encountering v2 envelope.
+  **Mitigation:** Object-shape envelope means v1's `Array.isArray` check fails → empty-state. Acceptable downgrade cost for manual curation.
+- **Risk:** `viewItem` drift (TS ↔ `package.json`).
+  **Mitigation:** `packageJsonContextKeys.test.ts` enforces bidirectional bijection plus explicit negative fixtures.
+- **Risk:** Symlink-resolved duplicates.
+  **Mitigation:** Documented (Non-Goals).
+- **Risk:** Cross-workspace unreachable paths render `(missing)`.
+  **Mitigation:** Acknowledged.
+- **Risk:** Stat refresh storm.
+  **Mitigation:** 30s TTL; UNC-skipped; targeted invalidation.
 - **Risk:** Persist queue starves under rapid mutations.
-  **Mitigation:** Serialized queue's worst case is one persist per mutation, 25-entry cap means bounded list size, and persist latency is dominated by VS Code's `globalState.update` (typically <10ms locally). Acceptable.
-- **Risk:** UNC path "looks present" until the user tries to launch it.
-  **Mitigation:** `markMissing` is wired into the launch-failure path so the cache learns from the launch attempt; subsequent renders dim the row.
-- **Risk:** Relocate dialog accepts a worktree path the existence-only check would have allowed.
-  **Mitigation:** Both `addFavorite` and `locateFavorite` route through the same `isWorktreePath()` predicate; tested with shared fixtures.
-- **Risk:** Multi-window simultaneous mutation overwriting each other.
-  **Mitigation:** Last-writer-wins on the entries array — same semantics as any concurrent storage update. Because there's no per-entry identifier, no identity is lost; only the merged set differs from each window's view. Acceptable for v1; full sync resolution is deferred.
+  **Mitigation:** Strict serialization. Worst case for 25-entry list is ~10ms per persist; bursts of 5 → ~50ms total. Acceptable.
+- **Risk:** UNC path stuck-missing after launch failure.
+  **Mitigation:** `markPresent` on next successful launch flips it back. Verified by `pathExistenceCache.test.ts`.
+- **Risk:** Multi-window last-writer-wins data loss.
+  **Mitigation:** Acknowledged with engineering rationale (Non-Goals). Documented in README "Known Limits."
+- **Risk:** `apply` throws inside `enqueueMutation`.
+  **Mitigation:** try/catch around `apply`; entries unchanged; promise rejects; no event fired. Tested.

--- a/docs/superpowers/specs/2026-04-28-75-favorites-design.md
+++ b/docs/superpowers/specs/2026-04-28-75-favorites-design.md
@@ -1,15 +1,26 @@
 # Design Spec — Favorites Sidebar Section (Issue #75)
 
-**Status:** Draft
+**Status:** Draft v2 (post inquisitor review)
 **Date:** 2026-04-28
 **Issue:** [#75](https://github.com/cbeaulieu-gt/vscode-claude-conductor/issues/75)
 **Branch:** `75-favorites`
+
+## Revision History
+
+- **v1 (2026-04-28)** — initial brainstorm output.
+- **v2 (2026-04-28)** — addressed inquisitor charges:
+  - Cross-panel race fixed by extracting a `FavoritesStore` service (charge 1).
+  - Synchronous `existsSync` replaced with async stat + TTL cache + UNC skip (charge 2).
+  - `viewItem` migration explicitly acknowledged with package.json menu-clause updates (charge 3).
+  - Storage shape changed to `Array<{path: string}>` with a one-shot read-side migration (charge 4).
+  - Missing-row click no longer hijacks `TreeItem.command` — relies on context menu + tooltip (charge 5).
+  - Risks/Non-Goals expanded for charges 6–11 (dedup canonical key, Settings Sync rationale, max favorites cap, refresh-storm split, test plan rewritten to behavior-based, cross-workspace acknowledgement).
 
 ## Summary
 
 Add a third top-level tree view, **Favorites**, to the Claude Conductor sidebar. It sits between **Active Sessions** and **Recent Projects** and renders user-pinned project roots, reusing the existing two-level grouping helper so worktrees nest under their parent project exactly as they do in Recent Projects today.
 
-Favorites is a **manual curation overlay**, not a usage tracker. Pinning a project does not affect Recent Projects (parallel lists). Favoriting is per-machine via `globalState`. There is no auto-frequency tracking and no Settings Sync involvement.
+Favorites is a **manual curation overlay**, not a usage tracker. Pinning a project does not affect Recent Projects (parallel lists). Favoriting is per-machine via `globalState`. There is no auto-frequency tracking and no Settings Sync involvement in v1.
 
 ## Goals
 
@@ -17,14 +28,16 @@ Favorites is a **manual curation overlay**, not a usage tracker. Pinning a proje
 - Reuse `projectGrouping.ts` and `RecentProjectsProvider` patterns — minimal new architecture.
 - Tolerate transient absence (unmounted drives) and intentional moves (folder relocated on disk) without silent data loss.
 - Keep the design scoped — no drag-to-reorder, no per-worktree pinning, no auto-tracking.
+- Future-proof storage so deferred features (drag-reorder, sync, frequency) don't force a schema migration later.
 
-## Non-Goals
+## Non-Goals (with rationale)
 
-- Drag-to-reorder. Deferred until evidence the alphabetical default is insufficient.
-- Per-worktree favorites. Explicitly excluded — favorites are project-rooted; worktrees come along for free via grouping.
-- Auto-frequency tracking. Out of scope per the issue.
-- Cross-machine sync. `globalState` is per-machine by design.
-- Promoting Favorites into a workspace-level (per-folder) setting. Stays user-global.
+- **Drag-to-reorder.** Deferred. Soft cap of 25 favorites enforced at `addFavorite` (toast on overflow); past that, alphabetical-only ordering is unusable and we revisit the deferred feature.
+- **Per-worktree favorites.** Excluded. Favorites are project-rooted; worktrees come along via grouping. Both `addFavorite` and `locateFavorite` reject worktree paths.
+- **Auto-frequency tracking.** Out of scope per the issue.
+- **Settings Sync (`setKeysForSync`).** Explicitly NOT registered in v1 because path portability across machines is unsolved (drive letters, project locations differ across desktop/laptop). Revisit when a user requests it AND proposes a path-resolution strategy. The forward-compatible storage shape (see Storage) means adding sync later is non-breaking — the `id` field can serve as a sync-portable identifier independent of the `path`.
+- **Cross-workspace filtering.** Favorites are user-global. Opening a workspace where most favorited paths live elsewhere produces `(missing)` rows for those paths. v1 accepts this; the dimmed visual treatment is intentionally unobtrusive so the panel doesn't read as "everything is broken."
+- **Promoting Favorites into a workspace-level setting.** Stays user-global.
 
 ## Architecture
 
@@ -42,48 +55,179 @@ Add a third `TreeView` contribution in `package.json`:
 }
 ```
 
-`Favorites` deliberately renders between the other two so curated items sit above the noisy recents feed without obscuring active session state.
+### `FavoritesStore` service (new file: `src/favoritesStore.ts`)
 
-### Provider
+A standalone service that owns all favorites state. **Both providers consult it; neither owns it.** This is the architectural crux that fixes the cross-panel race.
 
-A new `FavoritesProvider implements vscode.TreeDataProvider<TreeNode>` lives in `src/treeView.ts`, parallel to `RecentProjectsProvider`. It:
+```typescript
+export interface FavoritesEntry {
+  /** Canonical user-facing path, original case preserved. */
+  path: string;
+  /** Stable id (UUID v4) — survives path relocation, future-proofs sync. */
+  id: string;
+}
 
-1. Reads `globalState["claudeConductor.favorites"]: string[]` on demand.
-2. For each path, runs `fs.existsSync(path)` to compute a `missing` flag (synchronous; the same approach `RecentProjectsProvider` uses for `addFolderPrompt` parity).
-3. Feeds the resolved list through `groupByProjectRoot` (reused, not modified) so worktrees nest under each favorited root.
-4. Sorts top-level groups alphabetically by `path.basename(root)`, with the full `root` path as the tiebreak.
-5. Emits a `_onDidChangeTreeData` event whenever the underlying `globalState` array changes.
+export class FavoritesStore {
+  private entries: FavoritesEntry[] = [];
+  private keyIndex: Set<string> = new Set();   // lowercased canonical keys
+  private readonly _onDidChange = new vscode.EventEmitter<void>();
+  readonly onDidChange = this._onDidChange.event;
+
+  constructor(private readonly memento: vscode.Memento) {
+    this.entries = readAndMigrate(memento);
+    this.rebuildIndex();
+  }
+
+  // ---- Synchronous reads (called from getTreeItem) ----
+  isFavorited(path: string): boolean {
+    return this.keyIndex.has(canonicalKey(path));
+  }
+  list(): readonly FavoritesEntry[] { return this.entries; }
+
+  // ---- Async mutations (called from commands) ----
+  async add(path: string): Promise<{ ok: boolean; reason?: string }> { /* ... */ }
+  async remove(path: string): Promise<void> { /* ... */ }
+  async relocate(oldPath: string, newPath: string): Promise<{ ok: boolean; reason?: string }> { /* ... */ }
+
+  private rebuildIndex(): void { /* ... */ }
+}
+```
+
+**Why this fixes the race:** providers do not cache the favorites set across an `await`. Inside `getTreeItem(element)` — which VS Code calls synchronously per visible row — they call `store.isFavorited(element.path)` and read the live index. When the store mutates, it updates `entries` and `keyIndex` *first* (synchronous), then fires `onDidChange`, then persists to `globalState` asynchronously in the background. Stale paint is impossible because there is no stale snapshot to paint against — the index is the only source of truth and it's read fresh every render.
+
+**Persistence sequencing:** mutations apply to in-memory state synchronously; the async `memento.update()` is fire-and-forget but errors surface through a `.catch(handlePersistError)` that toasts the user and rolls back the in-memory change.
+
+### Canonical Key
+
+```typescript
+/**
+ * Canonical lookup key for dedup, isFavorited(), and store lookups.
+ * Pipeline: separator normalize → trim trailing separator → case-fold (lower).
+ *
+ * Notably does NOT call fs.realpathSync — symlink/junction resolution is
+ * deferred to v2 because realpathSync on missing paths throws, and the
+ * caller cannot distinguish "missing path that's also a symlink" from
+ * "missing path." Acknowledged tradeoff: two distinct symlink-resolved-same
+ * paths produce duplicate favorite entries. Document this in user-facing
+ * docs ("Favorites tracks paths as you typed them").
+ */
+function canonicalKey(p: string): string {
+  return p
+    .replace(/\\/g, "/")           // separator normalize
+    .replace(/\/+$/, "")           // trim trailing separators
+    .toLowerCase();                // case-fold (Windows-correct, harmless on POSIX)
+}
+```
+
+This canonical key is used in **every** dedup check: `add`, `relocate`, `isFavorited`, and the menu `when`-clause `viewItem` derivation. Tests assert the same key derivation in both `package.json` menu-clause logic and the store.
+
+### Existence Check (async, cached, UNC-aware)
+
+Replace the v1 sync `fs.existsSync` design with an async cache:
+
+```typescript
+class PathExistenceCache {
+  private cache = new Map<string, { exists: boolean; checkedAt: number }>();
+  private readonly TTL_MS = 30_000;
+  private readonly STAT_TIMEOUT_MS = 500;
+
+  /** Synchronous read for getTreeItem. Returns last-known value or 'unknown'. */
+  peek(path: string): "exists" | "missing" | "unknown" {
+    const e = this.cache.get(canonicalKey(path));
+    if (!e) return "unknown";
+    if (Date.now() - e.checkedAt > this.TTL_MS) return "unknown";
+    return e.exists ? "exists" : "missing";
+  }
+
+  /** Async refresh — non-blocking, with timeout. UNC paths skipped. */
+  async refresh(paths: string[]): Promise<void> {
+    const toCheck = paths.filter(p => !isLikelyNetworkPath(p));  // skip \\server\share
+    // ...stat each with Promise.race against STAT_TIMEOUT_MS, populate cache, fire event...
+  }
+}
+
+function isLikelyNetworkPath(p: string): boolean {
+  return p.startsWith("\\\\") || p.startsWith("//");
+}
+```
+
+**Behavior:**
+- Render time: `peek()` returns `"unknown"` initially; treat as optimistic-present (no `(missing)` decoration). Tree renders instantly.
+- Refresh: a background pass calls `cache.refresh(allFavoritedPaths)` on store load and on `onDidChange`. When stat results land, fire `_onDidChangeDecorations` so providers re-render rows with updated missing flags.
+- UNC paths: skipped by the refresh loop; always rendered as optimistic-present. User who favorites `\\server\share\proj` won't see `(missing)` if the share is offline — they'll get a launch error if they click. This is the correct tradeoff vs hanging the extension host.
+- TTL: 30s — re-stat happens at most twice per minute even with rapid refresh churn.
+
+**Why this addresses the inquisitor's charge:** sync stat on disconnected UNC paths can block the extension host for the SMB timeout (tens of seconds). The async + timeout + UNC-skip design caps the worst case at 500ms per non-UNC path, run on a background async pass that doesn't block any tree render.
+
+### Provider Refresh Decoupling
+
+Two distinct refresh axes, two distinct events:
+
+| Event | What changed | Provider response |
+|---|---|---|
+| `onDidChangeSessions` (existing) | Active session set | RecentProjectsProvider re-fetches `getAllFolders()`, re-groups, fires `onDidChangeTreeData(undefined)` |
+| `FavoritesStore.onDidChange` (new) | Favorites set | Both providers fire `onDidChangeTreeData(undefined)` *without* re-fetching folders. VS Code re-calls `getTreeItem` per row, which reads the live `isFavorited()` and renders the new icon. No re-grouping, no I/O. |
+| `existenceCache.onDidChange` (new) | A previously-unknown path now has a known existence state | Both providers fire `onDidChangeTreeData(undefined)`. Same pattern — re-render only, no re-fetch. |
+
+**Why this fixes the refresh storm:** the v1 design had `RecentProjectsProvider` re-running `getAllFolders()` on every favorites change. That's three full data refreshes per logical action (open session → favorite → idle bell). v2 splits "data changed" from "decoration changed"; favorites toggles trigger only icon/contextValue re-render, not folder re-fetch.
+
+### `viewItem` Context Values & Migration
+
+**Existing state:** `RecentProjectsProvider` rows currently have `contextValue = "recentProject"` (`treeView.ts:159`), and `package.json:143` has a menu clause `viewItem == recentProject`. The v1 spec silently changed `contextValue` to `projectRoot.unfavorited`, which would have broken the existing menu clause.
+
+**v2 migration plan:**
+
+1. Define exported constants in `src/treeView.ts`:
+   ```typescript
+   export const VIEW_ITEM = {
+     PROJECT_ROOT_FAVORITED:   "projectRoot.favorited",
+     PROJECT_ROOT_UNFAVORITED: "projectRoot.unfavorited",
+     PROJECT_ROOT_MISSING:     "projectRoot.missing",
+     WORKTREE_CHILD:           "worktreeChild",
+     // existing values preserved for back-compat
+     RECENT_PROJECT:           "recentProject",
+     ACTIVE_SESSION:           "activeSession",
+   } as const;
+   ```
+2. **RecentProjectsProvider rows** — `contextValue` becomes a *space-separated multi-value*: `"recentProject projectRoot.favorited"` or `"recentProject projectRoot.unfavorited"`. VS Code's `viewItem` matching handles space-separated tokens via the `=~` regex operator. This preserves the existing `viewItem == recentProject` clause AND enables new `viewItem =~ /projectRoot\\.favorited/` clauses without breaking anything.
+3. **FavoritesProvider rows** — `contextValue` is `"favoritedProject projectRoot.favorited"` (or `projectRoot.missing` when missing). The first token is a Favorites-specific marker; the second is the shared favorited-state token.
+4. **Test:** add a `package-json-context-keys.test.ts` that parses `package.json` menu `when` clauses, extracts every `viewItem` literal, and asserts it appears in the `VIEW_ITEM` constants. This is the drift detector the inquisitor demanded.
 
 ### Storage
 
 | Key | Type | Scope | Notes |
 |---|---|---|---|
-| `claudeConductor.favorites` | `string[]` | `globalState` (per-machine) | Flat list of normalized project root paths. Order is **not** UX-visible — alphabetical sort happens at render time. Storage order is whatever `addFavorite` produces (insertion). |
+| `claudeConductor.favorites` | `FavoritesEntry[]` | `globalState` (per-machine) | Each entry has `path` and stable `id`. Order is **not** UX-visible — alphabetical sort happens at render time. |
 
-Path normalization: trim trailing separators; preserve original case (Windows is case-insensitive, but we render the user's own path back to them). Comparison index uses `lowerCase` for the duplicate-detection set.
+**Read-side migration** (handles users coming from v1 string-array storage if any preview exists; also defensive):
 
-### Star Toggle (cross-panel)
+```typescript
+function readAndMigrate(memento: vscode.Memento): FavoritesEntry[] {
+  const raw = memento.get("claudeConductor.favorites");
+  if (!Array.isArray(raw)) return [];
+  if (raw.length === 0) return [];
 
-Both `RecentProjectsProvider` and `FavoritesProvider` consult the same lookup index — a `Set<string>` of lowercased favorited paths — built once per refresh. This drives:
+  // v1 shape: string[]
+  if (typeof raw[0] === "string") {
+    const migrated = (raw as string[]).map(path => ({ path, id: randomUUID() }));
+    memento.update("claudeConductor.favorites", migrated);  // fire-and-forget upgrade
+    return migrated;
+  }
 
-- The inline action button icon: `$(star-empty)` if not favorited, `$(star-full)` if favorited.
-- The `viewItem` context value (`projectRoot.favorited` / `projectRoot.unfavorited` / `projectRoot.missing`) used by `package.json` `menus.view/item/context` clauses.
+  // v2 shape: FavoritesEntry[]
+  return raw as FavoritesEntry[];
+}
+```
 
-When a favorite is added or removed, *both* providers fire `onDidChangeTreeData` so the star flips state in both panels simultaneously.
-
-### Worktree Children
-
-Worktree rows render as today (no star, no special context value beyond what they already carry). Favoriting only happens at project-root granularity; storage never contains a `.worktrees/<branch>` path.
+**Why this matters:** four deferred features (drag-reorder, frequency tracking, sync, custom labels) all want per-entry metadata. `Array<{path, id}>` future-proofs all of them at zero current cost. The `id` field is the load-bearing piece — it survives path relocation, so a relocate operation preserves identity (sort position, future timestamps).
 
 ## Commands
 
 | Command ID | Args | Behavior |
 |---|---|---|
-| `claudeConductor.addFavorite` | `path: string` | Validate path is a project root (not a worktree child). Normalize. Append to `globalState` array if not already present. Fire refresh event. |
-| `claudeConductor.removeFavorite` | `path: string` | Remove the matching entry (case-insensitive). Fire refresh event. No-op if absent. |
-| `claudeConductor.locateFavorite` | `path: string` | Show `vscode.window.showOpenDialog({ canSelectFolders: true, canSelectFiles: false, canSelectMany: false, openLabel: "Select new location" })`. On selection, replace the missing path **in place** in the storage array (preserves alphabetical position via re-sort on next render). If the chosen path is already a favorite, drop the missing entry instead and toast `"That folder is already in your Favorites — removed the missing entry."` |
-
-All three commands accept a path argument so they can be invoked both from inline action buttons (which pass the tree item's resource) and from the right-click context menu.
+| `claudeConductor.addFavorite` | `path: string` | Reject worktree paths. Reject if `entries.length >= 25` (toast: `"Favorites cap reached (25). Remove an entry first."`). Normalize. Append entry with new UUID. Fire `onDidChange`. Idempotent: if already favorited (canonical-key match), no-op silently. |
+| `claudeConductor.removeFavorite` | `path: string` | Remove entries whose canonical key matches. Fire `onDidChange`. No-op if absent. |
+| `claudeConductor.locateFavorite` | `oldPath: string` | Show `vscode.window.showOpenDialog({ canSelectFolders: true, canSelectFiles: false, canSelectMany: false, openLabel: "Select new location" })`. **Reject worktree paths from the dialog result** with toast `"Favorite the project root, not a worktree."` (the same guard `addFavorite` uses). On valid selection: if the new canonical key matches a *different* existing entry, drop the old entry and toast `"That folder is already in your Favorites — removed the missing entry."`. If the new key matches the OLD entry's key (case/separator tweaks), update path string in place. Otherwise: replace `path` on the matched entry, preserving `id`. Fire `onDidChange`. |
 
 ## Menus
 
@@ -92,115 +236,148 @@ All three commands accept a path argument so they can be invoked both from inlin
   "view/item/context": [
     {
       "command": "claudeConductor.addFavorite",
-      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.unfavorited",
+      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem =~ /projectRoot\\.unfavorited/",
       "group": "inline@1"
     },
     {
       "command": "claudeConductor.removeFavorite",
-      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.favorited",
+      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem =~ /projectRoot\\.favorited/",
       "group": "inline@1"
-    },
-    {
-      "command": "claudeConductor.removeFavorite",
-      "when": "view == claudeConductor.favorites && viewItem == projectRoot.missing",
-      "group": "missing@2"
     },
     {
       "command": "claudeConductor.locateFavorite",
-      "when": "view == claudeConductor.favorites && viewItem == projectRoot.missing",
+      "when": "view == claudeConductor.favorites && viewItem =~ /projectRoot\\.missing/",
       "group": "missing@1"
+    },
+    {
+      "command": "claudeConductor.removeFavorite",
+      "when": "view == claudeConductor.favorites && viewItem =~ /projectRoot\\.missing/",
+      "group": "missing@2"
+    },
+    // Non-inline duplicates for context-menu discoverability
+    {
+      "command": "claudeConductor.addFavorite",
+      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem =~ /projectRoot\\.unfavorited/",
+      "group": "favorites@1"
+    },
+    {
+      "command": "claudeConductor.removeFavorite",
+      "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem =~ /projectRoot\\.favorited/",
+      "group": "favorites@1"
     }
-    // ... plus the same add/remove pair under a non-inline group for context-menu discoverability
   ]
 }
 ```
 
-The inline `@1` slot is the on-hover star button. The non-inline duplicates appear in the right-click menu so users who don't hover still discover the action.
+The `=~` operator matches against the multi-token contextValue string. Existing `viewItem == recentProject` clauses (package.json:143) continue to match unchanged.
 
-## Missing-Folder Behavior
+## Missing-Folder Behavior (revised — no command hijack)
 
-When `fs.existsSync(path) === false`:
+When the existence cache reports `"missing"` for a row's path:
 
-1. **Render** — `TreeItem.description = "(missing)"`, `TreeItem.iconPath = new ThemeIcon("folder", new ThemeColor("disabledForeground"))`. The `viewItem` context value becomes `projectRoot.missing`.
-2. **Click** — the `command` on the tree item is intercepted to a small handler that shows:
+1. **Render** — `TreeItem.description = "(missing)"`, `TreeItem.iconPath = new ThemeIcon("folder", new ThemeColor("disabledForeground"))`. The contextValue token `projectRoot.missing` is set.
+2. **Tooltip** — `"This folder is missing on disk. Right-click to relocate or remove."`
+3. **`TreeItem.command`** — *not set*. Clicking the row does nothing. (No toast hijack. The right-click context menu is the affordance.)
+4. **Right-click menu** — offers `Locate Folder...` (group `missing@1`) and `Remove from Favorites` (group `missing@2`).
 
-   `vscode.window.showInformationMessage("This folder is missing on disk.", "Locate Folder...", "Remove from Favorites")`
-
-   - `"Locate Folder..."` → invokes `claudeConductor.locateFavorite`.
-   - `"Remove from Favorites"` → invokes `claudeConductor.removeFavorite`.
-   - Dismiss → no action; entry stays.
-3. **Right-click** — same two actions appear in the context menu (see `menus` above), so the user does not have to click and dismiss the toast first.
-
-Worktree children of a missing favorite are never queried (the parent's missing render short-circuits expansion). Returning to a present folder simply unsets the missing flag on the next refresh — no state is lost across the missing→present transition.
+**Worktree children of a missing favorite:** the parent's missing render does not change expansion behavior; users can still expand the group, but children come from `groupByProjectRoot` over the favorited-paths list, which means missing parents have zero worktree children (since worktrees aren't in `globalState["claudeConductor.favorites"]`). Net effect: missing rows are leaf-rendered.
 
 ## Data Flow
 
 ```
 User clicks star (Recent Projects, unfavorited row)
   └─> command: claudeConductor.addFavorite(path)
-        └─> globalState.update("claudeConductor.favorites", [...current, path])
-              └─> emit favoritesChanged event
-                    ├─> FavoritesProvider.refresh()
-                    └─> RecentProjectsProvider.refresh()  // star icon flips
+        └─> store.add(path)                       // sync: mutate entries[] + keyIndex
+              ├─> emit onDidChange                 // sync, immediate
+              │   ├─> RecentProjectsProvider fires onDidChangeTreeData → re-render icons
+              │   └─> FavoritesProvider fires onDidChangeTreeData → re-render list
+              └─> memento.update(...)              // async, background
+                  └─> .catch(handlePersistError)   // rollback + toast on failure
 ```
 
 ```
-User clicks a missing favorite
-  └─> command: internal "showMissingFavoriteToast" handler
-        └─> showInformationMessage(..., "Locate Folder...", "Remove from Favorites")
-              ├─ "Locate Folder..." → claudeConductor.locateFavorite(path)
-              │     └─> showOpenDialog → globalState.update(replace-in-place)
-              │           └─> emit favoritesChanged
-              ├─ "Remove from Favorites" → claudeConductor.removeFavorite(path)
-              └─ dismiss → no-op
+User right-clicks a missing favorite → "Locate Folder..."
+  └─> command: claudeConductor.locateFavorite(oldPath)
+        └─> showOpenDialog → newPath
+              ├─ undefined → no-op
+              ├─ worktree path → reject with toast
+              ├─ canonical(newPath) === canonical(oldPath) → update entry.path in place
+              ├─ canonical(newPath) matches another entry → drop old entry, toast
+              └─ otherwise → entry.path = newPath, preserve id
+        └─> store.relocate(...) → onDidChange → re-render
 ```
 
 ## Error Handling
 
 | Failure | Treatment |
 |---|---|
-| `globalState.update` rejection | Log via `console.error`; toast `"Couldn't save Favorites — please try again."`; do not mutate in-memory state. |
-| `showOpenDialog` returns `undefined` (user cancelled) | No-op. Missing entry stays as-is. |
-| `addFavorite` called with a path already present (case-insensitive) | No-op. Do not duplicate. Do not toast — silent dedup is fine for this case since the user expects "make this a favorite" to be idempotent. |
-| `addFavorite` called with a `.worktrees/<branch>` path | Reject with toast `"Favorite the project root, not a worktree."` and do not mutate storage. The view-context guards make this unreachable from UI clicks, but the command is still callable from the command palette. |
+| `globalState.update` rejection | Log to `console.error`. Toast `"Couldn't save Favorites — please try again."` Roll back the in-memory mutation. |
+| `showOpenDialog` returns `undefined` | No-op. Missing entry stays. |
+| `addFavorite` called with a path already favorited (canonical match) | Silent no-op. |
+| `addFavorite` called with a `.worktrees/<branch>` path | Reject with toast `"Favorite the project root, not a worktree."` Storage unchanged. |
+| `addFavorite` called when at cap (25) | Reject with toast `"Favorites cap reached (25). Remove an entry first."` |
 | `removeFavorite` called with a path not in storage | Silent no-op. |
-| `locateFavorite` chosen path equals the original missing path | Treat as no-op (user picked the same path that doesn't exist). Toast `"That's the same path. Choose a different folder."` |
+| `locateFavorite` chosen path equals the original missing path (canonical match) | Update path in place — covers case/separator tweaks where user "fixes" the casing. No toast. |
+| `locateFavorite` chosen path is a worktree | Reject as `addFavorite` does. |
+| Background stat throws (EACCES, etc.) | Cache as `missing`; the render falls through to the missing-row treatment. Logged once per path per session at console.warn. |
+| Stat times out (>500ms) | Cache as `unknown`; rendered as optimistic-present. Re-checked on next refresh cycle. |
 
-## Testing
+## Testing (behavior-first, not implementation-first)
 
-New file: `test/favoritesProvider.test.ts`. Additions to `test/treeView.test.ts` for the cross-panel star icon coupling.
+New file: `test/favoritesStore.test.ts` — store unit tests.
+New file: `test/favoritesProvider.test.ts` — provider rendering tests.
+New file: `test/packageJsonContextKeys.test.ts` — package.json drift detector.
+Additions to `test/treeView.test.ts` — cross-panel star coupling, multi-token contextValue.
+
+### `favoritesStore.test.ts`
+
+- `isFavorited` returns true/false synchronously after add/remove.
+- Canonical-key dedup: `C:\Foo` and `c:/foo/` produce the same key; second add is a no-op.
+- `add` rejects worktree paths.
+- `add` rejects past 25-entry cap.
+- `relocate` preserves `id`; in-place update for canonical-equal new path.
+- `relocate` to a path already favorited drops the old entry; emits one `onDidChange`.
+- Read-side migration: `string[]` storage value upgrades to `FavoritesEntry[]` on first read.
+- `globalState.update` rejection rolls back in-memory state and re-emits.
 
 ### `favoritesProvider.test.ts`
 
-- Empty state — provider returns `[]` when `globalState` key is unset or `[]`.
-- Single favorite, no worktrees — top-level row renders, no children.
-- Single favorite with worktrees — group renders with worktree children, no star on children.
-- Multiple favorites — alphabetical by basename; same-basename pair tie-broken by full path.
-- Missing folder — `description` is `"(missing)"`, icon dimmed, `contextValue` is `projectRoot.missing`.
-- `addFavorite` idempotence — calling twice with the same path produces a single entry.
-- `addFavorite` rejects worktree paths — storage unchanged, toast invoked.
-- `removeFavorite` removes case-insensitively (Windows behavior).
-- `locateFavorite` happy path — replaces path in-place; alphabetical position recomputed on next render.
-- `locateFavorite` dedup path — chosen path already favorited → missing entry dropped, toast emitted.
-- `locateFavorite` cancel — no storage mutation.
-- Refresh propagation — toggling a favorite fires `onDidChangeTreeData` on **both** providers (use a spy).
+- **Empty state.** Provider returns `[]` when store has no entries. Tree shows VS Code's default empty-state placeholder.
+- **Single favorite, no worktrees.** Tree contains exactly one row; description is `""` (not `(missing)`); icon is the standard folder icon.
+- **Single favorite with worktrees.** Group renders top + N worktree children; children's contextValue does NOT contain `projectRoot.favorited`.
+- **Alphabetical ordering.** Adding `vscode-claude-conductor` then `claude-personal-configs` then `azure-skills`: tree renders `azure-skills`, `claude-personal-configs`, `vscode-claude-conductor`. Same-basename pair tie-broken by full path.
+- **Missing folder render** (behavior-first). Mock existence cache to return `"missing"` for path X. Assert: tree row's `description === "(missing)"`, icon is the dimmed ThemeIcon, contextValue contains `projectRoot.missing`, **and `command` is `undefined`** (no click action). This is the test the inquisitor demanded — it would fail if rendering returns an empty array for missing rows.
+- **Click-on-missing has no toast.** Mock `showInformationMessage`; assert it is *not* called when a missing row's `TreeItem.command` would have fired (which it shouldn't because `command` is undefined). Documents the behavior change from v1.
+- **Locate-folder dedup.** Setup: favorites contains entries A and B (B is missing). Trigger `locateFavorite(B.path)` → dialog returns A.path. Assert: tree's getChildren returns exactly one row whose path is A.path. Toast was shown.
+- **`addFavorite` past cap toasts and does not mutate.** Add 25 entries. Try the 26th. Assert: tree still shows 25 rows. Toast invoked.
+- **Refresh-only-on-decoration-change.** Spy on `getAllFolders()`. Toggle a favorite via store. Assert `getAllFolders` was called *zero* times. (RecentProjectsProvider's data-axis refresh is unaffected.)
+
+### `packageJsonContextKeys.test.ts`
+
+- Parses `package.json`, walks `menus.view/item/context`, extracts every `viewItem ==` and `viewItem =~` literal/regex.
+- Asserts every literal token (e.g., `projectRoot.favorited`, `projectRoot.missing`, `recentProject`, `worktreeChild`) appears as a value in `VIEW_ITEM` exported from `src/treeView.ts`.
+- This is the drift detector. If a future PR changes the constant or the JSON without updating both, this test fails.
 
 ### `treeView.test.ts` additions
 
-- Star icon state — when `path X` is in `globalState["claudeConductor.favorites"]`, the inline icon on the corresponding `RecentProjectsProvider` row is `$(star-full)`; remove and it flips to `$(star-empty)`.
-- View ordering — registration order in the test harness puts Favorites between Active and Recent.
+- **Star icon coupling.** Add path X via store. Render Recent Projects row for X — inline action shows `$(star-full)` and contextValue contains `projectRoot.favorited`. Remove via store. Re-render — row shows `$(star-empty)` and contextValue contains `projectRoot.unfavorited`. Existing `recentProject` token is *still* in the contextValue throughout.
+- **`onDidChangeSessions` doesn't lose star state mid-toggle.** Setup: store has X favorited. Trigger `sessionManager._onDidChangeSessions.fire()` (full data refresh). Assert: rendered row for X still shows `projectRoot.favorited` (the live store read inside `getTreeItem` is the regression guard against the v1 race).
 
 ## File Touch List
 
 | File | Change |
 |---|---|
-| `package.json` | Add view contribution, three commands, menu clauses. Bump version. |
-| `src/treeView.ts` | New `FavoritesProvider`. New shared favorites lookup index. Stars on `RecentProjectsProvider` rows. Missing-folder click interception handler. |
-| `src/extension.ts` | Register `FavoritesProvider`, register the three new commands, wire the cross-provider refresh fan-out. |
+| `package.json` | Add view contribution, three commands, six menu clauses (three inline + three non-inline). Bump version. |
+| `src/favoritesStore.ts` | **New.** `FavoritesStore` service, `canonicalKey`, `readAndMigrate`. Zero VS Code imports except `Memento` + `EventEmitter`. |
+| `src/pathExistenceCache.ts` | **New.** Async stat + TTL + UNC skip. Zero VS Code imports. |
+| `src/treeView.ts` | New `FavoritesProvider`. Add `VIEW_ITEM` constant. Update `RecentProjectsProvider` to consult `FavoritesStore.isFavorited` inside `getTreeItem` and emit multi-token contextValue. No changes to existing data-fetch path. |
+| `src/extension.ts` | Construct `FavoritesStore` and `PathExistenceCache` at activation. Register `FavoritesProvider`. Register the three new commands. Wire `store.onDidChange` to fire both providers' `_onDidChangeTreeData`. |
 | `src/projectGrouping.ts` | **No changes.** Reused as-is. |
-| `test/favoritesProvider.test.ts` | New file (per the test plan above). |
-| `test/treeView.test.ts` | Add star-state and ordering tests. |
-| `README.md` | Document the Favorites section under "Activity Bar Sidebar". |
+| `test/favoritesStore.test.ts` | **New.** Per test plan above. |
+| `test/favoritesProvider.test.ts` | **New.** Per test plan above. |
+| `test/packageJsonContextKeys.test.ts` | **New.** Drift detector. |
+| `test/treeView.test.ts` | Add cross-panel star coupling and race-regression tests. |
+| `README.md` | Document the Favorites section under "Activity Bar Sidebar". Note the 25-favorite cap. Note UNC paths render optimistic-present. |
 | `CHANGELOG.md` | New entry under the next version. |
 
 ## Open Questions Resolved During Brainstorm
@@ -209,15 +386,23 @@ New file: `test/favoritesProvider.test.ts`. Additions to `test/treeView.test.ts`
 |---|---|
 | Parallel vs mutually exclusive lists? | **Parallel.** Favorites is a curated overlay; Recent stays untouched. |
 | Star button placement? | **Inline-on-hover + right-click context menu** (both interaction paths). |
-| Ordering scheme? | **Alphabetical** by folder basename, full path tiebreak. Drag-to-reorder deferred. |
-| Per-worktree favorites? | **No.** Project-only; worktrees come along via grouping. |
-| Missing-folder behavior? | **Dim + `(missing)` suffix; click shows toast with `[Locate Folder...]` and `[Remove from Favorites]`.** Locate-folder relocates in place with dedup. |
+| Ordering scheme? | **Alphabetical** by folder basename, full path tiebreak. Drag-to-reorder deferred. Soft cap at 25. |
+| Per-worktree favorites? | **No.** Project-only; worktrees come along via grouping. Both `addFavorite` and `locateFavorite` reject worktree paths. |
+| Missing-folder behavior? | **Dim + `(missing)` suffix + tooltip; right-click to relocate or remove.** No click intercept. |
 
 ## Risks & Mitigations
 
-- **Risk:** `fs.existsSync` on every refresh adds I/O overhead.
-  **Mitigation:** Favorites lists are small (target ≤10 entries). Sync stat is fine; if profiling later shows pain, cache results between events.
-- **Risk:** `viewItem` context-value churn — three values (`favorited`/`unfavorited`/`missing`) on the same row class could break menu `when` clauses if they're spelled inconsistently.
-  **Mitigation:** Define them as exported string constants in `treeView.ts`; reference from both `package.json` (manually kept in sync) and tests.
-- **Risk:** A user favorites a path during a session, then `clean_gone` deletes the worktree the path *was* (but shouldn't be — favorites are project-rooted, not worktree-rooted, so this shouldn't happen by design). The guard against worktree paths in `addFavorite` prevents this.
-  **Mitigation:** Hard reject worktree-path favorites at command boundary; covered in tests.
+- **Risk:** `viewItem` constants drift between TS and `package.json`.
+  **Mitigation:** `packageJsonContextKeys.test.ts` parses package.json menu clauses and asserts every literal token exists in the `VIEW_ITEM` exported constant. Test fails if either side changes without the other.
+- **Risk:** Symlink/junction-resolved paths produce duplicate entries (two distinct strings → same directory).
+  **Mitigation:** Acknowledged tradeoff. v1 uses string-canonical key only (no `realpathSync`), because `realpathSync` on missing paths throws and the relocate flow needs to handle missing paths uniformly. Document in README: "Favorites tracks paths as you typed them — `C:\Code\Foo` and a junction pointing to it are tracked separately."
+- **Risk:** A user opens a workspace where most favorites are unreachable; panel shows mostly `(missing)` rows.
+  **Mitigation:** Acknowledged as v1 cost (see Non-Goals). Dimmed visual treatment is intentionally low-noise. v2 might add per-workspace filtering.
+- **Risk:** Background stat refresh storms on rapid `onDidChangeSessions` events.
+  **Mitigation:** 30s TTL means stat runs at most twice per minute per path even with refresh churn. UNC paths skipped entirely.
+- **Risk:** `globalState.update` rejection mid-mutation leaves in-memory and persisted state divergent.
+  **Mitigation:** `.catch(handlePersistError)` rolls back the in-memory mutation and fires `onDidChange` again to re-render the rolled-back state. User sees the toggle "snap back" with an error toast.
+- **Risk:** Path containing only-case-different favorites on case-insensitive filesystems.
+  **Mitigation:** Canonical key case-folds. `C:\Foo` and `c:/foo` collapse to one entry.
+- **Risk:** User sets up Favorites on machine A; on machine B the paths don't exist.
+  **Mitigation:** `globalState` is per-machine; this is by design (see Non-Goals — Settings Sync). The `id` field future-proofs the eventual sync story.

--- a/package.json
+++ b/package.json
@@ -171,12 +171,12 @@
         },
         {
           "command": "claudeConductor.addFavorite",
-          "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.unfavorited",
+          "when": "view =~ /claudeConductor\\.(activeSessions|recentProjects|favorites)/ && viewItem == projectRoot.unfavorited",
           "group": "inline@1"
         },
         {
           "command": "claudeConductor.removeFavorite",
-          "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.favorited",
+          "when": "view =~ /claudeConductor\\.(activeSessions|recentProjects|favorites)/ && viewItem == projectRoot.favorited",
           "group": "inline@1"
         },
         {
@@ -191,12 +191,12 @@
         },
         {
           "command": "claudeConductor.addFavorite",
-          "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.unfavorited",
+          "when": "view =~ /claudeConductor\\.(activeSessions|recentProjects|favorites)/ && viewItem == projectRoot.unfavorited",
           "group": "favorites@1"
         },
         {
           "command": "claudeConductor.removeFavorite",
-          "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.favorited",
+          "when": "view =~ /claudeConductor\\.(activeSessions|recentProjects|favorites)/ && viewItem == projectRoot.favorited",
           "group": "favorites@1"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
         },
         {
           "command": "claudeConductor.openSession",
-          "when": "viewItem =~ /^projectRoot\\.(favorited|unfavorited|missing)$/",
+          "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem =~ /^projectRoot\\.(favorited|unfavorited|missing)$/",
           "group": "inline"
         },
         {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,23 @@
         "command": "claudeConductor.refreshTreeView",
         "title": "Refresh",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "claudeConductor.addFavorite",
+        "title": "Add to Favorites",
+        "category": "Claude Conductor",
+        "icon": "$(star-empty)"
+      },
+      {
+        "command": "claudeConductor.removeFavorite",
+        "title": "Remove from Favorites",
+        "category": "Claude Conductor",
+        "icon": "$(star-full)"
+      },
+      {
+        "command": "claudeConductor.locateFavorite",
+        "title": "Locate Folder...",
+        "category": "Claude Conductor"
       }
     ],
     "viewsContainers": {
@@ -97,6 +114,10 @@
         {
           "id": "claudeConductor.activeSessions",
           "name": "Active Sessions"
+        },
+        {
+          "id": "claudeConductor.favorites",
+          "name": "Favorites"
         },
         {
           "id": "claudeConductor.recentProjects",
@@ -140,8 +161,38 @@
         },
         {
           "command": "claudeConductor.openSession",
-          "when": "viewItem == recentProject",
+          "when": "viewItem =~ /^projectRoot\\./",
           "group": "inline"
+        },
+        {
+          "command": "claudeConductor.addFavorite",
+          "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.unfavorited",
+          "group": "inline@1"
+        },
+        {
+          "command": "claudeConductor.removeFavorite",
+          "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.favorited",
+          "group": "inline@1"
+        },
+        {
+          "command": "claudeConductor.locateFavorite",
+          "when": "view == claudeConductor.favorites && viewItem == projectRoot.missing",
+          "group": "inline@1"
+        },
+        {
+          "command": "claudeConductor.removeFavorite",
+          "when": "view == claudeConductor.favorites && viewItem == projectRoot.missing",
+          "group": "missing@2"
+        },
+        {
+          "command": "claudeConductor.addFavorite",
+          "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.unfavorited",
+          "group": "favorites@1"
+        },
+        {
+          "command": "claudeConductor.removeFavorite",
+          "when": "view =~ /claudeConductor\\.(recentProjects|favorites)/ && viewItem == projectRoot.favorited",
+          "group": "favorites@1"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -161,7 +161,12 @@
         },
         {
           "command": "claudeConductor.openSession",
-          "when": "viewItem =~ /^projectRoot\\./",
+          "when": "viewItem =~ /^projectRoot\\.(favorited|unfavorited|missing)$/",
+          "group": "inline"
+        },
+        {
+          "command": "claudeConductor.openSession",
+          "when": "viewItem == worktreeChild",
           "group": "inline"
         },
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,7 +75,10 @@ class SessionUriHandler implements vscode.UriHandler {
     }
 
     // Folder is already open — launch the session directly
-    await this.sm.launchSession(folderPath);
+    const result = await this.sm.launchSession(folderPath);
+    if (!result.ok && result.reason === "missing") {
+      void vscode.window.showErrorMessage(result.message);
+    }
   }
 }
 
@@ -94,7 +97,7 @@ export function activate(context: vscode.ExtensionContext): void {
   const autoLaunchFolder = context.globalState.get<string>(AUTO_LAUNCH_KEY);
   if (autoLaunchFolder) {
     context.globalState.update(AUTO_LAUNCH_KEY, undefined);
-    sessionManager.launchSession(autoLaunchFolder);
+    void sessionManager.launchSession(autoLaunchFolder);
   }
 
   // State watcher for idle notifications (via Claude Code hooks)
@@ -128,7 +131,10 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand("claudeConductor.openSession", async (folderPath?: string) => {
       if (typeof folderPath === "string") {
-        await sessionManager.launchSession(folderPath);
+        const result = await sessionManager.launchSession(folderPath);
+        if (!result.ok && result.reason === "missing") {
+          void vscode.window.showErrorMessage(result.message);
+        }
       } else {
         await showQuickPick(sessionManager);
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { SessionManager, ActiveSession } from "./sessionManager";
 import { showQuickPick, addFolderPrompt } from "./quickPick";
-import { ActiveSessionsProvider, RecentProjectsProvider } from "./treeView";
+import { ActiveSessionsProvider, RecentProjectsProvider, FavoritesProvider } from "./treeView";
 import { StatusBar } from "./statusBar";
 import { ClaudeTerminalLinkProvider } from "./terminalLinks";
 import { StateWatcher } from "./stateWatcher";
@@ -34,6 +34,23 @@ function resolveSession(arg: unknown): ActiveSession | undefined {
   // ActiveSession case: has a .terminal property
   if ("terminal" in obj && "folderPath" in obj) {
     return obj as unknown as ActiveSession;
+  }
+  return undefined;
+}
+
+/**
+ * Normalizes the argument passed to a favorites command.
+ *
+ * Favorites commands may be invoked with a plain string path (programmatic calls),
+ * a TreeItem-shaped object whose `.folderPath` or `.path` exposes the path (inline
+ * action buttons and context-menu entries), or `undefined` (Command Palette).
+ */
+function resolvePathArg(arg: unknown): string | undefined {
+  if (typeof arg === "string") return arg;
+  if (arg && typeof arg === "object") {
+    const obj = arg as Record<string, unknown>;
+    if (typeof obj.folderPath === "string") return obj.folderPath;
+    if (typeof obj.path === "string") return obj.path;
   }
   return undefined;
 }
@@ -113,15 +130,30 @@ export function activate(context: vscode.ExtensionContext): void {
   }, 3000);
 
   // Tree view providers
-  // TODO(Task 8): wire real FavoritesStore and PathExistenceCache instances here.
   const favoritesStore = new FavoritesStore(context.globalState);
   const existenceCache = new PathExistenceCache();
   const activeProvider = new ActiveSessionsProvider(sessionManager);
   const recentProvider = new RecentProjectsProvider(sessionManager, favoritesStore, existenceCache);
+  const favoritesProvider = new FavoritesProvider(favoritesStore, existenceCache);
+
+  const favoritesView = vscode.window.createTreeView("claudeConductor.favorites", {
+    treeDataProvider: favoritesProvider,
+    showCollapseAll: false,
+  });
+
+  // Banner above the Favorites tree when storage drift produces > MAX_FAVORITES entries.
+  function refreshOverCapBanner() {
+    favoritesView.message = favoritesProvider.getOverCapBanner() ?? undefined;
+  }
+  favoritesStore.onDidChange(() => refreshOverCapBanner());
+  refreshOverCapBanner();  // initial state
 
   context.subscriptions.push(
     vscode.window.registerTreeDataProvider("claudeConductor.activeSessions", activeProvider),
-    vscode.window.registerTreeDataProvider("claudeConductor.recentProjects", recentProvider)
+    vscode.window.registerTreeDataProvider("claudeConductor.recentProjects", recentProvider),
+    favoritesView,
+    favoritesStore,
+    existenceCache,
   );
 
   // Status bar
@@ -137,7 +169,10 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand("claudeConductor.openSession", async (folderPath?: string) => {
       if (typeof folderPath === "string") {
         const result = await sessionManager.launchSession(folderPath);
-        if (!result.ok && result.reason === "missing") {
+        if (result.ok) {
+          existenceCache.markPresent(folderPath);
+        } else if (result.reason === "missing") {
+          existenceCache.markMissing(folderPath);
           void vscode.window.showErrorMessage(result.message);
         }
       } else {
@@ -209,6 +244,47 @@ export function activate(context: vscode.ExtensionContext): void {
 
     vscode.commands.registerCommand("claudeConductor.prevSession", () => {
       cycleSession(sessionManager, -1);
+    }),
+
+    vscode.commands.registerCommand("claudeConductor.addFavorite", async (arg: unknown) => {
+      const p = resolvePathArg(arg);
+      if (!p) return;
+      const r = await favoritesStore.add(p);
+      if (!r.ok && r.reason) {
+        void vscode.window.showWarningMessage(r.reason);
+      }
+    }),
+
+    vscode.commands.registerCommand("claudeConductor.removeFavorite", async (arg: unknown) => {
+      const p = resolvePathArg(arg);
+      if (!p) return;
+      await favoritesStore.remove(p);
+      existenceCache.evict(p);
+    }),
+
+    vscode.commands.registerCommand("claudeConductor.locateFavorite", async (oldPathArg: unknown) => {
+      const oldPath = resolvePathArg(oldPathArg);
+      if (!oldPath) return;
+
+      const picked = await vscode.window.showOpenDialog({
+        canSelectFolders: true,
+        canSelectFiles: false,
+        canSelectMany: false,
+        openLabel: "Select new location",
+      });
+      if (!picked || picked.length === 0) return;
+      const newPath = picked[0].fsPath;
+
+      const r = await favoritesStore.relocate(oldPath, newPath);
+      if (r.ok) {
+        existenceCache.evict(oldPath);
+        if (r.reason) {
+          // Dedup case: the relocate succeeded but with an informational reason.
+          void vscode.window.showInformationMessage(r.reason);
+        }
+      } else if (r.reason) {
+        void vscode.window.showWarningMessage(r.reason);
+      }
     }),
   );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,8 @@ import { ClaudeTerminalLinkProvider } from "./terminalLinks";
 import { StateWatcher } from "./stateWatcher";
 import { ensureHooksInstalled, setupHooksCommand, uninstallHooks } from "./hookInstaller";
 import { isSameWorkspaceFolder } from "./workspaceMatch";
+import { FavoritesStore } from "./favoritesStore";
+import { PathExistenceCache } from "./pathExistenceCache";
 
 let sessionManager: SessionManager;
 
@@ -111,8 +113,11 @@ export function activate(context: vscode.ExtensionContext): void {
   }, 3000);
 
   // Tree view providers
+  // TODO(Task 8): wire real FavoritesStore and PathExistenceCache instances here.
+  const favoritesStore = new FavoritesStore(context.globalState);
+  const existenceCache = new PathExistenceCache();
   const activeProvider = new ActiveSessionsProvider(sessionManager);
-  const recentProvider = new RecentProjectsProvider(sessionManager);
+  const recentProvider = new RecentProjectsProvider(sessionManager, favoritesStore, existenceCache);
 
   context.subscriptions.push(
     vscode.window.registerTreeDataProvider("claudeConductor.activeSessions", activeProvider),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,7 +132,7 @@ export function activate(context: vscode.ExtensionContext): void {
   // Tree view providers
   const favoritesStore = new FavoritesStore(context.globalState);
   const existenceCache = new PathExistenceCache();
-  const activeProvider = new ActiveSessionsProvider(sessionManager);
+  const activeProvider = new ActiveSessionsProvider(sessionManager, favoritesStore);
   const recentProvider = new RecentProjectsProvider(sessionManager, favoritesStore, existenceCache);
   const favoritesProvider = new FavoritesProvider(favoritesStore, existenceCache);
 

--- a/src/favoritesStore.ts
+++ b/src/favoritesStore.ts
@@ -1,0 +1,209 @@
+import * as vscode from "vscode";
+import { isWorktreePath } from "./projectGrouping";
+
+export interface FavoritesEntry {
+  path: string;
+}
+
+export type FavoritesChangeEvent =
+  | { kind: "single"; path: string }
+  | { kind: "broad" };
+
+interface FavoritesStorageEnvelope {
+  version: 2;
+  entries: FavoritesEntry[];
+}
+
+export const STORAGE_KEY = "claudeConductor.favorites";
+export const MAX_FAVORITES = 25;
+
+export interface MutationResult {
+  ok: boolean;
+  reason?: string;
+}
+
+function canonicalKey(p: string): string {
+  return p.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+}
+
+/** Pure read; no write side effects. v1 string[] is converted in-memory only. */
+function readWithoutMigrating(memento: vscode.Memento): {
+  entries: FavoritesEntry[];
+  unknownVersion: boolean;
+} {
+  const raw = memento.get<unknown>(STORAGE_KEY);
+  if (raw === undefined || raw === null) return { entries: [], unknownVersion: false };
+  if (Array.isArray(raw)) {
+    if (raw.length === 0) return { entries: [], unknownVersion: false };
+    if (typeof raw[0] === "string") {
+      return {
+        entries: (raw as string[]).map(p => ({ path: p })),
+        unknownVersion: false,
+      };
+    }
+    return { entries: raw as FavoritesEntry[], unknownVersion: false };
+  }
+  if (typeof raw === "object" && raw !== null && "version" in raw) {
+    const env = raw as FavoritesStorageEnvelope;
+    if (env.version === 2) {
+      return { entries: Array.isArray(env.entries) ? env.entries : [], unknownVersion: false };
+    }
+    const maybeEntries = (env as { entries?: unknown }).entries;
+    return {
+      entries: Array.isArray(maybeEntries) ? maybeEntries as FavoritesEntry[] : [],
+      unknownVersion: true,
+    };
+  }
+  return { entries: [], unknownVersion: false };
+}
+
+export class FavoritesStore {
+  private entries: FavoritesEntry[] = [];
+  private keyIndex: Set<string> = new Set();
+  private readonly _onDidChange = new vscode.EventEmitter<FavoritesChangeEvent>();
+  readonly onDidChange = this._onDidChange.event;
+
+  /** Tracks the latest persist (success or rollback). Mutations await this. */
+  private persistChain: Promise<void> = Promise.resolve();
+
+  /** True when storage envelope has an unknown future version — block writes. */
+  private readonly unknownVersion: boolean;
+
+  constructor(private readonly memento: vscode.Memento) {
+    const r = readWithoutMigrating(memento);
+    this.entries = r.entries;
+    this.unknownVersion = r.unknownVersion;
+    this.rebuildIndex();
+  }
+
+  isFavorited(p: string): boolean {
+    return this.keyIndex.has(canonicalKey(p));
+  }
+  list(): readonly FavoritesEntry[] { return this.entries; }
+  isOverCap(): boolean { return this.entries.length > MAX_FAVORITES; }
+
+  /** Test helper: wait for in-flight persists (and any rollback) to complete. */
+  async waitForIdle(): Promise<void> {
+    await this.persistChain.catch(() => undefined);
+  }
+
+  async add(p: string): Promise<MutationResult> {
+    if (this.unknownVersion) {
+      return { ok: false, reason: "Storage version is newer than this build supports." };
+    }
+    if (isWorktreePath(p)) {
+      return { ok: false, reason: "Favorite the project root, not a worktree." };
+    }
+    if (this.isFavorited(p)) {
+      return { ok: true };
+    }
+    if (this.entries.length >= MAX_FAVORITES) {
+      return { ok: false, reason: `Favorites cap reached (${MAX_FAVORITES}). Remove an entry first.` };
+    }
+
+    await this.enqueueMutation(
+      snapshot => [...snapshot, { path: p }],
+      { kind: "single", path: p }
+    );
+    return { ok: true };
+  }
+
+  async remove(p: string): Promise<void> {
+    if (this.unknownVersion) return;
+    if (!this.isFavorited(p)) return;
+
+    const key = canonicalKey(p);
+    await this.enqueueMutation(
+      snapshot => snapshot.filter(e => canonicalKey(e.path) !== key),
+      { kind: "single", path: p }
+    );
+  }
+
+  async relocate(oldPath: string, newPath: string): Promise<MutationResult> {
+    if (this.unknownVersion) {
+      return { ok: false, reason: "Storage version is newer than this build supports." };
+    }
+    if (isWorktreePath(newPath)) {
+      return { ok: false, reason: "Favorite the project root, not a worktree." };
+    }
+
+    const oldKey = canonicalKey(oldPath);
+    const newKey = canonicalKey(newPath);
+
+    if (oldKey === newKey) {
+      return { ok: false, reason: "That's the same path. Choose a different folder." };
+    }
+
+    if (!this.keyIndex.has(oldKey)) {
+      return { ok: false, reason: "Original entry not found." };
+    }
+
+    if (this.keyIndex.has(newKey)) {
+      await this.enqueueMutation(
+        snapshot => snapshot.filter(e => canonicalKey(e.path) !== oldKey),
+        { kind: "broad" }
+      );
+      return { ok: true, reason: "That folder is already in your Favorites — removed the missing entry." };
+    }
+
+    await this.enqueueMutation(
+      snapshot => snapshot.map(e =>
+        canonicalKey(e.path) === oldKey ? { path: newPath } : e
+      ),
+      { kind: "single", path: newPath }
+    );
+    return { ok: true };
+  }
+
+  /** Test seam: expose enqueueMutation for the apply-throw test. */
+  _enqueueMutationForTest(
+    apply: (snapshot: FavoritesEntry[]) => FavoritesEntry[],
+    payload: FavoritesChangeEvent
+  ): Promise<void> {
+    return this.enqueueMutation(apply, payload);
+  }
+
+  private async enqueueMutation(
+    apply: (snapshot: FavoritesEntry[]) => FavoritesEntry[],
+    payload: FavoritesChangeEvent
+  ): Promise<void> {
+    await this.persistChain.catch(() => undefined);
+
+    const snapshot = [...this.entries];
+
+    let next: FavoritesEntry[];
+    try {
+      next = apply(snapshot);
+    } catch (err) {
+      throw err;
+    }
+
+    this.entries = next;
+    this.rebuildIndex();
+    this._onDidChange.fire(payload);
+
+    this.persistChain = Promise.resolve(
+      this.memento.update(STORAGE_KEY, { version: 2, entries: this.entries } as FavoritesStorageEnvelope)
+    )
+      .then(() => undefined)
+      .catch((err: unknown) => {
+        this.entries = snapshot;
+        this.rebuildIndex();
+        this._onDidChange.fire({ kind: "broad" });
+        const msg = err instanceof Error ? err.message : String(err);
+        void vscode.window.showErrorMessage(
+          `Couldn't save Favorites — please try again. (${msg})`
+        );
+      });
+
+    return this.persistChain;
+  }
+
+  private rebuildIndex(): void {
+    this.keyIndex = new Set(this.entries.map(e => canonicalKey(e.path)));
+  }
+
+  dispose(): void {
+    this._onDidChange.dispose();
+  }
+}

--- a/src/favoritesStore.ts
+++ b/src/favoritesStore.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { isWorktreePath } from "./projectGrouping";
+import { canonicalKey } from "./pathCanonical";
 
 export interface FavoritesEntry {
   path: string;
@@ -20,10 +21,6 @@ export const MAX_FAVORITES = 25;
 export interface MutationResult {
   ok: boolean;
   reason?: string;
-}
-
-function canonicalKey(p: string): string {
-  return p.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
 }
 
 /** Pure read; no write side effects. v1 string[] is converted in-memory only. */

--- a/src/pathCanonical.ts
+++ b/src/pathCanonical.ts
@@ -1,0 +1,11 @@
+/**
+ * Canonical path key for case/separator-insensitive lookups across the
+ * favorites and existence-cache systems.
+ *
+ * Pipeline: separator normalize (\ → /) → trim trailing separators → lowercase.
+ * Does NOT consult realpathSync (symlink resolution is a deliberate Non-Goal
+ * per the Favorites design spec).
+ */
+export function canonicalKey(p: string): string {
+  return p.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+}

--- a/src/pathExistenceCache.ts
+++ b/src/pathExistenceCache.ts
@@ -14,6 +14,7 @@
 
 import * as vscode from "vscode";
 import * as fs from "fs";
+import { canonicalKey } from "./pathCanonical";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -43,11 +44,6 @@ const STAT_TIMEOUT_MS = 500;
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** Normalize a path to a canonical cache key: forward slashes, lowercase, no trailing slash. */
-function canonicalKey(p: string): string {
-  return p.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
-}
 
 /** Returns true for UNC paths (\\server\share or //server/share). */
 function isLikelyNetworkPath(p: string): boolean {

--- a/src/pathExistenceCache.ts
+++ b/src/pathExistenceCache.ts
@@ -1,0 +1,181 @@
+/**
+ * PathExistenceCache — tracks whether filesystem paths exist, with TTL-based staleness.
+ *
+ * Design notes:
+ * - `peek()` is synchronous for use inside `getTreeItem` (called by both tree providers).
+ * - "missing" entries stay dimmed (stale=true) across TTL expiry until a fresh stat lands,
+ *   avoiding the v2 "flicker" failure mode where entries would briefly appear as unknown.
+ * - "exists" entries collapse to unknown after TTL so a deleted path gets re-checked.
+ * - Keys are canonicalized (lowercase, forward-slash, no trailing slash) so Windows paths
+ *   with mixed separators and casing compare equal.
+ * - UNC paths (\\server\share or //server/share) are skipped in refresh() to avoid
+ *   hangs on unavailable network shares.
+ */
+
+import * as vscode from "vscode";
+import * as fs from "fs";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type ExistenceState =
+  | { kind: "exists"; checkedAt: number }
+  | { kind: "missing"; checkedAt: number }
+  | { kind: "unknown" };
+
+export type PeekResult =
+  | { kind: "exists" }
+  | { kind: "missing"; stale: boolean }
+  | { kind: "unknown" };
+
+export type CacheChangeEvent =
+  | { kind: "single"; path: string }
+  | { kind: "broad" };
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TTL_MS = 30_000;
+const STAT_TIMEOUT_MS = 500;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Normalize a path to a canonical cache key: forward slashes, lowercase, no trailing slash. */
+function canonicalKey(p: string): string {
+  return p.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+}
+
+/** Returns true for UNC paths (\\server\share or //server/share). */
+function isLikelyNetworkPath(p: string): boolean {
+  return p.startsWith("\\\\") || p.startsWith("//");
+}
+
+/**
+ * Stat a path with a hard timeout.
+ * Resolves to: true=exists, false=missing, null=timed out (cache left unchanged).
+ */
+function statWithTimeout(p: string): Promise<boolean | null> {
+  return new Promise(resolve => {
+    let settled = false;
+    const t = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        resolve(null);
+      }
+    }, STAT_TIMEOUT_MS);
+
+    fs.stat(p, err => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(t);
+      resolve(err === null);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// PathExistenceCache
+// ---------------------------------------------------------------------------
+
+export class PathExistenceCache {
+  private readonly cache = new Map<string, ExistenceState>();
+  private readonly _onDidChange = new vscode.EventEmitter<CacheChangeEvent>();
+
+  /** Subscribe to cache change events. */
+  readonly onDidChange = this._onDidChange.event;
+
+  /**
+   * Test seam: inject a replacement for the real `statWithTimeout` so unit
+   * tests can verify refresh() behavior without hitting the filesystem.
+   * @internal — do not use in production code.
+   */
+  private _statForTest?: (p: string) => Promise<boolean | null>;
+
+  // -------------------------------------------------------------------------
+  // Read
+  // -------------------------------------------------------------------------
+
+  /**
+   * Synchronously read the current state of a path.
+   *
+   * - "exists"  — confirmed present within TTL
+   * - "missing" — confirmed absent; stale=true means TTL has elapsed but the
+   *               entry is intentionally retained (avoids v2 flicker)
+   * - "unknown" — never checked, or an "exists" entry whose TTL has lapsed
+   */
+  peek(p: string): PeekResult {
+    const e = this.cache.get(canonicalKey(p));
+    if (!e || e.kind === "unknown") return { kind: "unknown" };
+    const stale = Date.now() - e.checkedAt > TTL_MS;
+    if (e.kind === "missing") return { kind: "missing", stale };
+    // "exists": collapse to unknown when stale so the path gets re-checked
+    if (stale) return { kind: "unknown" };
+    return { kind: "exists" };
+  }
+
+  // -------------------------------------------------------------------------
+  // Write
+  // -------------------------------------------------------------------------
+
+  /** Record that a path exists and notify listeners. */
+  markPresent(p: string): void {
+    this.cache.set(canonicalKey(p), { kind: "exists", checkedAt: Date.now() });
+    this._onDidChange.fire({ kind: "single", path: p });
+  }
+
+  /** Record that a path is missing and notify listeners. */
+  markMissing(p: string): void {
+    this.cache.set(canonicalKey(p), { kind: "missing", checkedAt: Date.now() });
+    this._onDidChange.fire({ kind: "single", path: p });
+  }
+
+  /** Remove a path from the cache and notify listeners if the path was present. */
+  evict(p: string): void {
+    if (this.cache.delete(canonicalKey(p))) {
+      this._onDidChange.fire({ kind: "single", path: p });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Async refresh
+  // -------------------------------------------------------------------------
+
+  /**
+   * Stat a list of paths and update the cache.
+   *
+   * - UNC paths are skipped entirely (network share hangs).
+   * - Paths that time out leave the cache unchanged.
+   * - Fires a single "broad" event if any entry changed kind.
+   */
+  async refresh(paths: string[]): Promise<void> {
+    const stat = this._statForTest ?? statWithTimeout;
+    const toCheck = paths.filter(p => !isLikelyNetworkPath(p));
+    let anyChange = false;
+
+    for (const p of toCheck) {
+      const result = await stat(p);
+      if (result === null) continue; // timeout — leave cache alone
+      const key = canonicalKey(p);
+      const prev = this.cache.get(key);
+      const next: ExistenceState = result
+        ? { kind: "exists", checkedAt: Date.now() }
+        : { kind: "missing", checkedAt: Date.now() };
+      this.cache.set(key, next);
+      if (!prev || prev.kind !== next.kind) anyChange = true;
+    }
+
+    if (anyChange) this._onDidChange.fire({ kind: "broad" });
+  }
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  dispose(): void {
+    this._onDidChange.dispose();
+  }
+}

--- a/src/pathExistenceCache.ts
+++ b/src/pathExistenceCache.ts
@@ -133,7 +133,10 @@ export class PathExistenceCache {
     this._onDidChange.fire({ kind: "single", path: p });
   }
 
-  /** Remove a path from the cache and notify listeners if the path was present. */
+  /**
+   * Remove a path from the cache. Only fires `onDidChange` if the path was
+   * actually present (no spurious events for paths that were never tracked).
+   */
   evict(p: string): void {
     if (this.cache.delete(canonicalKey(p))) {
       this._onDidChange.fire({ kind: "single", path: p });

--- a/src/projectGrouping.ts
+++ b/src/projectGrouping.ts
@@ -79,6 +79,16 @@ function parseWorktreePath(p: string): { root: string; branch: string } | null {
 // ---------------------------------------------------------------------------
 
 /**
+ * True when `p` is a worktree path of the shape `<root>/.worktrees/<branch>`.
+ * Trailing separators are tolerated. Case-insensitive on the `.worktrees`
+ * segment to match the existing `parseWorktreePath` behavior.
+ */
+export function isWorktreePath(p: string): boolean {
+  const normalized = p.replace(/\\/g, "/").replace(/\/+$/, "");
+  return /\/\.worktrees\/[^/]+$/i.test(normalized);
+}
+
+/**
  * Group a flat list of items into project root + worktree-children buckets.
  *
  * @param items   Flat list of items to group.

--- a/src/quickPick.ts
+++ b/src/quickPick.ts
@@ -77,7 +77,10 @@ export async function showQuickPick(sessionManager: SessionManager): Promise<voi
       sessionManager.focusSession(session);
     }
   } else {
-    await sessionManager.launchSession(picked.folderPath);
+    const result = await sessionManager.launchSession(picked.folderPath);
+    if (!result.ok && result.reason === "missing") {
+      void vscode.window.showErrorMessage(result.message);
+    }
   }
 }
 

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -8,6 +8,24 @@ import { log, debugLog } from "./output";
 /** Prefix used for all Claude session terminal names */
 export const SESSION_NAME_PREFIX = "claude · ";
 
+/**
+ * Result returned by {@link SessionManager.launchSession}.
+ * - `ok: true` — session was created or reused successfully
+ * - `ok: false` — launch was refused; inspect `reason` and `message` for details
+ */
+export type LaunchResult =
+  | { ok: true; reused: boolean }
+  | { ok: false; reason: "missing" | "other"; message: string };
+
+/**
+ * Returns true for UNC paths (\\server\share) and forward-slash equivalents
+ * (//server/share). Sync fs.existsSync can hang on SMB timeouts for these
+ * paths, so the pre-flight existence check is skipped for them.
+ */
+function isLikelyNetworkPath(p: string): boolean {
+  return p.startsWith("\\\\") || p.startsWith("//");
+}
+
 const STATE_DIR = path.join(os.homedir(), ".claude", "session-state");
 
 interface SessionState {
@@ -72,24 +90,37 @@ export class SessionManager implements vscode.Disposable {
   /**
    * Launch a new Claude session in the given folder, or focus an existing one
    * if reuseExistingTerminal is enabled.
+   *
+   * Returns a {@link LaunchResult} describing the outcome. Callers that
+   * previously ignored the `void` return can continue to ignore `ok: true`;
+   * inspect `ok: false` to surface errors to the user.
    */
-  async launchSession(folderPath: string): Promise<void> {
+  async launchSession(folderPath: string): Promise<LaunchResult> {
     const normalized = path.normalize(folderPath);
 
     // Guard: refuse to create a terminal for a cwd that no longer exists on
     // disk.  This prevents VS Code from emitting "Starting directory does not
     // exist" errors when a stale _sessions entry (whose directory has since
     // been deleted or moved) is somehow passed here.
-    if (!fs.existsSync(normalized)) {
-      log(`[launch] skipping — cwd does not exist: ${normalized}`);
-      return;
+    //
+    // Skip the pre-flight for UNC paths — sync existsSync can hang on SMB
+    // timeouts for \\server\share paths, making the guard counterproductive.
+    if (!isLikelyNetworkPath(normalized)) {
+      if (!fs.existsSync(normalized)) {
+        log(`[launch] missing cwd: ${normalized}`);
+        return {
+          ok: false,
+          reason: "missing",
+          message: `Folder does not exist: ${normalized}`,
+        };
+      }
     }
 
     if (getReuseTerminal()) {
       const existing = this._findSessionByFolder(normalized);
       if (existing) {
         this.focusSession(existing);
-        return;
+        return { ok: true, reused: true };
       }
     }
 
@@ -109,6 +140,8 @@ export class SessionManager implements vscode.Disposable {
 
     // Dispatch the claude command only after the shell prompt is ready
     await this._dispatchClaudeCommand(terminal);
+
+    return { ok: true, reused: false };
   }
 
   /**

--- a/src/sessionManager.ts
+++ b/src/sessionManager.ts
@@ -107,7 +107,7 @@ export class SessionManager implements vscode.Disposable {
     // timeouts for \\server\share paths, making the guard counterproductive.
     if (!isLikelyNetworkPath(normalized)) {
       if (!fs.existsSync(normalized)) {
-        log(`[launch] missing cwd: ${normalized}`);
+        log(`[launch] skipping — cwd does not exist: ${normalized}`);
         return {
           ok: false,
           reason: "missing",

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -266,26 +266,14 @@ export class RecentProjectsProvider
 class FavoriteLeafItem extends vscode.TreeItem {
   readonly folderPath: string;
 
-  constructor(
-    folderPath: string,
-    isWorktreeChild: boolean,
-    state: { missing: boolean }
-  ) {
+  constructor(folderPath: string, state: { missing: boolean }) {
     super(path.basename(folderPath) || folderPath, vscode.TreeItemCollapsibleState.None);
     this.folderPath = folderPath;
     this.tooltip = state.missing
       ? "This folder is missing on disk. Click or press Enter to relocate; right-click for more options."
       : folderPath;
 
-    if (isWorktreeChild) {
-      this.contextValue = VIEW_ITEM.WORKTREE_CHILD;
-      this.iconPath = new vscode.ThemeIcon("folder");
-      this.command = {
-        command: "claudeConductor.openSession",
-        title: "Launch Session",
-        arguments: [folderPath],
-      };
-    } else if (state.missing) {
+    if (state.missing) {
       this.contextValue = VIEW_ITEM.PROJECT_ROOT_MISSING;
       this.description = "(missing)";
       this.iconPath = new vscode.ThemeIcon(
@@ -343,7 +331,7 @@ export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteTreeNo
       const peek = this.cache.peek(e.path);
       // Treat "unknown" as optimistic-present (e.g. UNC paths never get stat-checked).
       const missing = peek.kind === "missing";
-      return new FavoriteLeafItem(e.path, false, { missing });
+      return new FavoriteLeafItem(e.path, { missing });
     });
   }
 

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -29,15 +29,17 @@ export const VIEW_ITEM = {
 class ActiveGroupItem extends vscode.TreeItem {
   readonly group: ProjectGroup<ActiveSession>;
 
-  constructor(group: ProjectGroup<ActiveSession>) {
+  constructor(group: ProjectGroup<ActiveSession>, state: { favorited: boolean }) {
     const label = path.basename(group.root);
     super(label, vscode.TreeItemCollapsibleState.Collapsed);
     this.group = group;
 
     const count = group.children.length + (group.top !== null ? 1 : 0);
     this.description = `(${count})`;
-    // Folder icon — no command so click only expands/collapses.
     this.iconPath = new vscode.ThemeIcon("folder");
+    this.contextValue = state.favorited
+      ? VIEW_ITEM.PROJECT_ROOT_FAVORITED
+      : VIEW_ITEM.PROJECT_ROOT_UNFAVORITED;
     this.tooltip = group.root;
   }
 }
@@ -80,8 +82,12 @@ export class ActiveSessionsProvider
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
-  constructor(private readonly sessionManager: SessionManager) {
+  constructor(
+    private readonly sessionManager: SessionManager,
+    private readonly favoritesStore: FavoritesStore
+  ) {
     sessionManager.onDidChangeSessions(() => this._onDidChangeTreeData.fire());
+    favoritesStore.onDidChange(() => this._onDidChangeTreeData.fire());
   }
 
   getTreeItem(element: ActiveTreeNode): vscode.TreeItem {
@@ -107,7 +113,10 @@ export class ActiveSessionsProvider
     // Top level: return one group row per project root.
     const sessions = this.sessionManager.activeSessions;
     const groups = groupByProjectRoot(sessions, (s) => s.folderPath);
-    return groups.map((g) => new ActiveGroupItem(g));
+    return groups.map((g) => {
+      const fav = this.favoritesStore.isFavorited(g.root);
+      return new ActiveGroupItem(g, { favorited: fav });
+    });
   }
 
   refresh(): void {
@@ -131,7 +140,10 @@ export class ActiveSessionsProvider
 class RecentGroupItem extends vscode.TreeItem {
   readonly group: ProjectGroup<FolderEntry>;
 
-  constructor(group: ProjectGroup<FolderEntry>) {
+  constructor(
+    group: ProjectGroup<FolderEntry>,
+    state: { favorited: boolean; missing: boolean }
+  ) {
     const label = path.basename(group.root);
     super(label, vscode.TreeItemCollapsibleState.Collapsed);
     this.group = group;
@@ -139,15 +151,29 @@ class RecentGroupItem extends vscode.TreeItem {
     const count = group.children.length + (group.top !== null ? 1 : 0);
 
     if (group.isPhantom) {
+      // Phantom roots stay un-favoritable. No contextValue → no star menu.
+      // (We don't conflate "not in recents" with "favorite missing on disk".)
       this.description = `(${count}) (not in recents)`;
-      // Dimmed folder icon — signals that the root itself is not in Recent Projects.
       this.iconPath = new vscode.ThemeIcon(
         "folder",
         new vscode.ThemeColor("disabledForeground")
       );
+    } else if (state.missing && state.favorited) {
+      // Favorite whose root is missing on disk → projectRoot.missing
+      this.description = `(${count}) (missing)`;
+      this.iconPath = new vscode.ThemeIcon(
+        "folder",
+        new vscode.ThemeColor("disabledForeground")
+      );
+      this.contextValue = VIEW_ITEM.PROJECT_ROOT_MISSING;
+    } else if (state.favorited) {
+      this.description = `(${count})`;
+      this.iconPath = new vscode.ThemeIcon("folder");
+      this.contextValue = VIEW_ITEM.PROJECT_ROOT_FAVORITED;
     } else {
       this.description = `(${count})`;
       this.iconPath = new vscode.ThemeIcon("folder");
+      this.contextValue = VIEW_ITEM.PROJECT_ROOT_UNFAVORITED;
     }
 
     this.tooltip = group.root;
@@ -162,11 +188,7 @@ class RecentGroupItem extends vscode.TreeItem {
 class RecentProjectItem extends vscode.TreeItem {
   readonly folderPath: string;
 
-  constructor(
-    entry: FolderEntry,
-    isWorktreeChild: boolean,
-    state: { favorited: boolean; missing: boolean }
-  ) {
+  constructor(entry: FolderEntry, isWorktreeChild: boolean) {
     super(entry.name, vscode.TreeItemCollapsibleState.None);
     this.folderPath = entry.folderPath;
     this.description = isWorktreeChild
@@ -174,21 +196,7 @@ class RecentProjectItem extends vscode.TreeItem {
       : entry.parentDir;
     this.tooltip = `${entry.folderPath} (${entry.source})`;
     this.iconPath = new vscode.ThemeIcon("folder");
-
-    if (isWorktreeChild) {
-      this.contextValue = VIEW_ITEM.WORKTREE_CHILD;
-    } else if (state.missing) {
-      this.contextValue = VIEW_ITEM.PROJECT_ROOT_MISSING;
-      this.description = "(missing)";
-      this.iconPath = new vscode.ThemeIcon(
-        "folder",
-        new vscode.ThemeColor("disabledForeground")
-      );
-    } else if (state.favorited) {
-      this.contextValue = VIEW_ITEM.PROJECT_ROOT_FAVORITED;
-    } else {
-      this.contextValue = VIEW_ITEM.PROJECT_ROOT_UNFAVORITED;
-    }
+    this.contextValue = isWorktreeChild ? VIEW_ITEM.WORKTREE_CHILD : undefined;
 
     this.command = {
       command: "claudeConductor.openSession",
@@ -225,13 +233,10 @@ export class RecentProjectsProvider
       const { group } = element;
       const leaves: RecentProjectItem[] = [];
       if (group.top !== null) {
-        const fav = this.favoritesStore.isFavorited(group.top.folderPath);
-        const peek = this.existenceCache.peek(group.top.folderPath);
-        const missing = fav && peek.kind === "missing";  // only flag favorited rows as missing
-        leaves.push(new RecentProjectItem(group.top, false, { favorited: fav, missing }));
+        leaves.push(new RecentProjectItem(group.top, false));
       }
       for (const child of group.children) {
-        leaves.push(new RecentProjectItem(child, true, { favorited: false, missing: false }));
+        leaves.push(new RecentProjectItem(child, true));
       }
       return leaves;
     }
@@ -242,7 +247,13 @@ export class RecentProjectsProvider
     // Projects simultaneously.
     const folders = await getAllFolders();
     const groups = groupByProjectRoot(folders, (f) => f.folderPath);
-    return groups.map((g) => new RecentGroupItem(g));
+    return groups.map((g) => {
+      // For phantom groups, state is read but the constructor ignores it.
+      const fav = !g.isPhantom && this.favoritesStore.isFavorited(g.root);
+      const peek = this.existenceCache.peek(g.root);
+      const missing = fav && peek.kind === "missing";
+      return new RecentGroupItem(g, { favorited: fav, missing });
+    });
   }
 
   refresh(): void {

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -249,3 +249,107 @@ export class RecentProjectsProvider
     this._onDidChangeTreeData.fire(undefined);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Favorites — tree items
+// ---------------------------------------------------------------------------
+
+/**
+ * A single flat row in the Favorites panel.
+ *
+ * v1: favorites are rendered single-level (no nested worktree children).
+ * Worktree children of favorited project roots appear in Recent Projects only.
+ * Missing entries get a dimmed icon and a click-to-relocate command instead of
+ * the normal open-session command, so the user cannot accidentally launch a
+ * session for a path that no longer exists.
+ */
+class FavoriteLeafItem extends vscode.TreeItem {
+  readonly folderPath: string;
+
+  constructor(
+    folderPath: string,
+    isWorktreeChild: boolean,
+    state: { missing: boolean }
+  ) {
+    super(path.basename(folderPath) || folderPath, vscode.TreeItemCollapsibleState.None);
+    this.folderPath = folderPath;
+    this.tooltip = state.missing
+      ? "This folder is missing on disk. Click or press Enter to relocate; right-click for more options."
+      : folderPath;
+
+    if (isWorktreeChild) {
+      this.contextValue = VIEW_ITEM.WORKTREE_CHILD;
+      this.iconPath = new vscode.ThemeIcon("folder");
+      this.command = {
+        command: "claudeConductor.openSession",
+        title: "Launch Session",
+        arguments: [folderPath],
+      };
+    } else if (state.missing) {
+      this.contextValue = VIEW_ITEM.PROJECT_ROOT_MISSING;
+      this.description = "(missing)";
+      this.iconPath = new vscode.ThemeIcon(
+        "folder",
+        new vscode.ThemeColor("disabledForeground")
+      );
+      this.command = {
+        command: "claudeConductor.locateFavorite",
+        title: "Relocate Folder",
+        arguments: [folderPath],
+      };
+    } else {
+      this.contextValue = VIEW_ITEM.PROJECT_ROOT_FAVORITED;
+      this.iconPath = new vscode.ThemeIcon("folder");
+      this.command = {
+        command: "claudeConductor.openSession",
+        title: "Launch Session",
+        arguments: [folderPath],
+      };
+    }
+  }
+}
+
+type FavoriteTreeNode = FavoriteLeafItem;  // single-level for now
+
+export class FavoritesProvider implements vscode.TreeDataProvider<FavoriteTreeNode> {
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<FavoriteTreeNode | undefined | void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  constructor(
+    private readonly store: FavoritesStore,
+    private readonly cache: PathExistenceCache
+  ) {
+    store.onDidChange(() => this._onDidChangeTreeData.fire(undefined));
+    cache.onDidChange(() => this._onDidChangeTreeData.fire(undefined));
+  }
+
+  getTreeItem(el: FavoriteTreeNode): vscode.TreeItem { return el; }
+
+  async getChildren(_element?: FavoriteTreeNode): Promise<FavoriteTreeNode[]> {
+    // Single-level rendering: each favorite is a flat top-level row.
+    // Worktree children of favorited project roots are NOT nested here in v1
+    // (worktrees aren't stored in favorites). Recent Projects continues to
+    // show the nested view.
+    const entries = [...this.store.list()];
+
+    entries.sort((a, b) => {
+      const aName = path.basename(a.path).toLowerCase();
+      const bName = path.basename(b.path).toLowerCase();
+      if (aName !== bName) return aName.localeCompare(bName);
+      return a.path.toLowerCase().localeCompare(b.path.toLowerCase());
+    });
+
+    return entries.map(e => {
+      const peek = this.cache.peek(e.path);
+      // Treat "unknown" as optimistic-present (e.g. UNC paths never get stat-checked).
+      const missing = peek.kind === "missing";
+      return new FavoriteLeafItem(e.path, false, { missing });
+    });
+  }
+
+  /** Returns the over-cap banner string when storage drift exists; null otherwise. */
+  getOverCapBanner(): string | null {
+    if (!this.store.isOverCap()) return null;
+    return `Favorites: ${this.store.list().length} entries (over the 25 cap — consider removing some).`;
+  }
+}

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -3,6 +3,20 @@ import * as path from "path";
 import { SessionManager, ActiveSession } from "./sessionManager";
 import { getAllFolders, FolderEntry } from "./folderSource";
 import { groupByProjectRoot, ProjectGroup } from "./projectGrouping";
+import { FavoritesStore } from "./favoritesStore";
+import { PathExistenceCache } from "./pathExistenceCache";
+
+// ---------------------------------------------------------------------------
+// Shared contextValue tokens
+// ---------------------------------------------------------------------------
+
+export const VIEW_ITEM = {
+  PROJECT_ROOT_FAVORITED:   "projectRoot.favorited",
+  PROJECT_ROOT_UNFAVORITED: "projectRoot.unfavorited",
+  PROJECT_ROOT_MISSING:     "projectRoot.missing",
+  WORKTREE_CHILD:           "worktreeChild",
+  ACTIVE_SESSION:           "activeSession",
+} as const;
 
 // ---------------------------------------------------------------------------
 // Active Sessions — tree items
@@ -148,7 +162,11 @@ class RecentGroupItem extends vscode.TreeItem {
 class RecentProjectItem extends vscode.TreeItem {
   readonly folderPath: string;
 
-  constructor(entry: FolderEntry, isWorktreeChild: boolean) {
+  constructor(
+    entry: FolderEntry,
+    isWorktreeChild: boolean,
+    state: { favorited: boolean; missing: boolean }
+  ) {
     super(entry.name, vscode.TreeItemCollapsibleState.None);
     this.folderPath = entry.folderPath;
     this.description = isWorktreeChild
@@ -156,7 +174,22 @@ class RecentProjectItem extends vscode.TreeItem {
       : entry.parentDir;
     this.tooltip = `${entry.folderPath} (${entry.source})`;
     this.iconPath = new vscode.ThemeIcon("folder");
-    this.contextValue = "recentProject";
+
+    if (isWorktreeChild) {
+      this.contextValue = VIEW_ITEM.WORKTREE_CHILD;
+    } else if (state.missing) {
+      this.contextValue = VIEW_ITEM.PROJECT_ROOT_MISSING;
+      this.description = "(missing)";
+      this.iconPath = new vscode.ThemeIcon(
+        "folder",
+        new vscode.ThemeColor("disabledForeground")
+      );
+    } else if (state.favorited) {
+      this.contextValue = VIEW_ITEM.PROJECT_ROOT_FAVORITED;
+    } else {
+      this.contextValue = VIEW_ITEM.PROJECT_ROOT_UNFAVORITED;
+    }
+
     this.command = {
       command: "claudeConductor.openSession",
       title: "Launch Session",
@@ -170,11 +203,17 @@ type RecentTreeNode = RecentGroupItem | RecentProjectItem;
 export class RecentProjectsProvider
   implements vscode.TreeDataProvider<RecentTreeNode>
 {
-  private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<RecentTreeNode | undefined | void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
-  constructor(private readonly sessionManager: SessionManager) {
-    sessionManager.onDidChangeSessions(() => this._onDidChangeTreeData.fire());
+  constructor(
+    private readonly sessionManager: SessionManager,
+    private readonly favoritesStore: FavoritesStore,
+    private readonly existenceCache: PathExistenceCache
+  ) {
+    sessionManager.onDidChangeSessions(() => this._onDidChangeTreeData.fire(undefined));
+    favoritesStore.onDidChange(() => this._onDidChangeTreeData.fire(undefined));
+    existenceCache.onDidChange(() => this._onDidChangeTreeData.fire(undefined));
   }
 
   getTreeItem(element: RecentTreeNode): vscode.TreeItem {
@@ -183,14 +222,16 @@ export class RecentProjectsProvider
 
   async getChildren(element?: RecentTreeNode): Promise<RecentTreeNode[]> {
     if (element instanceof RecentGroupItem) {
-      // Return the leaves for this group.
       const { group } = element;
       const leaves: RecentProjectItem[] = [];
       if (group.top !== null) {
-        leaves.push(new RecentProjectItem(group.top, false));
+        const fav = this.favoritesStore.isFavorited(group.top.folderPath);
+        const peek = this.existenceCache.peek(group.top.folderPath);
+        const missing = fav && peek.kind === "missing";  // only flag favorited rows as missing
+        leaves.push(new RecentProjectItem(group.top, false, { favorited: fav, missing }));
       }
       for (const child of group.children) {
-        leaves.push(new RecentProjectItem(child, true));
+        leaves.push(new RecentProjectItem(child, true, { favorited: false, missing: false }));
       }
       return leaves;
     }
@@ -205,6 +246,6 @@ export class RecentProjectsProvider
   }
 
   refresh(): void {
-    this._onDidChangeTreeData.fire();
+    this._onDidChangeTreeData.fire(undefined);
   }
 }

--- a/test/favoritesProvider.test.ts
+++ b/test/favoritesProvider.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Memento } from "vscode";
+
+import { FavoritesStore } from "../src/favoritesStore";
+import { PathExistenceCache } from "../src/pathExistenceCache";
+import { FavoritesProvider, VIEW_ITEM } from "../src/treeView";
+
+function makeMemento(): Memento {
+  const data: Record<string, unknown> = {};
+  return {
+    keys: () => Object.keys(data),
+    get: <T>(k: string) => data[k] as T | undefined,
+    update: async (k: string, v: unknown) => { data[k] = v; },
+  } as unknown as Memento;
+}
+
+describe("FavoritesProvider", () => {
+  it("returns empty children when store has no entries", async () => {
+    const store = new FavoritesStore(makeMemento());
+    const cache = new PathExistenceCache();
+    const provider = new FavoritesProvider(store, cache);
+    expect(await provider.getChildren()).toEqual([]);
+  });
+
+  it("renders a single favorite as a top-level row with projectRoot.favorited contextValue", async () => {
+    const store = new FavoritesStore(makeMemento());
+    await store.add("C:/proj");
+    const cache = new PathExistenceCache();
+    cache.markPresent("C:/proj");
+
+    const provider = new FavoritesProvider(store, cache);
+    const top = await provider.getChildren();
+    expect(top).toHaveLength(1);
+    expect(top[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_FAVORITED);
+  });
+
+  it("renders alphabetically (basename, full-path tiebreak)", async () => {
+    const store = new FavoritesStore(makeMemento());
+    await store.add("C:/zzz");
+    await store.add("C:/aaa");
+    await store.add("C:/mmm");
+    const cache = new PathExistenceCache();
+    const provider = new FavoritesProvider(store, cache);
+
+    const top = await provider.getChildren();
+    expect(top.map(n => n.label)).toEqual(["aaa", "mmm", "zzz"]);
+  });
+
+  it("renders missing folder with (missing) description, dimmed icon, and locate command", async () => {
+    const store = new FavoritesStore(makeMemento());
+    await store.add("C:/missing");
+    const cache = new PathExistenceCache();
+    cache.markMissing("C:/missing");
+
+    const provider = new FavoritesProvider(store, cache);
+    const [row] = await provider.getChildren();
+
+    expect(row.description).toBe("(missing)");
+    expect(row.contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_MISSING);
+    expect(row.command).toEqual({
+      command: "claudeConductor.locateFavorite",
+      title: "Relocate Folder",
+      arguments: ["C:/missing"],
+    });
+  });
+
+  it("stale-missing renders identical to fresh-missing (no flicker regression)", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = new FavoritesStore(makeMemento());
+      await store.add("C:/missing");
+      const cache = new PathExistenceCache();
+      cache.markMissing("C:/missing");
+      vi.advanceTimersByTime(31_000);
+
+      const provider = new FavoritesProvider(store, cache);
+      const [row] = await provider.getChildren();
+      expect(row.description).toBe("(missing)");
+      expect(row.contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_MISSING);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("optimistic-present on UNC paths (cache returns unknown)", async () => {
+    const store = new FavoritesStore(makeMemento());
+    await store.add("\\\\server\\share\\foo");
+    const cache = new PathExistenceCache();
+
+    const provider = new FavoritesProvider(store, cache);
+    const [row] = await provider.getChildren();
+    expect(row.description).not.toBe("(missing)");
+    expect(row.contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_FAVORITED);
+  });
+
+  it("renders all entries when storage drifts >25; getOverCapBanner returns banner string", async () => {
+    const m = makeMemento();
+    const seed = Array.from({ length: 30 }, (_, i) => ({ path: `C:/p${String(i).padStart(2, "0")}` }));
+    await m.update("claudeConductor.favorites", { version: 2, entries: seed });
+
+    const store = new FavoritesStore(m);
+    const cache = new PathExistenceCache();
+    const provider = new FavoritesProvider(store, cache);
+
+    const top = await provider.getChildren();
+    expect(top).toHaveLength(30);
+    expect(provider.getOverCapBanner()).toMatch(/over the 25 cap/i);
+  });
+
+  it("addFavorite past cap: store rejects, provider state unchanged", async () => {
+    const store = new FavoritesStore(makeMemento());
+    for (let i = 0; i < 25; i++) await store.add(`C:/p${i}`);
+    const cache = new PathExistenceCache();
+    const provider = new FavoritesProvider(store, cache);
+
+    const r = await store.add("C:/over");
+    expect(r.ok).toBe(false);
+
+    const top = await provider.getChildren();
+    expect(top).toHaveLength(25);
+  });
+});

--- a/test/favoritesProvider.test.ts
+++ b/test/favoritesProvider.test.ts
@@ -46,6 +46,21 @@ describe("FavoritesProvider", () => {
     expect(top.map(n => n.label)).toEqual(["aaa", "mmm", "zzz"]);
   });
 
+  it("alphabetical sort tiebreak: identical basenames sort by full path", async () => {
+    const store = new FavoritesStore(makeMemento());
+    await store.add("D:/zebra/aaa");
+    await store.add("C:/alpha/aaa");
+    const cache = new PathExistenceCache();
+    const provider = new FavoritesProvider(store, cache);
+
+    const top = await provider.getChildren();
+    expect(top).toHaveLength(2);
+    // Both rows have label "aaa"; their order is determined by the full-path tiebreak.
+    // Lowercased full-path comparison: "c:/alpha/aaa" < "d:/zebra/aaa".
+    expect((top[0] as { folderPath: string }).folderPath).toBe("C:/alpha/aaa");
+    expect((top[1] as { folderPath: string }).folderPath).toBe("D:/zebra/aaa");
+  });
+
   it("renders missing folder with (missing) description, dimmed icon, and locate command", async () => {
     const store = new FavoritesStore(makeMemento());
     await store.add("C:/missing");
@@ -104,7 +119,7 @@ describe("FavoritesProvider", () => {
 
     const top = await provider.getChildren();
     expect(top).toHaveLength(30);
-    expect(provider.getOverCapBanner()).toMatch(/over the 25 cap/i);
+    expect(provider.getOverCapBanner()).toMatch(/over the 25 cap.*consider removing/i);
   });
 
   it("addFavorite past cap: store rejects, provider state unchanged", async () => {

--- a/test/favoritesStore.test.ts
+++ b/test/favoritesStore.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Memento } from "vscode";
+import { FavoritesStore, MAX_FAVORITES } from "../src/favoritesStore";
+
+function makeMemento(initial?: unknown): Memento & { _data: Record<string, unknown>; updateCalls: unknown[] } {
+  const data: Record<string, unknown> = {};
+  if (initial !== undefined) data["claudeConductor.favorites"] = initial;
+  const calls: unknown[] = [];
+  const m = {
+    _data: data,
+    updateCalls: calls,
+    keys: () => Object.keys(data),
+    get: <T>(key: string) => data[key] as T | undefined,
+    update: vi.fn(async (key: string, value: unknown) => {
+      calls.push({ key, value });
+      data[key] = value;
+    }),
+  };
+  return m as unknown as Memento & { _data: Record<string, unknown>; updateCalls: unknown[] };
+}
+
+describe("FavoritesStore", () => {
+  it("isFavorited returns false for empty store", () => {
+    const s = new FavoritesStore(makeMemento());
+    expect(s.isFavorited("C:/x")).toBe(false);
+  });
+
+  it("add, then isFavorited returns true (synchronous read after async add)", async () => {
+    const s = new FavoritesStore(makeMemento());
+    await s.add("C:/proj");
+    expect(s.isFavorited("C:/proj")).toBe(true);
+  });
+
+  it("canonical-key dedup: two case-different paths collapse to one entry", async () => {
+    const s = new FavoritesStore(makeMemento());
+    await s.add("C:\\Foo");
+    await s.add("c:/foo/");
+    expect(s.list()).toEqual([{ path: "C:\\Foo" }]);
+  });
+
+  it("rejects worktree paths", async () => {
+    const s = new FavoritesStore(makeMemento());
+    const r = await s.add("C:/proj/.worktrees/fix");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/worktree/i);
+    expect(s.list()).toEqual([]);
+  });
+
+  it("rejects past 25-entry cap", async () => {
+    const s = new FavoritesStore(makeMemento());
+    for (let i = 0; i < MAX_FAVORITES; i++) await s.add(`C:/p${i}`);
+    const r = await s.add(`C:/over`);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/cap/i);
+    expect(s.list()).toHaveLength(MAX_FAVORITES);
+  });
+
+  it("relocate to canonical-equal path is a no-op with reason 'same-path'", async () => {
+    const s = new FavoritesStore(makeMemento());
+    await s.add("C:/Foo");
+    const r = await s.relocate("C:/Foo", "c:\\foo\\");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/same/i);
+    expect(s.list()).toEqual([{ path: "C:/Foo" }]);
+  });
+
+  it("relocate to a different existing entry drops the old, fires broad event", async () => {
+    const s = new FavoritesStore(makeMemento());
+    await s.add("C:/A");
+    await s.add("C:/B");
+
+    const events: unknown[] = [];
+    s.onDidChange(e => events.push(e));
+
+    const r = await s.relocate("C:/A", "C:/B");
+    expect(r.ok).toBe(true);
+    expect(s.list()).toEqual([{ path: "C:/B" }]);
+    expect(events).toContainEqual({ kind: "broad" });
+  });
+
+  it("relocate to a brand-new path replaces entry path; fires single-path event", async () => {
+    const s = new FavoritesStore(makeMemento());
+    await s.add("C:/Old");
+
+    const events: unknown[] = [];
+    s.onDidChange(e => events.push(e));
+
+    const r = await s.relocate("C:/Old", "C:/New");
+    expect(r.ok).toBe(true);
+    expect(s.list()).toEqual([{ path: "C:/New" }]);
+    expect(events.some(e => (e as { kind: string }).kind === "single")).toBe(true);
+  });
+
+  it("v1 string[] storage is read but not written until first mutation (deferred migration)", async () => {
+    const m = makeMemento(["C:/legacy1", "C:/legacy2"]);
+    const s = new FavoritesStore(m);
+    expect(s.list()).toEqual([{ path: "C:/legacy1" }, { path: "C:/legacy2" }]);
+    expect(m.updateCalls).toEqual([]);
+
+    await s.add("C:/new");
+    expect(m.updateCalls).toHaveLength(1);
+    const written = (m.updateCalls[0] as { value: unknown }).value as { version: number; entries: unknown[] };
+    expect(written.version).toBe(2);
+    expect(written.entries).toHaveLength(3);
+  });
+
+  it("future-version envelope renders best-effort, blocks writes", async () => {
+    const m = makeMemento({ version: 99, entries: [{ path: "C:/futureA" }] });
+    const s = new FavoritesStore(m);
+    expect(s.list()).toEqual([{ path: "C:/futureA" }]);
+
+    const r = await s.add("C:/blocked");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/version/i);
+    expect(s.list()).toEqual([{ path: "C:/futureA" }]);
+  });
+
+  it("persist failure rolls back exactly one mutation (await-prior contract)", async () => {
+    const m = makeMemento();
+    let callCount = 0;
+    m.update = vi.fn(async () => {
+      callCount++;
+      if (callCount === 1) throw new Error("simulated persist failure");
+    });
+
+    const s = new FavoritesStore(m);
+
+    await s.add("C:/A").catch(() => undefined);
+    await s.waitForIdle();
+    expect(s.list()).toEqual([]);
+
+    await s.add("C:/B");
+    expect(s.list()).toEqual([{ path: "C:/B" }]);
+  });
+
+  it("apply throw is contained: state unchanged, no event fired", async () => {
+    const s = new FavoritesStore(makeMemento());
+    await s.add("C:/seed");
+    const eventsBefore: unknown[] = [];
+    s.onDidChange(e => eventsBefore.push(e));
+
+    await expect(
+      s._enqueueMutationForTest(() => { throw new Error("boom"); }, { kind: "broad" })
+    ).rejects.toThrow("boom");
+
+    expect(s.list()).toEqual([{ path: "C:/seed" }]);
+    expect(eventsBefore).toEqual([]);
+  });
+});

--- a/test/packageJsonContextKeys.test.ts
+++ b/test/packageJsonContextKeys.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { VIEW_ITEM } from "../src/treeView";
+
+interface Menu {
+  command?: string;
+  when?: string;
+  group?: string;
+}
+
+const PKG_PATH = path.join(__dirname, "..", "package.json");
+const pkg = JSON.parse(fs.readFileSync(PKG_PATH, "utf8")) as {
+  contributes?: { menus?: { "view/item/context"?: Menu[] } };
+};
+
+const clauses = pkg.contributes?.menus?.["view/item/context"] ?? [];
+const allWhen = clauses.map(c => c.when ?? "").filter(Boolean);
+
+const VIEW_ITEM_VALUES = Object.values(VIEW_ITEM) as string[];
+
+/** Extract every `viewItem == "X"` literal token from a when string. */
+function extractEqLiterals(when: string): string[] {
+  const re = /viewItem\s*==\s*([A-Za-z][A-Za-z0-9._-]*)/g;
+  const out: string[] = [];
+  let m;
+  while ((m = re.exec(when)) !== null) out.push(m[1]);
+  return out;
+}
+
+/** Extract every `viewItem =~ /pattern/flags?` regex (compiled as RegExp) from a when string. */
+function extractRegexes(when: string): RegExp[] {
+  // Match: viewItem =~ /escaped/flags?
+  const re = /viewItem\s*=~\s*\/((?:\\\/|[^/])+)\/([gimsuy]*)/g;
+  const out: RegExp[] = [];
+  let m;
+  while ((m = re.exec(when)) !== null) {
+    // package.json stores `\\.` for a regex literal-dot. After JSON.parse the
+    // string already contains a single `\.` — no further unescaping needed.
+    out.push(new RegExp(m[1], m[2]));
+  }
+  return out;
+}
+
+const NEGATIVE_FIXTURES = [
+  "projectRootSomething",       // missing dot separator
+  "projectRoot",                // missing state suffix
+  "myprojectRoot.favorited",    // prefix
+  "projectRoot.favoritedExtra", // suffix beyond a state token
+  "recentProject",              // legacy un-migrated value — should NOT match the migrated regex
+  "xyzactiveSession",
+  "activeSessionFoo",
+];
+
+describe("package.json viewItem ↔ VIEW_ITEM bidirectional bijection", () => {
+  it("every `viewItem == X` literal references a VIEW_ITEM value", () => {
+    const literals = allWhen.flatMap(extractEqLiterals);
+    expect(literals.length).toBeGreaterThan(0);  // sanity: some `==` clauses exist
+    for (const lit of literals) {
+      expect(VIEW_ITEM_VALUES).toContain(lit);
+    }
+  });
+
+  it("every `viewItem =~ /pattern/` matches at least one VIEW_ITEM value", () => {
+    const regexes = allWhen.flatMap(extractRegexes);
+    for (const re of regexes) {
+      const matched = VIEW_ITEM_VALUES.some(v => re.test(v));
+      expect(matched, `regex ${re.source} matched no VIEW_ITEM value`).toBe(true);
+    }
+  });
+
+  it("every VIEW_ITEM value is referenced by at least one menu clause", () => {
+    const literals = allWhen.flatMap(extractEqLiterals);
+    const regexes = allWhen.flatMap(extractRegexes);
+    for (const value of VIEW_ITEM_VALUES) {
+      const referenced =
+        literals.includes(value) ||
+        regexes.some(re => re.test(value));
+      expect(
+        referenced,
+        `VIEW_ITEM value '${value}' is orphaned (no menu clause references it)`
+      ).toBe(true);
+    }
+  });
+
+  it("regexes do not match negative-fixture sibling tokens", () => {
+    const regexes = allWhen.flatMap(extractRegexes);
+    for (const re of regexes) {
+      for (const neg of NEGATIVE_FIXTURES) {
+        expect(
+          re.test(neg),
+          `regex ${re.source} unexpectedly matched negative fixture '${neg}'`
+        ).toBe(false);
+      }
+    }
+  });
+});

--- a/test/pathExistenceCache.test.ts
+++ b/test/pathExistenceCache.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PathExistenceCache } from "../src/pathExistenceCache";
+
+describe("PathExistenceCache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("peek returns unknown for an unseen path", () => {
+    const cache = new PathExistenceCache();
+    expect(cache.peek("C:/x")).toEqual({ kind: "unknown" });
+  });
+
+  it("markPresent flips state and fires single-path event", () => {
+    const cache = new PathExistenceCache();
+    const events: unknown[] = [];
+    cache.onDidChange(e => events.push(e));
+
+    cache.markPresent("C:/x");
+
+    expect(cache.peek("C:/x")).toEqual({ kind: "exists" });
+    expect(events).toEqual([{ kind: "single", path: "C:/x" }]);
+  });
+
+  it("markMissing flips state and fires single-path event", () => {
+    const cache = new PathExistenceCache();
+    cache.markMissing("C:/x");
+    expect(cache.peek("C:/x")).toEqual({ kind: "missing", stale: false });
+  });
+
+  it("missing entries report stale=true after TTL but never collapse to unknown (v2 flicker regression)", () => {
+    const cache = new PathExistenceCache();
+    cache.markMissing("C:/x");
+    vi.advanceTimersByTime(31_000);  // > 30s TTL
+    expect(cache.peek("C:/x")).toEqual({ kind: "missing", stale: true });
+  });
+
+  it("exists entries collapse to unknown after TTL", () => {
+    const cache = new PathExistenceCache();
+    cache.markPresent("C:/x");
+    vi.advanceTimersByTime(31_000);
+    expect(cache.peek("C:/x")).toEqual({ kind: "unknown" });
+  });
+
+  it("markPresent after markMissing unsticks the entry (v3 stuck-missing regression)", () => {
+    const cache = new PathExistenceCache();
+    cache.markMissing("C:/x");
+    expect(cache.peek("C:/x")).toEqual({ kind: "missing", stale: false });
+    cache.markPresent("C:/x");
+    expect(cache.peek("C:/x")).toEqual({ kind: "exists" });
+  });
+
+  it("evict removes the entry", () => {
+    const cache = new PathExistenceCache();
+    cache.markPresent("C:/x");
+    cache.evict("C:/x");
+    expect(cache.peek("C:/x")).toEqual({ kind: "unknown" });
+  });
+
+  it("canonical-key matching: case and separator insensitive", () => {
+    const cache = new PathExistenceCache();
+    cache.markPresent("C:\\Foo");
+    expect(cache.peek("c:/foo")).toEqual({ kind: "exists" });
+    expect(cache.peek("C:\\Foo\\")).toEqual({ kind: "exists" });
+  });
+
+  it("refresh skips UNC paths (\\\\server\\share style)", async () => {
+    const cache = new PathExistenceCache();
+    const statSpy = vi.fn();
+    // Inject stat for testability:
+    (cache as unknown as { _statForTest: typeof statSpy })._statForTest = statSpy;
+
+    await cache.refresh(["\\\\server\\share\\foo", "//server/share/bar"]);
+
+    expect(statSpy).not.toHaveBeenCalled();
+    expect(cache.peek("\\\\server\\share\\foo")).toEqual({ kind: "unknown" });
+  });
+});

--- a/test/projectGrouping.test.ts
+++ b/test/projectGrouping.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { groupByProjectRoot } from "../src/projectGrouping";
+import { groupByProjectRoot, isWorktreePath } from "../src/projectGrouping";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -173,5 +173,42 @@ describe("groupByProjectRoot — not-a-worktree edge cases", () => {
     const rootGroup = groups.find((g) => g.root === root);
     // The .worktrees dir itself should NOT be counted as a child worktree
     expect(rootGroup!.children).not.toContain(worktreesDir);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isWorktreePath
+// ---------------------------------------------------------------------------
+
+describe("isWorktreePath", () => {
+  it("matches a basic .worktrees branch path with forward slashes", () => {
+    expect(isWorktreePath("C:/proj/.worktrees/fix-bug")).toBe(true);
+  });
+
+  it("matches a path with backslashes (Windows native)", () => {
+    expect(isWorktreePath("C:\\proj\\.worktrees\\fix-bug")).toBe(true);
+  });
+
+  it("matches a path with a trailing separator (regression for v3 raw-input gap)", () => {
+    expect(isWorktreePath("C:\\proj\\.worktrees\\fix-bug\\")).toBe(true);
+    expect(isWorktreePath("C:/proj/.worktrees/fix-bug/")).toBe(true);
+  });
+
+  it("rejects a project root (no .worktrees segment)", () => {
+    expect(isWorktreePath("C:\\proj")).toBe(false);
+    expect(isWorktreePath("/home/user/proj")).toBe(false);
+  });
+
+  it("rejects a .worktrees directory itself with no branch segment", () => {
+    expect(isWorktreePath("C:/proj/.worktrees")).toBe(false);
+    expect(isWorktreePath("C:/proj/.worktrees/")).toBe(false);
+  });
+
+  it("rejects a nested path beneath a worktree (more than one segment under .worktrees)", () => {
+    expect(isWorktreePath("C:/proj/.worktrees/fix-bug/src")).toBe(false);
+  });
+
+  it("is case-insensitive on the .worktrees segment", () => {
+    expect(isWorktreePath("C:/proj/.WorkTrees/branch")).toBe(true);
   });
 });

--- a/test/sessionManager.launchResult.test.ts
+++ b/test/sessionManager.launchResult.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+
+// Must use vi.mock("fs") — the same pattern as addFolderPrompt.stale.test.ts —
+// because ESM module namespaces are not reconfigurable via vi.spyOn.
+vi.mock("fs");
+
+vi.mock("vscode", async () => {
+  const m = await import("./mocks/vscode");
+  return m;
+});
+
+import { SessionManager } from "../src/sessionManager";
+
+describe("launchSession LaunchResult", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    // Default: fs.existsSync returns true (path exists), readdirSync returns
+    // empty array (no session-state files to process during cleanup).
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readdirSync).mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns {ok:false, reason:'missing'} for a non-UNC path that doesn't exist", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    const sm = new SessionManager();
+    const r = await sm.launchSession("C:/no/such/path");
+    expect(r).toEqual(expect.objectContaining({ ok: false, reason: "missing" }));
+    sm.dispose();
+  });
+
+  it("returns {ok:true} for a path that exists", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const sm = new SessionManager();
+    const r = await sm.launchSession("C:/exists");
+    expect(r.ok).toBe(true);
+    sm.dispose();
+  });
+
+  it("skips fs.existsSync pre-flight for UNC paths", async () => {
+    // existsSync returns false — but for UNC paths we should skip the check
+    // and still succeed.
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    const sm = new SessionManager();
+    const r = await sm.launchSession("\\\\server\\share\\foo");
+    // existsSync should not have been called for the UNC path itself
+    expect(vi.mocked(fs.existsSync)).not.toHaveBeenCalledWith(
+      expect.stringMatching(/^\\\\server/)
+    );
+    expect(r.ok).toBe(true);
+    sm.dispose();
+  });
+});

--- a/test/treeView.test.ts
+++ b/test/treeView.test.ts
@@ -13,6 +13,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ActiveSession } from "../src/sessionManager";
 import type { FolderEntry } from "../src/folderSource";
+import type { FavoritesStore } from "../src/favoritesStore";
+import type { PathExistenceCache } from "../src/pathExistenceCache";
 
 // ---------------------------------------------------------------------------
 // Minimal stubs — keep them local so this test file is self-contained.
@@ -62,6 +64,36 @@ function makeSessionManager(sessions: ActiveSession[]) {
 }
 
 // ---------------------------------------------------------------------------
+// Minimal FavoritesStore and PathExistenceCache stubs
+// ---------------------------------------------------------------------------
+
+function makeFakeFavoritesStore(): FavoritesStore {
+  return {
+    isFavorited: () => false,
+    list: () => [],
+    isOverCap: () => false,
+    onDidChange: () => ({ dispose: () => {} }),
+    add: async () => ({ ok: true }),
+    remove: async () => undefined,
+    relocate: async () => ({ ok: true }),
+    waitForIdle: async () => undefined,
+    dispose: () => {},
+  } as unknown as FavoritesStore;
+}
+
+function makeFakeExistenceCache(): PathExistenceCache {
+  return {
+    peek: () => ({ kind: "unknown" } as const),
+    markPresent: () => {},
+    markMissing: () => {},
+    evict: () => {},
+    refresh: async () => {},
+    onDidChange: () => ({ dispose: () => {} }),
+    dispose: () => {},
+  } as unknown as PathExistenceCache;
+}
+
+// ---------------------------------------------------------------------------
 // Import providers under test (after vi.mock declarations)
 // ---------------------------------------------------------------------------
 
@@ -70,7 +102,7 @@ vi.mock("../src/folderSource", () => ({
   getAllFolders: vi.fn(),
 }));
 
-import { ActiveSessionsProvider, RecentProjectsProvider } from "../src/treeView";
+import { ActiveSessionsProvider, RecentProjectsProvider, VIEW_ITEM } from "../src/treeView";
 import { getAllFolders } from "../src/folderSource";
 import {
   TreeItemCollapsibleState,
@@ -184,7 +216,7 @@ describe("RecentProjectsProvider — grouped tree", () => {
   it("getChildren(undefined) returns group items when folders include worktrees", async () => {
     vi.mocked(getAllFolders).mockResolvedValue([makeFolder(root), makeFolder(wt1)]);
     const mgr = makeSessionManager([]);
-    const provider = new RecentProjectsProvider(mgr as never);
+    const provider = new RecentProjectsProvider(mgr as never, makeFakeFavoritesStore(), makeFakeExistenceCache());
 
     const topLevel = await provider.getChildren(undefined);
 
@@ -195,7 +227,7 @@ describe("RecentProjectsProvider — grouped tree", () => {
   it("getChildren(groupItem) returns the group's folder leaf items", async () => {
     vi.mocked(getAllFolders).mockResolvedValue([makeFolder(root), makeFolder(wt1)]);
     const mgr = makeSessionManager([]);
-    const provider = new RecentProjectsProvider(mgr as never);
+    const provider = new RecentProjectsProvider(mgr as never, makeFakeFavoritesStore(), makeFakeExistenceCache());
 
     const topLevel = await provider.getChildren(undefined);
     const children = await provider.getChildren(topLevel[0]);
@@ -209,7 +241,7 @@ describe("RecentProjectsProvider — grouped tree", () => {
   it("child count appears in group description for non-phantom root", async () => {
     vi.mocked(getAllFolders).mockResolvedValue([makeFolder(root), makeFolder(wt1)]);
     const mgr = makeSessionManager([]);
-    const provider = new RecentProjectsProvider(mgr as never);
+    const provider = new RecentProjectsProvider(mgr as never, makeFakeFavoritesStore(), makeFakeExistenceCache());
 
     const topLevel = await provider.getChildren(undefined);
 
@@ -220,7 +252,7 @@ describe("RecentProjectsProvider — grouped tree", () => {
     // Only the worktree is in recents — the root itself is absent
     vi.mocked(getAllFolders).mockResolvedValue([makeFolder(wt1)]);
     const mgr = makeSessionManager([]);
-    const provider = new RecentProjectsProvider(mgr as never);
+    const provider = new RecentProjectsProvider(mgr as never, makeFakeFavoritesStore(), makeFakeExistenceCache());
 
     const topLevel = await provider.getChildren(undefined);
 
@@ -231,7 +263,7 @@ describe("RecentProjectsProvider — grouped tree", () => {
   it("phantom root has a dimmed icon", async () => {
     vi.mocked(getAllFolders).mockResolvedValue([makeFolder(wt1)]);
     const mgr = makeSessionManager([]);
-    const provider = new RecentProjectsProvider(mgr as never);
+    const provider = new RecentProjectsProvider(mgr as never, makeFakeFavoritesStore(), makeFakeExistenceCache());
 
     const topLevel = await provider.getChildren(undefined);
     const icon = topLevel[0].iconPath as ThemeIcon;
@@ -247,7 +279,7 @@ describe("RecentProjectsProvider — grouped tree", () => {
     // After this change, the same path may appear in both panels.
     vi.mocked(getAllFolders).mockResolvedValue([makeFolder(root)]);
     const mgr = makeSessionManager([makeSession(root)]);
-    const provider = new RecentProjectsProvider(mgr as never);
+    const provider = new RecentProjectsProvider(mgr as never, makeFakeFavoritesStore(), makeFakeExistenceCache());
 
     const topLevel = await provider.getChildren(undefined);
 
@@ -265,9 +297,23 @@ describe("RecentProjectsProvider — grouped tree", () => {
     const rootB = "/home/user/project-b";
     vi.mocked(getAllFolders).mockResolvedValue([makeFolder(root), makeFolder(rootB)]);
     const mgr = makeSessionManager([]);
-    const provider = new RecentProjectsProvider(mgr as never);
+    const provider = new RecentProjectsProvider(mgr as never, makeFakeFavoritesStore(), makeFakeExistenceCache());
 
     const topLevel = await provider.getChildren(undefined);
     expect(topLevel).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// VIEW_ITEM constants
+// ---------------------------------------------------------------------------
+
+describe("VIEW_ITEM constants", () => {
+  it("has all required tokens", () => {
+    expect(VIEW_ITEM.PROJECT_ROOT_FAVORITED).toBe("projectRoot.favorited");
+    expect(VIEW_ITEM.PROJECT_ROOT_UNFAVORITED).toBe("projectRoot.unfavorited");
+    expect(VIEW_ITEM.PROJECT_ROOT_MISSING).toBe("projectRoot.missing");
+    expect(VIEW_ITEM.WORKTREE_CHILD).toBe("worktreeChild");
+    expect(VIEW_ITEM.ACTIVE_SESSION).toBe("activeSession");
   });
 });

--- a/test/treeView.test.ts
+++ b/test/treeView.test.ts
@@ -13,8 +13,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ActiveSession } from "../src/sessionManager";
 import type { FolderEntry } from "../src/folderSource";
-import type { FavoritesStore } from "../src/favoritesStore";
-import type { PathExistenceCache } from "../src/pathExistenceCache";
+import type { FavoritesStore as FavoritesStoreType } from "../src/favoritesStore";
+import { FavoritesStore } from "../src/favoritesStore";
+import type { PathExistenceCache as PathExistenceCacheType } from "../src/pathExistenceCache";
+import { PathExistenceCache } from "../src/pathExistenceCache";
 
 // ---------------------------------------------------------------------------
 // Minimal stubs — keep them local so this test file is self-contained.
@@ -67,7 +69,7 @@ function makeSessionManager(sessions: ActiveSession[]) {
 // Minimal FavoritesStore and PathExistenceCache stubs
 // ---------------------------------------------------------------------------
 
-function makeFakeFavoritesStore(): FavoritesStore {
+function makeFakeFavoritesStore(): FavoritesStoreType {
   return {
     isFavorited: () => false,
     list: () => [],
@@ -81,7 +83,7 @@ function makeFakeFavoritesStore(): FavoritesStore {
   } as unknown as FavoritesStore;
 }
 
-function makeFakeExistenceCache(): PathExistenceCache {
+function makeFakeExistenceCache(): PathExistenceCacheType {
   return {
     peek: () => ({ kind: "unknown" } as const),
     markPresent: () => {},
@@ -315,5 +317,74 @@ describe("VIEW_ITEM constants", () => {
     expect(VIEW_ITEM.PROJECT_ROOT_MISSING).toBe("projectRoot.missing");
     expect(VIEW_ITEM.WORKTREE_CHILD).toBe("worktreeChild");
     expect(VIEW_ITEM.ACTIVE_SESSION).toBe("activeSession");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-panel star coupling + race regression
+// ---------------------------------------------------------------------------
+
+describe("Cross-panel star coupling", () => {
+  function makeRealMemento(): import("vscode").Memento {
+    const data: Record<string, unknown> = {};
+    return {
+      keys: () => Object.keys(data),
+      get: <T>(k: string) => data[k] as T | undefined,
+      update: async (k: string, v: unknown) => { data[k] = v; },
+    } as unknown as import("vscode").Memento;
+  }
+
+  it("Recent Projects row reflects favorited state immediately after store.add", async () => {
+    const store = new FavoritesStore(makeRealMemento());
+    const cache = new PathExistenceCache();
+    const sm = makeSessionManager([]);
+
+    vi.mocked(getAllFolders).mockResolvedValue([
+      { folderPath: "C:/proj", name: "proj", parentDir: "C:", source: "recent" as const },
+    ]);
+
+    const provider = new RecentProjectsProvider(sm as never, store, cache);
+
+    // Before add: contextValue should be unfavorited
+    const groupsBefore = await provider.getChildren();
+    const leavesBefore = await provider.getChildren(groupsBefore[0]);
+    expect(leavesBefore[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_UNFAVORITED);
+
+    await store.add("C:/proj");
+
+    // After add: contextValue is favorited
+    const groupsAfter = await provider.getChildren();
+    const leavesAfter = await provider.getChildren(groupsAfter[0]);
+    expect(leavesAfter[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_FAVORITED);
+  });
+
+  it("regression: leaf items reflect live store state, not a stale snapshot", async () => {
+    // Simulates the v1-blocker race: provider's getChildren(group) is called
+    // AFTER getAllFolders() resolved, so the leaf-item construction reads the
+    // store synchronously at construction time. If a mutation lands between
+    // getAllFolders() resolving and getChildren(group) running, the new state
+    // must be reflected.
+    const store = new FavoritesStore(makeRealMemento());
+    const cache = new PathExistenceCache();
+    const sm = makeSessionManager([]);
+
+    vi.mocked(getAllFolders).mockResolvedValue([
+      { folderPath: "C:/proj", name: "proj", parentDir: "C:", source: "recent" as const },
+    ]);
+
+    const provider = new RecentProjectsProvider(sm as never, store, cache);
+
+    // Step 1: fetch top-level groups (this is where getAllFolders is awaited)
+    const groups = await provider.getChildren();
+    expect(groups).toHaveLength(1);
+
+    // Step 2: mutate the store BEFORE asking for the group's leaves.
+    // The leaf construction is synchronous and reads `store.isFavorited()`
+    // at that moment.
+    await store.add("C:/proj");
+
+    // Step 3: now ask for leaves. They MUST reflect the latest store state.
+    const leaves = await provider.getChildren(groups[0]);
+    expect(leaves[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_FAVORITED);
   });
 });

--- a/test/treeView.test.ts
+++ b/test/treeView.test.ts
@@ -124,7 +124,7 @@ describe("ActiveSessionsProvider — grouped tree", () => {
   it("getChildren(undefined) returns group-level items (not flat sessions)", () => {
     const sessions = [makeSession(root), makeSession(wt1), makeSession(wt2)];
     const mgr = makeSessionManager(sessions);
-    const provider = new ActiveSessionsProvider(mgr as never);
+    const provider = new ActiveSessionsProvider(mgr as never, makeFakeFavoritesStore());
 
     const topLevel = provider.getChildren(undefined);
 
@@ -137,7 +137,7 @@ describe("ActiveSessionsProvider — grouped tree", () => {
   it("getChildren(groupItem) returns the group's session leaf items", () => {
     const sessions = [makeSession(root), makeSession(wt1), makeSession(wt2)];
     const mgr = makeSessionManager(sessions);
-    const provider = new ActiveSessionsProvider(mgr as never);
+    const provider = new ActiveSessionsProvider(mgr as never, makeFakeFavoritesStore());
 
     const topLevel = provider.getChildren(undefined);
     const children = provider.getChildren(topLevel[0]);
@@ -153,7 +153,7 @@ describe("ActiveSessionsProvider — grouped tree", () => {
   it("child count N appears in the group row description", () => {
     const sessions = [makeSession(root), makeSession(wt1)];
     const mgr = makeSessionManager(sessions);
-    const provider = new ActiveSessionsProvider(mgr as never);
+    const provider = new ActiveSessionsProvider(mgr as never, makeFakeFavoritesStore());
 
     const topLevel = provider.getChildren(undefined);
 
@@ -163,7 +163,7 @@ describe("ActiveSessionsProvider — grouped tree", () => {
   it("worktree leaf description shows branch name, not parent directory", () => {
     const sessions = [makeSession(root), makeSession(wt1)];
     const mgr = makeSessionManager(sessions);
-    const provider = new ActiveSessionsProvider(mgr as never);
+    const provider = new ActiveSessionsProvider(mgr as never, makeFakeFavoritesStore());
 
     const [group] = provider.getChildren(undefined);
     const children = provider.getChildren(group);
@@ -183,7 +183,7 @@ describe("ActiveSessionsProvider — grouped tree", () => {
     const rootB = "/home/user/project-b";
     const sessions = [makeSession(root), makeSession(rootB)];
     const mgr = makeSessionManager(sessions);
-    const provider = new ActiveSessionsProvider(mgr as never);
+    const provider = new ActiveSessionsProvider(mgr as never, makeFakeFavoritesStore());
 
     const topLevel = provider.getChildren(undefined);
     expect(topLevel).toHaveLength(2);
@@ -192,7 +192,7 @@ describe("ActiveSessionsProvider — grouped tree", () => {
   it("single session with no worktrees still returns a group with 1 child", () => {
     const sessions = [makeSession(root)];
     const mgr = makeSessionManager(sessions);
-    const provider = new ActiveSessionsProvider(mgr as never);
+    const provider = new ActiveSessionsProvider(mgr as never, makeFakeFavoritesStore());
 
     const topLevel = provider.getChildren(undefined);
     expect(topLevel).toHaveLength(1);
@@ -334,7 +334,7 @@ describe("Cross-panel star coupling", () => {
     } as unknown as import("vscode").Memento;
   }
 
-  it("Recent Projects row reflects favorited state immediately after store.add", async () => {
+  it("Recent Projects group row reflects favorited state immediately after store.add", async () => {
     const store = new FavoritesStore(makeRealMemento());
     const cache = new PathExistenceCache();
     const sm = makeSessionManager([]);
@@ -345,24 +345,22 @@ describe("Cross-panel star coupling", () => {
 
     const provider = new RecentProjectsProvider(sm as never, store, cache);
 
-    // Before add: contextValue should be unfavorited
+    // Before add: group row contextValue should be unfavorited
     const groupsBefore = await provider.getChildren();
-    const leavesBefore = await provider.getChildren(groupsBefore[0]);
-    expect(leavesBefore[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_UNFAVORITED);
+    expect(groupsBefore[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_UNFAVORITED);
 
     await store.add("C:/proj");
 
-    // After add: contextValue is favorited
+    // After add: group row contextValue is favorited
     const groupsAfter = await provider.getChildren();
-    const leavesAfter = await provider.getChildren(groupsAfter[0]);
-    expect(leavesAfter[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_FAVORITED);
+    expect(groupsAfter[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_FAVORITED);
   });
 
-  it("regression: leaf items reflect live store state, not a stale snapshot", async () => {
-    // Simulates the v1-blocker race: provider's getChildren(group) is called
-    // AFTER getAllFolders() resolved, so the leaf-item construction reads the
+  it("regression: group rows reflect live store state, not a stale snapshot", async () => {
+    // Simulates the v1-blocker race: provider's getChildren(undefined) is called
+    // AFTER getAllFolders() resolved, so the group-item construction reads the
     // store synchronously at construction time. If a mutation lands between
-    // getAllFolders() resolving and getChildren(group) running, the new state
+    // getAllFolders() resolving and a second getChildren() call, the new state
     // must be reflected.
     const store = new FavoritesStore(makeRealMemento());
     const cache = new PathExistenceCache();
@@ -378,13 +376,41 @@ describe("Cross-panel star coupling", () => {
     const groups = await provider.getChildren();
     expect(groups).toHaveLength(1);
 
-    // Step 2: mutate the store BEFORE asking for the group's leaves.
-    // The leaf construction is synchronous and reads `store.isFavorited()`
-    // at that moment.
+    // Step 2: mutate the store.
     await store.add("C:/proj");
 
-    // Step 3: now ask for leaves. They MUST reflect the latest store state.
-    const leaves = await provider.getChildren(groups[0]);
-    expect(leaves[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_FAVORITED);
+    // Step 3: re-fetch groups — they MUST reflect the latest store state.
+    const groupsAfter = await provider.getChildren();
+    expect(groupsAfter[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_FAVORITED);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ActiveSessionsProvider favorited contextValue
+// ---------------------------------------------------------------------------
+
+describe("ActiveSessionsProvider favorited contextValue", () => {
+  it("group row reflects favorited state synchronously after store.add", async () => {
+    const data: Record<string, unknown> = {};
+    const memento = {
+      keys: () => Object.keys(data),
+      get: <T>(k: string) => data[k] as T | undefined,
+      update: async (k: string, v: unknown) => { data[k] = v; },
+    } as unknown as import("vscode").Memento;
+
+    const store = new FavoritesStore(memento);
+    const sm = makeSessionManager([
+      makeSession("C:/proj"),
+    ]);
+
+    const provider = new ActiveSessionsProvider(sm as never, store);
+
+    const groupsBefore = provider.getChildren();
+    expect(groupsBefore[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_UNFAVORITED);
+
+    await store.add("C:/proj");
+
+    const groupsAfter = provider.getChildren();
+    expect(groupsAfter[0].contextValue).toBe(VIEW_ITEM.PROJECT_ROOT_FAVORITED);
   });
 });


### PR DESCRIPTION
Closes #75

## Summary

Adds a third top-level tree view, **Favorites**, to the Claude Conductor sidebar. Sits between Active Sessions and Recent Projects. Star toggle on Recent Projects rows persists per-machine via `globalState`. Missing-folder rows dim with `(missing)` and click-to-relocate via a folder picker. Soft cap of 25 favorites with an over-cap banner if storage drifts.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-04-28-75-favorites-design.md` — v4, locked after brainstorm + 3 inquisitor passes
- Plan: `docs/superpowers/plans/2026-04-28-75-favorites.md` — 12 tasks, executed via subagent-driven-development with two-stage review per task

## Architecture

- **`FavoritesStore`** (`src/favoritesStore.ts`) owns canonical state via a lowercase index. Mutations are serialized: each `add`/`remove`/`relocate` `await`s the prior persist (success or rollback) before snapshotting, eliminating cascade-rollback bugs. Storage envelope is `{version: 2, entries: [{path}]}`; v1 `string[]` reads are deferred-migrated on first mutation.
- **`PathExistenceCache`** (`src/pathExistenceCache.ts`) — async stat with 30s TTL and 500ms timeout. UNC paths skip the background refresh. `markPresent`/`markMissing` flip state immediately and feed back from `launchSession` outcomes — closing the v3 stuck-missing one-way ratchet.
- **`FavoritesProvider`** (in `src/treeView.ts`) — alphabetical sort, single-level rendering, missing-row click opens the relocate dialog directly (no toast hijack, no a11y regression).
- **`VIEW_ITEM` constants** (`src/treeView.ts`) — single composite tokens (`projectRoot.favorited`, `projectRoot.unfavorited`, `projectRoot.missing`, `worktreeChild`, `activeSession`) shared across both providers; menus disambiguate via `view ==`.
- **Drift detector** (`test/packageJsonContextKeys.test.ts`) — bidirectional bijection between `package.json` `viewItem` clauses and `VIEW_ITEM` constants, with explicit negative-fixture list to catch regex anchoring bugs.

## Notable behavior

- **`launchSession`** refactored from `Promise<void>` to `Promise<LaunchResult>` (`{ok: true, reused} | {ok: false, reason: "missing" | "other", message}`). All four caller sites updated minimally; existing no-throw guarantee preserved.
- **`recentProject` contextValue migrated** — the existing `viewItem == recentProject` clause in `package.json` is now `viewItem =~ /^projectRoot\.(favorited|unfavorited|missing)$/`, anchored on both ends to prevent partial-token false positives.
- **Cross-panel race avoided** — both providers consult `FavoritesStore.isFavorited()` synchronously inside `getTreeItem` per row; there is no cached snapshot across an `await`, so star icons can't drift.

## Tests

15 test files, 112 tests, all green:
- New: `favoritesStore` (12), `favoritesProvider` (9), `pathExistenceCache` (9), `sessionManager.launchResult` (3), `packageJsonContextKeys` drift detector (4)
- Modified: `projectGrouping` (+7 isWorktreePath cases), `treeView` (cross-panel coupling + race regression)

## CI status

All four jobs green locally:
- `npm run lint` (tsc noEmit)
- `npx tsc --noEmit -p tsconfig.test.json`
- `npm test -- --run` (15 files, 112 tests)
- `npm run compile`

## Test plan

- [ ] CI passes on the PR
- [ ] Manual smoke test in the Extension Development Host (F5):
  - Favorites view appears between Active Sessions and Recent Projects
  - Hover a Recent Projects row → star button appears; click adds to Favorites
  - Click filled star to remove
  - Right-click row → "Add/Remove from Favorites" appears
  - Delete a favorited folder externally; click it from Favorites → relocate dialog opens
  - Add 25 favorites; 26th rejects with toast

🤖 Generated by Claude Code on behalf of @cbeaulieu-gt
